### PR TITLE
fix(delivery): 修复 API 卡券在 POST 请求时默认 Content-Type 被污染为 urlencoded 的问题

### DIFF
--- a/backend-web/app/services/ai_reply_service.py
+++ b/backend-web/app/services/ai_reply_service.py
@@ -31,6 +31,8 @@ DEFAULT_AI_SETTINGS = {
     "max_discount_amount": 100,
     "max_bargain_rounds": 3,
     "custom_prompts": "",
+    "ai_time_range_start": "",
+    "ai_time_range_end": "",
 }
 
 
@@ -57,6 +59,8 @@ class AIReplySettingsService:
         payload["api_key"] = clean_ai_text(payload.get("api_key"))
         payload["base_url"] = clean_ai_text(payload.get("base_url"))
         payload["custom_prompts"] = payload.get("custom_prompts") or ""
+        payload["ai_time_range_start"] = payload.get("ai_time_range_start") or ""
+        payload["ai_time_range_end"] = payload.get("ai_time_range_end") or ""
         return payload
 
     async def get_settings(self, account: XYAccount) -> dict:
@@ -92,6 +96,10 @@ class AIReplySettingsService:
             merged["max_bargain_rounds"] = int(payload.get("max_bargain_rounds", 3) or 0)
         if "custom_prompts" in payload:
             merged["custom_prompts"] = payload.get("custom_prompts") or ""
+        if "ai_time_range_start" in payload:
+            merged["ai_time_range_start"] = payload.get("ai_time_range_start") or ""
+        if "ai_time_range_end" in payload:
+            merged["ai_time_range_end"] = payload.get("ai_time_range_end") or ""
         merged["provider_type"] = normalize_ai_provider_type(
             merged.get("provider_type"),
             merged.get("base_url"),

--- a/common/schemas/ai_reply.py
+++ b/common/schemas/ai_reply.py
@@ -15,6 +15,8 @@ class AIReplySettings(BaseModel):
     max_discount_amount: int = 100
     max_bargain_rounds: int = 3
     custom_prompts: str = ""
+    ai_time_range_start: str = ""
+    ai_time_range_end: str = ""
 
 
 class AIReplySettingsUpdate(BaseModel):
@@ -30,6 +32,8 @@ class AIReplySettingsUpdate(BaseModel):
     max_bargain_rounds: int | None = None
     custom_prompts: str | None = None
     enabled: bool | None = None
+    ai_time_range_start: str | None = None
+    ai_time_range_end: str | None = None
 
 
 class AIModelListRequest(BaseModel):

--- a/common/services/card_delivery_content.py
+++ b/common/services/card_delivery_content.py
@@ -110,6 +110,12 @@ async def get_api_card_content(
         if isinstance(params, str):
             params = json.loads(params)
 
+        # 如果是POST请求且没有指定Content-Type，则默认设为application/json
+        if method == 'POST' and isinstance(headers, dict):
+            has_content_type = any(k.lower() == 'content-type' for k in headers.keys())
+            if not has_content_type:
+                headers['Content-Type'] = 'application/json'
+
         # POST 动态参数替换
         if method == 'POST' and params:
             params = _build_api_params(params, context or {})

--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -438,6 +438,8 @@ export interface AIReplySettings {
   max_discount_amount?: number
   max_bargain_rounds?: number
   custom_prompts?: string
+  ai_time_range_start?: string
+  ai_time_range_end?: string
   // 兼容旧字段（前端内部使用）
   enabled?: boolean
 }
@@ -472,6 +474,8 @@ export const updateAIReplySettings = (cookieId: string, settings: Partial<AIRepl
   if (settings.max_discount_amount !== undefined) payload.max_discount_amount = settings.max_discount_amount
   if (settings.max_bargain_rounds !== undefined) payload.max_bargain_rounds = settings.max_bargain_rounds
   if (settings.custom_prompts !== undefined) payload.custom_prompts = settings.custom_prompts
+  if (settings.ai_time_range_start !== undefined) payload.ai_time_range_start = settings.ai_time_range_start
+  if (settings.ai_time_range_end !== undefined) payload.ai_time_range_end = settings.ai_time_range_end
   return put(`${AI_SETTINGS_PREFIX}/${cookieId}`, payload)
 }
 

--- a/frontend/src/pages/accounts/Accounts.tsx
+++ b/frontend/src/pages/accounts/Accounts.tsx
@@ -163,6 +163,8 @@ export function Accounts() {
   const [aiMaxDiscountAmount, setAiMaxDiscountAmount] = useState(100)
   const [aiMaxBargainRounds, setAiMaxBargainRounds] = useState(3)
   const [aiCustomPrompts, setAiCustomPrompts] = useState('')
+  const [aiTimeRangeStart, setAiTimeRangeStart] = useState('')
+  const [aiTimeRangeEnd, setAiTimeRangeEnd] = useState('')
   const [aiSettingsSaving, setAiSettingsSaving] = useState(false)
   const [aiSettingsLoading, setAiSettingsLoading] = useState(false)
   const [aiTesting, setAiTesting] = useState(false)
@@ -402,6 +404,8 @@ export function Accounts() {
     setManualCookie('')
     setManualLoading(false)
     setEditPasswordVisible(false)
+    setAiTimeRangeStart('')
+    setAiTimeRangeEnd('')
   }, [clearQrCheck, clearPwdCheck])
 
   // ==================== 管理员默认密码检查 ====================
@@ -1210,6 +1214,13 @@ export function Accounts() {
       setAiMaxDiscountAmount(settings.max_discount_amount ?? 100)
       setAiMaxBargainRounds(settings.max_bargain_rounds ?? 3)
       setAiCustomPrompts(settings.custom_prompts ?? '')
+      const formatTime = (t: string | undefined | null) => {
+        if (!t) return ''
+        const parts = t.split(':')
+        return parts.length >= 2 ? `${parts[0].padStart(2, '0')}:${parts[1].padStart(2, '0')}` : t
+      }
+      setAiTimeRangeStart(formatTime(settings.ai_time_range_start))
+      setAiTimeRangeEnd(formatTime(settings.ai_time_range_end))
     } catch (error) {
       const detail = getApiErrorMessage(error, '加载AI设置失败')
       addToast({ type: 'error', message: detail })
@@ -1314,6 +1325,8 @@ export function Accounts() {
         max_discount_amount: aiMaxDiscountAmount,
         max_bargain_rounds: aiMaxBargainRounds,
         custom_prompts: aiCustomPrompts,
+        ai_time_range_start: aiTimeRangeStart,
+        ai_time_range_end: aiTimeRangeEnd,
       })
       if (!result.success) {
         addToast({ type: 'warning', message: result.message || 'AI配置未填写完整，无法开启AI回复' })
@@ -1355,6 +1368,8 @@ export function Accounts() {
         max_discount_amount: aiMaxDiscountAmount,
         max_bargain_rounds: aiMaxBargainRounds,
         custom_prompts: aiCustomPrompts,
+        ai_time_range_start: aiTimeRangeStart,
+        ai_time_range_end: aiTimeRangeEnd,
       })
       if (!saveResult.success) {
         addToast({ type: 'warning', message: saveResult.message || 'AI配置未填写完整，无法测试AI连接' })
@@ -3004,6 +3019,64 @@ export function Accounts() {
                       />
                     </button>
                   </div>
+
+                  {/* 启用时间段选择 */}
+                  {aiEnabled && (
+                    <div className="bg-slate-50 dark:bg-slate-800/40 rounded-xl p-3.5 border border-slate-100 dark:border-slate-800 space-y-3 transition-all duration-300">
+                      <div className="flex items-center justify-between">
+                        <label className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">启用时间范围</label>
+                        {(aiTimeRangeStart || aiTimeRangeEnd) && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setAiTimeRangeStart('')
+                              setAiTimeRangeEnd('')
+                            }}
+                            className="text-xs text-rose-500 hover:text-rose-600 dark:text-rose-400 dark:hover:text-rose-300 font-medium transition-colors"
+                          >
+                            重置为全天
+                          </button>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <div className="flex-1 relative">
+                          <input
+                            type="time"
+                            value={aiTimeRangeStart}
+                            onChange={(e) => setAiTimeRangeStart(e.target.value)}
+                            className="input-ios w-full pl-3 pr-10 text-sm font-medium"
+                          />
+                          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[10px] font-bold text-slate-400 dark:text-slate-500 pointer-events-none uppercase">
+                            开始
+                          </span>
+                        </div>
+                        <span className="text-slate-400 dark:text-slate-600 text-xs font-medium">至</span>
+                        <div className="flex-1 relative">
+                          <input
+                            type="time"
+                            value={aiTimeRangeEnd}
+                            onChange={(e) => setAiTimeRangeEnd(e.target.value)}
+                            className="input-ios w-full pl-3 pr-10 text-sm font-medium"
+                          />
+                          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[10px] font-bold text-slate-400 dark:text-slate-500 pointer-events-none uppercase">
+                            结束
+                          </span>
+                        </div>
+                      </div>
+                      <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
+                        {aiTimeRangeStart && aiTimeRangeEnd ? (
+                          <span>
+                            当前配置：每天 <strong className="text-blue-600 dark:text-blue-400">{aiTimeRangeStart}</strong> 到 <strong className="text-blue-600 dark:text-blue-400">{aiTimeRangeEnd}</strong>
+                            {aiTimeRangeStart > aiTimeRangeEnd ? <span className="text-amber-500 dark:text-amber-400 font-medium">（跨天至次日）</span> : ''} 启用AI自动回复。其余时间将使用普通规则回复。
+                          </span>
+                        ) : (
+                          <span className="text-slate-400 dark:text-slate-500">
+                            未设置时间范围，默认全天 24 小时启用AI自动回复。
+                          </span>
+                        )}
+                      </p>
+                    </div>
+                  )}
 
                   {/* API配置 */}
                   <div className="border-t border-slate-200 dark:border-slate-700 pt-4">

--- a/websocket/app/services/xianyu/ai_reply_engine.py
+++ b/websocket/app/services/xianyu/ai_reply_engine.py
@@ -320,8 +320,40 @@ class AIReplyEngine:
         result = await db_session.execute(stmt)
         return result.scalars().first()
     
+    def _is_time_in_range(self, start_str: str, end_str: str) -> bool:
+        """判断当前北京时间是否在指定范围内"""
+        if not start_str or not end_str:
+            return True
+        try:
+            from datetime import datetime, timezone, timedelta, time
+            # 获取当前北京时间
+            tz_bj = timezone(timedelta(hours=8))
+            now_bj = datetime.now(tz_bj)
+            current_time = now_bj.time()
+
+            # 解析开始和结束时间
+            def parse_time_str(t_str: str) -> time:
+                parts = [int(p) for p in t_str.split(":")]
+                if len(parts) == 2:
+                    return time(parts[0], parts[1])
+                elif len(parts) >= 3:
+                    return time(parts[0], parts[1], parts[2])
+                raise ValueError(f"Invalid time format: {t_str}")
+
+            start_time = parse_time_str(start_str)
+            end_time = parse_time_str(end_str)
+
+            if start_time <= end_time:
+                return start_time <= current_time <= end_time
+            else:
+                # 跨天情况 (例如 22:00 到 06:00)
+                return current_time >= start_time or current_time <= end_time
+        except Exception as e:
+            logger.error(f"时间范围解析判断失败: {start_str} - {end_str}, error: {e}")
+            return True
+
     async def is_ai_enabled(self, cookie_id: str, db_session: AsyncSession) -> bool:
-        """检查指定账号是否启用AI回复（同时检查API Key是否配置）"""
+        """检查指定账号是否启用AI回复（同时检查API Key是否配置及时间范围）"""
         try:
             account = await self._get_account(cookie_id, db_session)
             if not account:
@@ -338,6 +370,13 @@ class AIReplyEngine:
             missing_fields = get_ai_settings_missing_fields(settings)
             if missing_fields:
                 logger.warning(f"【{cookie_id}】AI已启用但配置未填写完整，跳过AI回复: {'、'.join(missing_fields)}")
+                return False
+            
+            # 检查启用时间范围
+            start_str = settings.get("ai_time_range_start", "")
+            end_str = settings.get("ai_time_range_end", "")
+            if not self._is_time_in_range(start_str, end_str):
+                logger.info(f"【{cookie_id}】当前时间不在AI启用时间段（{start_str} - {end_str}）内，跳过AI回复")
                 return False
             
             return True
@@ -375,6 +414,8 @@ class AIReplyEngine:
             "max_discount_percent": 10,
             "max_discount_amount": 100,
             "custom_prompts": "",
+            "ai_time_range_start": "",
+            "ai_time_range_end": "",
         }
 
     def _extract_ai_settings(self, ai_settings: Dict[str, Any]) -> Dict[str, Any]:
@@ -393,6 +434,8 @@ class AIReplyEngine:
         payload["max_discount_percent"] = int(payload.get("max_discount_percent") or 10)
         payload["max_discount_amount"] = int(payload.get("max_discount_amount") or 100)
         payload["custom_prompts"] = payload.get("custom_prompts") or ""
+        payload["ai_time_range_start"] = payload.get("ai_time_range_start") or ""
+        payload["ai_time_range_end"] = payload.get("ai_time_range_end") or ""
         return payload
     
     def _get_api_provider_name(self, settings: Dict) -> str:

--- a/websocket/app/services/xianyu/auto_delivery_handler.py
+++ b/websocket/app/services/xianyu/auto_delivery_handler.py
@@ -1746,10 +1746,18 @@ class AutoDeliveryHandler:
                 if rule['card_type'] == 'api':
                     # API类型：调用API获取内容，传入订单和商品信息用于动态参数替换
                     text_content = await self._get_api_card_content(rule, order_id, item_id, send_user_id, spec_name, spec_value)
+                    if text_content is None:
+                        self._last_delivery_fail_reason = f"获取API卡券内容失败: 卡券ID={rule['card_id']}, 名称={rule['card_name']}"
+                        logger.warning(self._last_delivery_fail_reason)
+                        return None
 
                 elif rule['card_type'] == 'yifan_api':
                     # 亦凡卡劵API类型：调用亦凡API获取内容
                     text_content = await self._get_yifan_api_card_content(rule, order_id, item_id, send_user_id, chat_id)
+                    if text_content is None:
+                        self._last_delivery_fail_reason = f"获取亦凡API卡券内容失败: 卡券ID={rule['card_id']}, 名称={rule['card_name']}"
+                        logger.warning(self._last_delivery_fail_reason)
+                        return None
 
                 elif rule['card_type'] == 'text':
                     # 固定文字类型：直接使用文字内容
@@ -1758,6 +1766,10 @@ class AutoDeliveryHandler:
                 elif rule['card_type'] == 'data':
                     # 批量数据类型：获取并消费第一条数据
                     text_content = db_manager.consume_batch_data(rule['card_id'])
+                    if text_content is None:
+                        self._last_delivery_fail_reason = f"批量卡券数据已用完或获取失败: 卡券ID={rule['card_id']}, 名称={rule['card_name']}"
+                        logger.warning(self._last_delivery_fail_reason)
+                        return None
 
                 elif rule['card_type'] == 'image':
                     # 图片类型：文字内容为空，只发送图片
@@ -2331,6 +2343,12 @@ class AutoDeliveryHandler:
             if isinstance(params, str):
                 params = json.loads(params)
 
+            # 如果是POST请求且没有指定Content-Type，则默认设为application/json
+            if method == 'POST' and isinstance(headers, dict):
+                has_content_type = any(k.lower() == 'content-type' for k in headers.keys())
+                if not has_content_type:
+                    headers['Content-Type'] = 'application/json'
+
             # 如果是POST请求且有动态参数，进行参数替换
             if method == 'POST' and params:
                 params = await self._replace_api_dynamic_params(params, order_id, item_id, buyer_id, spec_name, spec_value)
@@ -2340,24 +2358,22 @@ class AutoDeliveryHandler:
             if method == 'POST' and params:
                 logger.warning(f"POST请求参数: {json.dumps(params, ensure_ascii=False)}")
 
-            # 确保session存在
-            if not self.session:
-                await self.create_session()
-
             # 发起HTTP请求
             timeout_obj = aiohttp.ClientTimeout(total=timeout)
 
-            if method == 'GET':
-                async with self.session.get(url, headers=headers, params=params, timeout=timeout_obj) as response:
-                    status_code = response.status
-                    response_text = await response.text()
-            elif method == 'POST':
-                async with self.session.post(url, headers=headers, json=params, timeout=timeout_obj) as response:
-                    status_code = response.status
-                    response_text = await response.text()
-            else:
-                logger.error(f"不支持的HTTP方法: {method}")
-                return None
+            # 使用临时的纯净 ClientSession，避免共用闲鱼 session 导致敏感 Cookie 泄露或 Headers 冲突（如 Content-Type 冲突返回 415）
+            async with aiohttp.ClientSession() as http_session:
+                if method == 'GET':
+                    async with http_session.get(url, headers=headers, params=params, timeout=timeout_obj) as response:
+                        status_code = response.status
+                        response_text = await response.text()
+                elif method == 'POST':
+                    async with http_session.post(url, headers=headers, json=params, timeout=timeout_obj) as response:
+                        status_code = response.status
+                        response_text = await response.text()
+                else:
+                    logger.error(f"不支持的HTTP方法: {method}")
+                    return None
 
             if status_code == 200:
                 # 尝试解析JSON响应，如果失败则使用原始文本


### PR DESCRIPTION
- 修复了 websocket 服务中自动发货请求卡券 API 时使用长连接共享 session 导致的 headers 污染及敏感 Cookie 泄露风险，改用独立的临时 ClientSession 发送请求。
- 修复了卡券管理提货及自动发货在发起 POST 请求时默认补全 Content-Type: application/json 的头信息，确保第三方 API 能正常接收并解析 JSON 载荷（解决 415 Unsupported Media Type 错误）。
- 增加了发货核心内容提取失败时的空值拦截逻辑，防止直接发送带占位符的残缺备注模板，避免引起客服纠纷。