### PR TITLE
fix: 商品管理页面关联卡券配置面板中卡券列表无法滚动

### DIFF
--- a/frontend/src/pages/items/ItemCardRelationModal.tsx
+++ b/frontend/src/pages/items/ItemCardRelationModal.tsx
@@ -211,7 +211,7 @@ export function ItemCardRelationModal({ itemId, itemName, onClose, onSaved }: It
           <div className="modal-body flex-1 overflow-hidden p-0">
             <div className="grid grid-cols-2 gap-0 h-full" style={{ height: '60vh' }}>
               {/* 左侧：卡券列表 */}
-              <div className="flex flex-col border-r border-gray-200 dark:border-gray-700">
+              <div className="flex flex-col border-r border-gray-200 dark:border-gray-700 overflow-hidden">
                 <div className="flex-shrink-0 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
                   <div className="flex items-center justify-between mb-2">
                     <h3 className="font-medium text-gray-900 dark:text-white text-sm">待选卡券</h3>
@@ -317,7 +317,7 @@ export function ItemCardRelationModal({ itemId, itemName, onClose, onSaved }: It
               </div>
 
               {/* 右侧：已选卡券 */}
-              <div className="flex flex-col">
+              <div className="flex flex-col overflow-hidden">
                 <div className="flex-shrink-0 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-green-50 dark:bg-green-900/20">
                   <div className="flex items-center justify-between mb-2">
                     <h3 className="font-medium text-green-700 dark:text-green-400 text-sm">已选卡券</h3>


### PR DESCRIPTION
修复商品管理页面关联卡券配置面板中卡券列表无法滚动的问题。

复现步骤：

1.在卡券管理中添加多个卡券
2. 进入商品管理页面
3. 点击随意商品的关联卡券功能

<img width="1046" height="771" alt="left" src="https://github.com/user-attachments/assets/1bfa34a1-f20d-4e35-b14e-6d6c002ac183" />
<img width="1061" height="773" alt="right" src="https://github.com/user-attachments/assets/9f8795dc-f89d-4f5f-a133-b16491490320" />

修复后：

<img width="1085" height="806" alt="fixed" src="https://github.com/user-attachments/assets/5ca35331-e633-4524-ba05-bca67f0f73bc" />

