### PR TITLE
fix: 批量发布商品特殊字符(emoji/表情)失败 (#186)

### DIFF
--- a/backend-web/app/services/xianyu_publisher.py
+++ b/backend-web/app/services/xianyu_publisher.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import os
 import re
 from pathlib import Path
@@ -1097,7 +1098,7 @@ class XianyuPublisher:
         logger.info(f"描述内容: {full_description[:100]}...")
         await desc_input.click()
         await asyncio.sleep(0.5)
-        await desc_input.evaluate(f"el => el.innerText = {repr(full_description)}")
+        await desc_input.evaluate(f"el => el.innerText = {json.dumps(full_description, ensure_ascii=False)}")
 
         logger.info("✅ 描述已填写")
 


### PR DESCRIPTION
## 问题描述

Issue #186 报告了两个问题：
1. **素材库第二行无法编辑删除**（Bug1）
2. **批量发布商品时，描述中包含特殊字符（emoji/表情）会失败**（Bug2）

## 根因分析

**Bug2 根因：** 批量发布商品时，代码使用 Python 的 `repr()` 函数将商品描述文本转换为 JavaScript 字符串注入到 Playwright 的 `evaluate()` 调用中。

当描述中包含 emoji 等非 BMP Unicode 字符时，`repr()` 会将其转义为 Python 的 Unicode escape 序列，但这些序列在 JavaScript 中是无效的语法，导致 JS 解析错误，发布失败。

## 解决方案

将 `repr(full_description)` 替换为 `json.dumps(full_description, ensure_ascii=False)`：
- `json.dumps()` 生成的 JSON 字符串语法与 JavaScript 完全兼容
- `ensure_ascii=False` 确保中文和 emoji 直接以 UTF-8 原文输出，不被转义
- 这样无论描述中包含什么字符（中文、emoji、表情符号），都能正确传递给浏览器

**改动文件：** `backend-web/app/services/xianyu_publisher.py`
- 新增 `import json`
- 将 `repr(full_description)` 替换为 `json.dumps(full_description, ensure_ascii=False)`

## 关于素材库第二行问题（Bug1）的说明

素材库第二行无法编辑/删除的问题属于前端 UI 层面的 Bug，需要在浏览器环境中复现和调试。本 PR 暂不包含该问题的修复，后续如有复现条件会单独提交修复。
