### PR TITLE
fix: 环境变量默认admin密码配置不生效

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -620,7 +620,8 @@ class DBManager:
 
             if not admin_exists:
                 # 首次创建admin用户，设置默认密码
-                default_password_hash = hashlib.sha256("admin123".encode()).hexdigest()
+                password = os.getenv("ADMIN_PASSWORD", "admin123")
+                default_password_hash = hashlib.sha256(password.encode()).hexdigest()
                 cursor.execute('''
                 INSERT INTO users (username, email, password_hash) VALUES
                 ('admin', 'admin@localhost', ?)


### PR DESCRIPTION
管理员的用户名密码似乎硬编码在代码中写死了，已经看到很多issue提出无法修改管理员密码的问题。
对此进行了小修改，由于不确定“admin”在代码中硬编码的影响范围，此pr仅实现从环境变量中读取默认密码