### PR TITLE
Feature/debug

### DIFF
--- a/Start.py
+++ b/Start.py
@@ -10,9 +10,6 @@ import sys
 import shutil
 from pathlib import Path
 
-node_bin = '/opt/eric/nodejs/node-v24.1.0-linux-x64/bin'
-os.environ['PATH'] = f"{node_bin}:{os.environ.get('PATH', '')}"
-
 # ==================== 在导入任何模块之前先迁移数据库 ====================
 def _migrate_database_files_early():
     """在启动前检查并迁移数据库文件到data目录（使用print，因为logger还未初始化）"""


### PR DESCRIPTION
解决Pycharm的debug问题，原因是

<img width="1262" height="356" alt="image" src="https://github.com/user-attachments/assets/fc14a272-9f8b-4e37-b343-5145b4671436" />

报错信息:
```python
/Users/HOX4SGH/Project/Python/xianyu-auto-reply/.venv/lib/python3.13/site-packages/uvicorn/server.py:67: RuntimeWarning: coroutine 'Server.serve' was never awaited
  return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Traceback (most recent call last):
  File "/Users/HOX4SGH/.local/share/uv/python/cpython-3.13.7-macos-aarch64-none/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Users/HOX4SGH/.local/share/uv/python/cpython-3.13.7-macos-aarch64-none/lib/python3.13/threading.py", line 994, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/HOX4SGH/Project/Python/xianyu-auto-reply/Start.py", line 146, in _start_api_server
    uvicorn.run("reply_server:app", host=host, port=port, log_level="info")
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/HOX4SGH/Project/Python/xianyu-auto-reply/.venv/lib/python3.13/site-packages/uvicorn/main.py", line 593, in run
    server.run()
    ~~~~~~~~~~^^
  File "/Users/HOX4SGH/Project/Python/xianyu-auto-reply/.venv/lib/python3.13/site-packages/uvicorn/server.py", line 67, in run
    return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())
TypeError: _patch_asyncio.<locals>.run() got an unexpected keyword argument 'loop_factory' 
```

