### PR TITLE
fix: 修复服务器部署时前端静态资源404问题

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -64,6 +64,6 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    assetsDir: 'static',
+    assetsDir: 'assets',
   },
 })


### PR DESCRIPTION
## 问题描述

修复 #193 中报告的问题：使用服务器一键部署方案时，前端页面空白，浏览器控制台显示：
```
请求 URL: http://IP:9000/static/index-Cdceh4Nu.js
状态代码: 404 Not Found
```

## 问题根因

经过深入分析发现：
- **Vite 配置**：`frontend/vite.config.ts` 中 `assetsDir` 设置为 `'static'`
- **Nginx 配置**：`docker/frontend/nginx.conf` 中配置了 `location /assets`
- **路径不匹配**：构建产物输出到 `/static/`，但 Nginx 期望 `/assets/`

这导致前端构建产物的实际路径与 Nginx location 配置不一致，引发 404 错误。

## 修复方案

将 `frontend/vite.config.ts` 第 67 行的 `assetsDir` 从 `'static'` 修改为 `'assets'`：

```diff
  build: {
    outDir: 'dist',
-   assetsDir: 'static',
+   assetsDir: 'assets',
  },
```

## 为什么这样修复？

1. ✅ **符合 Nginx 配置**：`nginx.conf` 已经正确配置了 `location /assets`
2. ✅ **避免路径冲突**：`/static` 应保留给后端上传的资源（第 48-52 行配置）
3. ✅ **遵循最佳实践**：前端构建产物使用 `/assets` 是业界标准

## 影响范围

- ✅ 前端构建产物将输出到 `dist/assets/` 而非 `dist/static/`
- ✅ 不影响后端 `/static` 路径（用于上传的图片、群二维码等）
- ✅ 修复后前端页面可以正常加载

## 测试

修复后，前端资源路径将从：
```
http://IP:9000/static/index-Cdceh4Nu.js  ❌ 404
```
变为：
```
http://IP:9000/assets/index-Cdceh4Nu.js  ✅ 200
```

与 Nginx 的 `location /assets` 配置完美匹配。

## 相关 Issue

Fixes #193

---

感谢 @DLmaster361 报告此问题！🙏