### PR TITLE
perf: 仪表盘在线数缓存 + 发送状态查询索引优化

### DIFF
--- a/backend-web/app/services/dashboard_stats_service.py
+++ b/backend-web/app/services/dashboard_stats_service.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import and_, case, func, or_, select
@@ -33,6 +34,10 @@ BEIJING_TZ = timezone(timedelta(hours=8))
 
 class DashboardStatsService:
     """仪表盘统计聚合服务。"""
+
+    # Online cookies cache: (timestamp, count)
+    _online_cookies_cache: tuple[float, int] | None = None
+    _ONLINE_COOKIES_CACHE_TTL = 10  # seconds
 
     INACTIVE_ACCOUNT_STATUSES = ("inactive", "disabled", "suspended", "deleted")
     CLOSED_ORDER_STATUSES = ("cancelled", "已关闭")
@@ -284,16 +289,24 @@ class DashboardStatsService:
         }
 
     async def _get_online_cookies_count(self) -> int:
-        """实时获取真实 WebSocket 在线账号数（调用 websocket 服务的连接统计接口）。
+        """实时获取真实 WebSocket 在线账号数（10 秒 TTL 缓存）。
 
         失败时返回 0，不影响其它统计展示。
         """
+        now = time.time()
+        if self.__class__._online_cookies_cache is not None:
+            ts, count = self.__class__._online_cookies_cache
+            if now - ts < self._ONLINE_COOKIES_CACHE_TTL:
+                return count
+
         try:
             settings = get_settings()
             url = f"{settings.websocket_service_url.rstrip('/')}/internal/accounts/connection-stats"
             response = await get_http_client().get(url)
             if isinstance(response, dict) and response.get("success"):
-                return int((response.get("data") or {}).get("connected", 0) or 0)
+                count = int((response.get("data") or {}).get("connected", 0) or 0)
+                self.__class__._online_cookies_cache = (now, count)
+                return count
         except Exception as e:
             logger.warning(f"获取在线账号数失败: {e}")
         return 0

--- a/common/models/auto_reply_message_log.py
+++ b/common/models/auto_reply_message_log.py
@@ -28,6 +28,7 @@ class XYAutoReplyMessageLog(Base):
         Index("idx_arml_status_created", "process_status", "created_at"),
         Index("idx_arml_status_strategy_created", "process_status", "reply_strategy", "created_at"),
         Index("idx_arml_strategy_created", "reply_strategy", "created_at"),
+        Index("idx_arml_order_strategy_id", "order_no", "reply_strategy", "id"),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)


### PR DESCRIPTION
## 问题描述

1. 仪表盘每次加载都会调用 websocket 服务获取在线账号数，高频刷新时造成不必要的网络开销
2. `xy_auto_reply_message_logs` 表在按 `order_no` + `reply_strategy` 查询发送状态时缺少复合索引，全表扫描影响查询性能

## 修复方案

### 1. 在线账号数缓存
- 为 `_get_online_cookies_count` 增加 10 秒 TTL 内存缓存（`_online_cookies_cache`）
- 缓存命中时直接返回，避免重复 HTTP 调用 websocket 服务
- 使用类变量存储缓存，多实例共享

### 2. 发送状态查询索引优化
- 新增复合索引 `idx_arml_order_strategy_id` (order_no, reply_strategy, id)
- 覆盖自动发货场景下按订单号和回复策略查询的常见模式
- 提升发送状态查询和超时检测任务的扫描效率

## 测试验证
- 在线数缓存：10 秒内多次请求返回相同值，不触发 websocket 调用
- 索引优化：EXPLAIN 查询确认新索引被命中