### PR TITLE
fix(distribution): 分销卡券功能优化 - 缓存/限流/超时检测

### DIFF
--- a/backend-web/app/api/routes/card_dock.py
+++ b/backend-web/app/api/routes/card_dock.py
@@ -12,9 +12,11 @@
 """
 from __future__ import annotations
 
+import time
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from app.api import deps
@@ -22,6 +24,24 @@ from app.services.card_dock_service import CardDockService
 from common.models.user import User
 
 router = APIRouter(prefix="/card-dock", tags=["分销卡券"])
+
+# Rate limiter: {user_id: [timestamps]}
+_purchase_rate_limit: dict[int, list[float]] = {}
+_PURCHASE_MAX_REQUESTS = 5
+_PURCHASE_WINDOW_SECONDS = 60
+
+
+def _check_purchase_rate_limit(user_id: int) -> bool:
+    """Return True if within limit, False if exceeded."""
+    now = time.time()
+    window_start = now - _PURCHASE_WINDOW_SECONDS
+    timestamps = _purchase_rate_limit.setdefault(user_id, [])
+    # Prune old entries
+    _purchase_rate_limit[user_id] = [t for t in timestamps if t > window_start]
+    if len(_purchase_rate_limit[user_id]) >= _PURCHASE_MAX_REQUESTS:
+        return False
+    _purchase_rate_limit[user_id].append(now)
+    return True
 
 
 class CardPurchaseRequest(BaseModel):
@@ -89,6 +109,11 @@ async def purchase_card(
     service: CardDockService = Depends(deps.get_card_dock_service),
 ) -> Dict[str, Any]:
     """提货：通过上游卡券系统购买并返回卡密"""
+    if not _check_purchase_rate_limit(current_user.id):
+        return JSONResponse(
+            status_code=429,
+            content={"success": False, "code": 429, "message": "请求过于频繁，请稍后再试", "data": None},
+        )
     if not payload.source_code.strip():
         return {"success": False, "code": 400, "message": "请先选择卡券商", "data": None}
     if payload.quantity < 1:

--- a/backend-web/app/services/card_dock_service.py
+++ b/backend-web/app/services/card_dock_service.py
@@ -12,6 +12,7 @@
 """
 from __future__ import annotations
 
+import time
 from typing import Any, Dict, Optional
 from urllib.parse import quote, urlencode
 
@@ -25,6 +26,10 @@ from common.models.user_setting import UserSetting
 
 # 对接卡密秘钥在用户设置中的键名（迁移到个人设置后按用户存储）
 CARD_SECRET_KEY_SETTING = "distribution.card_secret_key"
+
+# Secret key cache: {user_id: (timestamp, secret_key)}
+_secret_key_cache: Dict[int, tuple[float, str]] = {}
+_SECRET_KEY_CACHE_TTL = 300  # 5 minutes
 
 # 上游代理端接口路径前缀
 _AGENT_PREFIX = "/api/card-product/agent"
@@ -61,14 +66,31 @@ class CardDockService:
         return f"{self.base_url}{_AGENT_PREFIX}{path}"
 
     async def _get_secret_key(self, user_id: int) -> str:
-        """从当前用户的个人设置读取对接卡密秘钥"""
+        """从当前用户的个人设置读取对接卡密秘钥（带 5 分钟 TTL 缓存）"""
+        now = time.time()
+        cached = _secret_key_cache.get(user_id)
+        if cached is not None:
+            ts, value = cached
+            if now - ts < _SECRET_KEY_CACHE_TTL:
+                return value
+
         stmt = select(UserSetting).where(
             UserSetting.user_id == user_id,
             UserSetting.key == CARD_SECRET_KEY_SETTING,
         )
         result = await self.session.execute(stmt)
         record = result.scalars().first()
-        return (record.value or "").strip() if record and record.value else ""
+        secret = (record.value or "").strip() if record and record.value else ""
+        _secret_key_cache[user_id] = (now, secret)
+        return secret
+
+    @staticmethod
+    def invalidate_secret_key_cache(user_id: int | None = None) -> None:
+        """清空秘钥缓存。传入 user_id 只清该用户，不传则清全部。"""
+        if user_id is not None:
+            _secret_key_cache.pop(user_id, None)
+        else:
+            _secret_key_cache.clear()
 
     @staticmethod
     def _fail(message: str, code: int = 400) -> Dict[str, Any]:

--- a/scheduler/app/services/scheduled_task_service.py
+++ b/scheduler/app/services/scheduled_task_service.py
@@ -33,6 +33,7 @@ TASK_CODE_API_COOKIE_RENEW = "api_cookie_renew"
 TASK_CODE_CLOSE_NOTICE = "close_notice"
 TASK_CODE_RED_FLOWER = "red_flower"
 TASK_CODE_DB_BACKUP = "db_backup"
+TASK_CODE_DELIVERY_TIMEOUT = "delivery_timeout"
 
 # 默认配置（数据库无配置时使用）
 DEFAULT_CONFIGS = {
@@ -50,6 +51,7 @@ DEFAULT_CONFIGS = {
     TASK_CODE_CLOSE_NOTICE: {"interval_seconds": 600, "enabled": False},
     TASK_CODE_RED_FLOWER: {"interval_seconds": 300, "enabled": True},
     TASK_CODE_DB_BACKUP: {"interval_seconds": 3600, "enabled": True},
+    TASK_CODE_DELIVERY_TIMEOUT: {"interval_seconds": 60, "enabled": True},
 }
 
 

--- a/scheduler/app/services/scheduler/delivery_timeout_task.py
+++ b/scheduler/app/services/scheduler/delivery_timeout_task.py
@@ -1,0 +1,77 @@
+"""
+自动发货消息超时检测任务
+
+功能：
+1. 扫描 send_status='unknown' 且 created_at 超过 5 分钟的自动发货日志
+2. 将这些记录的 send_status 更新为 'timeout'
+
+该任务定期清理因 WebSocket 发送后未收到服务端响应而滞留在 unknown 状态的记录，
+避免发送状态长期显示为"未知"，同时不影响正在等待响应的最新记录。
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from loguru import logger
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from common.db.session import async_session_maker
+from common.models.auto_reply_message_log import XYAutoReplyMessageLog
+
+
+class DeliveryTimeoutTask:
+    """自动发货消息超时检测任务"""
+
+    # 超过该时间阈值的 unknown 记录将被标记为 timeout
+    TIMEOUT_MINUTES = 5
+
+    async def execute(self) -> str:
+        """
+        执行超时检测任务
+
+        Returns:
+            执行结果摘要
+        """
+        logger.info("[发货超时检测] 开始执行")
+        try:
+            async with async_session_maker() as session:
+                count = await self._mark_unknown_as_timeout(session)
+                summary = f"标记 {count} 条 unknown 记录为 timeout"
+                logger.info(f"[发货超时检测] 执行完成: {summary}")
+                return summary
+        except Exception as e:
+            logger.error(f"[发货超时检测] 执行异常: {e}")
+            return f"执行异常: {e}"
+
+    async def _mark_unknown_as_timeout(self, session: AsyncSession) -> int:
+        """
+        将超时的 unknown 记录更新为 timeout
+
+        Args:
+            session: 数据库会话
+
+        Returns:
+            更新的记录数
+        """
+        threshold = datetime.now(timezone.utc) - timedelta(minutes=self.TIMEOUT_MINUTES)
+
+        stmt = (
+            update(XYAutoReplyMessageLog)
+            .where(
+                XYAutoReplyMessageLog.send_status == "unknown",
+                XYAutoReplyMessageLog.reply_strategy == "auto_delivery",
+                XYAutoReplyMessageLog.created_at < threshold,
+            )
+            .values(send_status="timeout")
+        )
+        result = await session.execute(stmt)
+        await session.commit()
+        count = result.rowcount
+        if count > 0:
+            logger.info(f"[发货超时检测] 已将 {count} 条 unknown 记录标记为 timeout")
+        return count
+
+
+# 模块级单例，供调度器引用
+delivery_timeout_task_service = DeliveryTimeoutTask()

--- a/scheduler/app/services/scheduler_service.py
+++ b/scheduler/app/services/scheduler_service.py
@@ -31,6 +31,7 @@ from app.services.scheduler.api_cookie_renew_task import api_cookie_renew_task_s
 from app.services.scheduler.close_notice_task import close_notice_task_service
 from app.services.scheduler.red_flower_task import RedFlowerTask
 from app.services.scheduler.db_backup_task import db_backup_task_service
+from app.services.scheduler.delivery_timeout_task import delivery_timeout_task_service
 from app.services.scheduled_task_service import (
     ScheduledTaskService,
     TASK_CODE_REDELIVERY,
@@ -47,6 +48,7 @@ from app.services.scheduled_task_service import (
     TASK_CODE_CLOSE_NOTICE,
     TASK_CODE_RED_FLOWER,
     TASK_CODE_DB_BACKUP,
+    TASK_CODE_DELIVERY_TIMEOUT,
 )
 from common.db.session import async_session_maker
 
@@ -72,6 +74,7 @@ class SchedulerService:
         self._close_notice_task_handle: Optional[asyncio.Task] = None
         self._red_flower_task_handle: Optional[asyncio.Task] = None
         self._db_backup_task_handle: Optional[asyncio.Task] = None
+        self._delivery_timeout_task_handle: Optional[asyncio.Task] = None
         self._redelivery_task = RedeliveryTask()
         self._rate_task = RateTask()
         self._polish_task = polish_task_service
@@ -86,6 +89,7 @@ class SchedulerService:
         self._close_notice_task = close_notice_task_service
         self._red_flower_task = RedFlowerTask()
         self._db_backup_task = db_backup_task_service
+        self._delivery_timeout_task = delivery_timeout_task_service
     
     @classmethod
     def get_instance(cls) -> "SchedulerService":
@@ -116,6 +120,8 @@ class SchedulerService:
         """重新加载所有任务配置"""
         for task_code in [TASK_CODE_REDELIVERY, TASK_CODE_RATE, TASK_CODE_POLISH, TASK_CODE_DAY_SWITCH, TASK_CODE_CLEANUP_BROWSER_DATA, TASK_CODE_FETCH_ORDERS, TASK_CODE_FETCH_PENDING_ORDERS, TASK_CODE_FETCH_ITEMS, TASK_CODE_LOGIN_RENEW, TASK_CODE_COOKIES_REFRESH, TASK_CODE_API_COOKIE_RENEW, TASK_CODE_CLOSE_NOTICE, TASK_CODE_RED_FLOWER, TASK_CODE_DB_BACKUP]:
             await self.reload_task_config(task_code)
+        for task_code in [TASK_CODE_DELIVERY_TIMEOUT]:
+            await self.reload_task_config(task_code)
     
     def start(self) -> None:
         """启动定时任务"""
@@ -139,6 +145,7 @@ class SchedulerService:
         self._close_notice_task_handle = asyncio.create_task(self._run_close_notice_loop())
         self._red_flower_task_handle = asyncio.create_task(self._run_red_flower_loop())
         self._db_backup_task_handle = asyncio.create_task(self._run_db_backup_loop())
+        self._delivery_timeout_task_handle = asyncio.create_task(self._run_delivery_timeout_loop())
         logger.info("[定时任务调度] 已启动")
     
     def stop(self) -> None:
@@ -190,6 +197,9 @@ class SchedulerService:
         if self._db_backup_task_handle:
             self._db_backup_task_handle.cancel()
             self._db_backup_task_handle = None
+        if self._delivery_timeout_task_handle:
+            self._delivery_timeout_task_handle.cancel()
+            self._delivery_timeout_task_handle = None
         logger.info("[定时任务调度] 已停止")
     
     def get_task_status(self) -> dict:
@@ -208,6 +218,7 @@ class SchedulerService:
         close_notice_config = ScheduledTaskService.get_cached_config(TASK_CODE_CLOSE_NOTICE)
         red_flower_config = ScheduledTaskService.get_cached_config(TASK_CODE_RED_FLOWER)
         db_backup_config = ScheduledTaskService.get_cached_config(TASK_CODE_DB_BACKUP)
+        delivery_timeout_config = ScheduledTaskService.get_cached_config(TASK_CODE_DELIVERY_TIMEOUT)
         
         return {
             "running": self._running,
@@ -310,6 +321,13 @@ class SchedulerService:
                         and not self._db_backup_task_handle.done()
                     ),
                 },
+                TASK_CODE_DELIVERY_TIMEOUT: {
+                    "config": delivery_timeout_config or {"interval_seconds": 60, "enabled": True},
+                    "task_running": (
+                        self._delivery_timeout_task_handle is not None
+                        and not self._delivery_timeout_task_handle.done()
+                    ),
+                },
             }
         }
     
@@ -362,6 +380,9 @@ class SchedulerService:
         elif task_code == TASK_CODE_DB_BACKUP:
             logger.info("[定时任务调度] 手动触发数据库备份任务")
             await self._db_backup_task.execute()
+        elif task_code == TASK_CODE_DELIVERY_TIMEOUT:
+            logger.info("[定时任务调度] 手动触发发货超时检测任务")
+            await self._delivery_timeout_task.execute()
         else:
             logger.warning(f"[定时任务调度] 未知的任务代码: {task_code}")
     
@@ -825,6 +846,39 @@ class SchedulerService:
                 break
 
         logger.info("[定时任务调度] 数据库备份任务循环结束")
+
+    async def _run_delivery_timeout_loop(self) -> None:
+        """发货超时检测任务执行循环"""
+        logger.info("[定时任务调度] 发货超时检测任务循环开始")
+
+        # 初始加载配置
+        await self.reload_task_config(TASK_CODE_DELIVERY_TIMEOUT)
+
+        while self._running:
+            config = ScheduledTaskService.get_cached_config(TASK_CODE_DELIVERY_TIMEOUT)
+            if not config:
+                config = {"interval_seconds": 60, "enabled": True}
+
+            interval = config.get("interval_seconds", 60)
+            enabled = config.get("enabled", True)
+
+            if enabled:
+                try:
+                    await self._delivery_timeout_task.execute()
+                except asyncio.CancelledError:
+                    logger.info("[定时任务调度] 发货超时检测任务被取消")
+                    break
+                except Exception as e:
+                    logger.error(f"[定时任务调度] 发货超时检测任务执行异常: {e}")
+
+            # 等待下一次执行
+            try:
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                logger.info("[定时任务调度] 发货超时检测任务等待被取消")
+                break
+
+        logger.info("[定时任务调度] 发货超时检测任务循环结束")
 
 
 # 全局实例获取函数


### PR DESCRIPTION
## 问题描述

1. 每次调用分销卡券接口都会查询数据库获取 secret_key，高频场景下造成不必要的数据库压力
2. 提货接口没有频率限制，存在被恶意刷单的风险
3. WebSocket 发送后未收到响应的发货记录会永久停留在 unknown 状态，影响发货统计准确性

## 修复方案

### 1. Secret Key 缓存优化
- 为 `_get_secret_key` 增加 5 分钟 TTL 内存缓存（`_secret_key_cache`）
- 缓存命中时直接返回，避免重复数据库查询
- 新增 `invalidate_secret_key_cache` 方法，支持按用户或全局清空缓存

### 2. 提货接口限流
- 为 `/card-dock/purchase` 接口增加基于用户的滑动窗口限流
- 限制：每用户 60 秒内最多 5 次请求
- 超限返回 HTTP 429 状态码

### 3. 发货超时检测任务
- 新增 `DeliveryTimeoutTask` 定时任务（每 60 秒执行一次）
- 扫描 `send_status=unknown` 且 `reply_strategy=auto_delivery` 超过 5 分钟的记录
- 将符合条件的记录标记为 `timeout`
- 已注册到定时任务调度器，支持配置调整和手动触发

## 测试验证
- secret_key 缓存：首次查询走数据库，5 分钟内重复请求走缓存
- 限流：连续快速提货超过 5 次后返回 429
- 超时检测：unknown 超过 5 分钟的自动发货记录会被标记为 timeout