### PR TITLE
[codex] Make default secrets configurable

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -13,6 +13,12 @@ from PIL import Image, ImageDraw, ImageFont
 from typing import List, Tuple, Dict, Optional, Any
 from loguru import logger
 
+
+def get_initial_admin_password() -> str:
+    """Return the password used only when creating the first admin account."""
+    return os.getenv('ADMIN_PASSWORD') or 'admin123'
+
+
 class DBManager:
     """SQLite数据库管理，持久化存储Cookie和关键字"""
     
@@ -484,6 +490,13 @@ class DBManager:
             ('qq_reply_secret_key', 'xianyu_qq_reply_2024', 'QQ回复消息API秘钥')
             ''')
 
+            env_qq_secret_key = os.getenv('QQ_REPLY_SECRET_KEY')
+            if env_qq_secret_key:
+                cursor.execute(
+                    "UPDATE system_settings SET value = ?, updated_at = CURRENT_TIMESTAMP WHERE key = 'qq_reply_secret_key'",
+                    (env_qq_secret_key,)
+                )
+
             # 检查并升级数据库
             self.check_and_upgrade_db(cursor)
 
@@ -667,12 +680,16 @@ class DBManager:
 
             if not admin_exists:
                 # 首次创建admin用户，设置默认密码
-                default_password_hash = hashlib.sha256("admin123".encode()).hexdigest()
+                default_password = get_initial_admin_password()
+                default_password_hash = hashlib.sha256(default_password.encode()).hexdigest()
                 cursor.execute('''
                 INSERT INTO users (username, email, password_hash) VALUES
                 ('admin', 'admin@localhost', ?)
                 ''', (default_password_hash,))
-                logger.info("创建默认admin用户，密码: admin123")
+                if os.getenv('ADMIN_PASSWORD'):
+                    logger.info("已使用环境变量 ADMIN_PASSWORD 创建默认admin用户")
+                else:
+                    logger.warning("创建默认admin用户，使用内置默认密码 admin123")
 
             # 获取admin用户ID，用于历史数据绑定
             self._execute_sql(cursor, "SELECT id FROM users WHERE username = 'admin'")

--- a/reply_server.py
+++ b/reply_server.py
@@ -40,10 +40,13 @@ except ImportError:
 KEYWORDS_FILE = Path(__file__).parent / "回复关键字.txt"
 
 # 简单的用户认证配置
-ADMIN_USERNAME = "admin"
-DEFAULT_ADMIN_PASSWORD = "admin123"  # 系统初始化时的默认密码
+ADMIN_USERNAME = os.getenv("ADMIN_USERNAME", "admin")
+DEFAULT_ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "admin123")  # 系统初始化时的默认密码
 SESSION_TOKENS = {}  # 存储会话token: {token: {'user_id': int, 'username': str, 'timestamp': float}}
-TOKEN_EXPIRE_TIME = 24 * 60 * 60  # token过期时间：24小时
+try:
+    TOKEN_EXPIRE_TIME = int(os.getenv("TOKEN_EXPIRE_TIME", str(24 * 60 * 60)))  # token过期时间：默认24小时
+except ValueError:
+    TOKEN_EXPIRE_TIME = 24 * 60 * 60
 
 # HTTP Bearer认证
 security = HTTPBearer(auto_error=False)
@@ -1115,9 +1118,8 @@ async def register(request: RegisterRequest):
 
 # ------------------------- 发送消息接口 -------------------------
 
-# 固定的API秘钥（生产环境中应该从配置文件或环境变量读取）
-# 注意：现在从系统设置中读取QQ回复消息秘钥
-API_SECRET_KEY = "xianyu_api_secret_2024"  # 保留作为后备
+# API秘钥后备值。优先从系统设置读取QQ回复消息秘钥，再退回环境变量。
+API_SECRET_KEY = os.getenv("API_SECRET_KEY", "xianyu_api_secret_2024")
 
 class SendMessageRequest(BaseModel):
     api_key: str
@@ -1176,8 +1178,9 @@ async def send_message_api(request: SendMessageRequest):
                 message="API秘钥不能为空"
             )
 
-        # 特殊测试秘钥处理
-        if cleaned_api_key == "zhinina_test_key":
+        # 特殊测试秘钥处理，默认关闭，避免本地部署保留公开测试入口。
+        allow_test_key = os.getenv("ALLOW_TEST_API_KEY", "false").lower() == "true"
+        if allow_test_key and cleaned_api_key == "zhinina_test_key":
             logger.info("使用测试秘钥，直接返回成功")
             return SendMessageResponse(
                 success=True,


### PR DESCRIPTION
## Summary
- Read initial admin credentials and token expiry from environment variables.
- Allow the send-message API fallback secret to come from the environment.
- Disable the public test API key unless explicitly enabled.
- Let deployments override the QQ reply secret through `QQ_REPLY_SECRET_KEY`.

## Why
This avoids local or containerized deployments inheriting public default credentials and hard-coded API secrets by accident.

## Validation
- `python3 -m py_compile db_manager.py reply_server.py`
- Local OrbStack container health check passed before publishing.