### PR TITLE
feat: IPv6 双栈支持

### DIFF
--- a/backend-web/.env.example
+++ b/backend-web/.env.example
@@ -8,6 +8,9 @@ LOG_LEVEL=INFO
 # 高并发生产环境如需降低开销可设为 false
 SQL_ECHO=true
 
+# 监听地址：:: 同时监听 IPv4 和 IPv6（dual-stack），0.0.0.0 仅监听 IPv4
+# HOST=::
+
 # 数据库配置
 MYSQL_HOST=localhost
 MYSQL_PORT=3306

--- a/backend-web/_bootstrap.py
+++ b/backend-web/_bootstrap.py
@@ -312,7 +312,7 @@ def run_server():
     
     uvicorn.run(
         "main:app",
-        host="0.0.0.0",
+        host=settings.host,  # 默认 "::" 双栈监听，可通过 HOST 环境变量覆盖
         port=settings.service_port,
         reload=False,
         log_level=settings.log_level.lower(),

--- a/common/core/config.py
+++ b/common/core/config.py
@@ -73,7 +73,11 @@ class BaseConfig(BaseSettings):
     jwt_algorithm: str = Field(default="HS256")
     access_token_expire_minutes: int = Field(default=30)
     refresh_token_expire_minutes: int = Field(default=60 * 24 * 7)
-    
+
+    # 服务监听地址：`::` 同时监听 IPv4 和 IPv6（dual-stack），
+    # 适用于 Linux/macOS；如需仅监听 IPv4 可设为 0.0.0.0
+    host: str = Field(default="::")
+
     # 服务地址配置
     websocket_service_url: str = Field(default="http://127.0.0.1:8001")
 
@@ -85,19 +89,22 @@ class BaseConfig(BaseSettings):
     def database_url(self) -> str:
         """同步数据库连接URL"""
         password = quote_plus(self.mysql_password)
-        return f"{self.sync_driver}://{self.mysql_user}:{password}@{self.mysql_host}:{self.mysql_port}/{self.mysql_database}"
+        host = f"[{self.mysql_host}]" if ":" in self.mysql_host else self.mysql_host
+        return f"{self.sync_driver}://{self.mysql_user}:{password}@{host}:{self.mysql_port}/{self.mysql_database}"
 
     @property
     def async_database_url(self) -> str:
         """异步数据库连接URL"""
         password = quote_plus(self.mysql_password)
-        return f"{self.async_driver}://{self.mysql_user}:{password}@{self.mysql_host}:{self.mysql_port}/{self.mysql_database}"
-    
+        host = f"[{self.mysql_host}]" if ":" in self.mysql_host else self.mysql_host
+        return f"{self.async_driver}://{self.mysql_user}:{password}@{host}:{self.mysql_port}/{self.mysql_database}"
+
     @property
     def redis_url(self) -> str:
         """Redis连接URL"""
         password = quote_plus(self.redis_password)
-        return f"redis://:{password}@{self.redis_host}:{self.redis_port}/{self.redis_db}"
+        host = f"[{self.redis_host}]" if ":" in self.redis_host else self.redis_host
+        return f"redis://:{password}@{host}:{self.redis_port}/{self.redis_db}"
 
 
 @lru_cache

--- a/promotion/backend/.env.example
+++ b/promotion/backend/.env.example
@@ -7,6 +7,9 @@
 ENVIRONMENT=development
 LOG_LEVEL=INFO
 
+# 监听地址：:: 同时监听 IPv4 和 IPv6（dual-stack），0.0.0.0 仅监听 IPv4
+# HOST=::
+
 # ---------- 服务端口 ----------
 PROMOTION_PORT=8092
 

--- a/promotion/backend/_bootstrap.py
+++ b/promotion/backend/_bootstrap.py
@@ -165,7 +165,7 @@ def run_server():
         logger.warning("Windows环境已自动关闭reload，避免Playwright因SelectorEventLoop无法启动浏览器子进程")
     uvicorn.run(
         "main:app",
-        host="0.0.0.0",
+        host=settings.host,  # 默认 "::" 双栈监听，可通过 HOST 环境变量覆盖
         port=settings.service_port,
         reload=reload_enabled,
     )

--- a/scheduler/.env.example
+++ b/scheduler/.env.example
@@ -8,6 +8,9 @@ LOG_LEVEL=INFO
 # 高并发生产环境如需降低开销可设为 false
 SQL_ECHO=true
 
+# 监听地址：:: 同时监听 IPv4 和 IPv6（dual-stack），0.0.0.0 仅监听 IPv4
+# HOST=::
+
 # 数据库配置
 MYSQL_HOST=localhost
 MYSQL_PORT=3306

--- a/scheduler/_bootstrap.py
+++ b/scheduler/_bootstrap.py
@@ -197,7 +197,7 @@ def run_server():
     
     uvicorn.run(
         "main:app",
-        host="0.0.0.0",
+        host=settings.host,  # 默认 "::" 双栈监听，可通过 HOST 环境变量覆盖
         port=settings.service_port,
         reload=False,
         log_level=settings.log_level.lower(),

--- a/websocket/.env.example
+++ b/websocket/.env.example
@@ -8,6 +8,9 @@ LOG_LEVEL=INFO
 # 高并发生产环境如需降低开销可设为 false
 SQL_ECHO=true
 
+# 监听地址：:: 同时监听 IPv4 和 IPv6（dual-stack），0.0.0.0 仅监听 IPv4
+# HOST=::
+
 # 数据库配置
 MYSQL_HOST=localhost
 MYSQL_PORT=3306

--- a/websocket/_bootstrap.py
+++ b/websocket/_bootstrap.py
@@ -182,7 +182,7 @@ def run_server():
     
     uvicorn.run(
         "main:app",
-        host="0.0.0.0",
+        host=settings.host,  # 默认 "::" 双栈监听，可通过 HOST 环境变量覆盖
         port=settings.service_port,
         reload=False,
         log_level=settings.log_level.lower(),


### PR DESCRIPTION
## 问题描述

当前所有服务（backend-web、websocket、scheduler、promotion）硬编码监听 `0.0.0.0`（仅 IPv4），在纯 IPv6 环境下无法正常提供服务。此外，当 MySQL/Redis 配置为 IPv6 地址时，连接 URL 拼接错误（缺少方括号），导致连接失败。

## 解决方案

1. 在 `BaseConfig` 中新增 `host` 配置项，默认值为 `::`（同时监听 IPv4 和 IPv6，即 dual-stack），可通过 `HOST` 环境变量覆盖
2. 4 个服务的 `uvicorn.run()` 启动调用从硬编码 `"0.0.0.0"` 改为读取 `settings.host`
3. `database_url`、`async_database_url`、`redis_url` 属性自动检测 IPv6 地址并添加 `[]` 方括号，确保连接 URL 格式正确
4. 各服务的 `.env.example` 增加 `HOST` 配置说明

## 改动文件列表

- `common/core/config.py` — 新增 `host` 字段；数据库/Redis URL IPv6 地址方括号处理
- `backend-web/_bootstrap.py` — uvicorn host 改为 `settings.host`
- `websocket/_bootstrap.py` — uvicorn host 改为 `settings.host`
- `scheduler/_bootstrap.py` — uvicorn host 改为 `settings.host`
- `promotion/backend/_bootstrap.py` — uvicorn host 改为 `settings.host`
- `backend-web/.env.example` — 增加 HOST 配置说明
- `websocket/.env.example` — 增加 HOST 配置说明
- `scheduler/.env.example` — 增加 HOST 配置说明
- `promotion/backend/.env.example` — 增加 HOST 配置说明

## 测试验证

- 默认 `HOST=::` 在 Linux/macOS 下可同时接受 IPv4 和 IPv6 连接
- 设置 `HOST=0.0.0.0` 可回退到仅 IPv4 行为，向下兼容
- MySQL/Redis 配置 IPv6 地址（如 `::1`）时 URL 正确生成为 `[::1]` 格式