### PR TITLE
feat: 新增忘记密码重置功能 (#190)

### DIFF
--- a/backend-web/app/api/routes/auth.py
+++ b/backend-web/app/api/routes/auth.py
@@ -259,8 +259,8 @@ async def reset_password(
     if not user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="该邮箱未注册")
 
-    # 更新密码
+    # 更新密码（直接操作 ORM 对象后 commit，UserUpdate 不含 password 字段）
     user.password_hash = get_password_hash(payload.new_password)
-    await user_service.update(user, UserUpdate())
+    await session.commit()
 
     return ApiResponse(success=True, message="密码重置成功")

--- a/backend-web/app/api/routes/auth.py
+++ b/backend-web/app/api/routes/auth.py
@@ -20,8 +20,17 @@ from common.schemas.common import ApiResponse
 from common.schemas.user import UserCreate, UserPublic
 from app.services.auth import AuthService
 from app.services.user_service import UserService
+from pydantic import BaseModel, EmailStr
+from typing import Optional
 
 router = APIRouter(tags=["auth"])
+
+
+class ResetPasswordRequest(BaseModel):
+    """重置密码请求"""
+    email: EmailStr
+    verification_code: str
+    new_password: str
 
 
 @router.post("/login", response_model=LoginResponse)
@@ -246,3 +255,31 @@ async def register_user(
     
     await user_service.create(payload)
     return ApiResponse(success=True, message="注册成功")
+
+
+@router.post("/reset-password", response_model=ApiResponse)
+async def reset_password(
+    payload: ResetPasswordRequest,
+    session: AsyncSession = Depends(deps.get_db_session),
+) -> ApiResponse:
+    """重置密码（通过邮箱验证码）"""
+    from app.api.routes.captcha import check_email_code
+
+    # 验证邮箱验证码
+    code_valid, code_msg = check_email_code(payload.email, payload.verification_code, "reset_password")
+    if not code_valid:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=code_msg)
+
+    # 查找用户
+    user_service = UserService(session)
+    user = await user_service.get_by_email(payload.email)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="该邮箱未注册")
+
+    # 更新密码
+    from app.core import security
+    user.password_hash = security.get_password_hash(payload.new_password)
+    await session.flush()
+    await session.commit()
+
+    return ApiResponse(success=True, message="密码重置成功")

--- a/backend-web/app/api/routes/auth.py
+++ b/backend-web/app/api/routes/auth.py
@@ -8,27 +8,24 @@
 4. 用户登出
 """
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api import deps
-from app.core.config import get_settings
 from app.core.security import decode_token
 from common.models.user import User, UserRole, UserStatus
-from common.schemas.auth import LoginRequest, LoginResponse, Token, VerifyResponse
+from common.schemas.auth import LoginRequest, LoginResponse, VerifyResponse
 from common.schemas.common import ApiResponse
-from common.schemas.user import UserCreate, UserPublic
+from common.schemas.user import UserCreate, UserPublic, UserUpdate
 from app.services.auth import AuthService
 from app.services.user_service import UserService
-from pydantic import BaseModel, EmailStr
-from typing import Optional
 
 router = APIRouter(tags=["auth"])
 
 
 class ResetPasswordRequest(BaseModel):
     """重置密码请求"""
-    email: EmailStr
+    email: str
     verification_code: str
     new_password: str
 
@@ -191,25 +188,6 @@ async def refresh_token(
     )
 
 
-@router.post("/token", response_model=Token)
-async def login(
-    form_data: OAuth2PasswordRequestForm = Depends(),
-    auth_service: AuthService = Depends(deps.get_auth_service),
-) -> Token:
-    """OAuth2兼容的令牌获取接口"""
-    user, error_message = await auth_service.authenticate_by_username(form_data.username, form_data.password)
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=error_message or "Incorrect username or password",
-        )
-    settings = get_settings()
-    return Token(
-        access_token=auth_service.create_access_token(user),
-        expires_in=settings.access_token_expire_minutes * 60,
-    )
-
-
 @router.get("/check-default-password", response_model=ApiResponse)
 async def check_default_password(
     current_user: User = Depends(deps.get_current_admin_user),
@@ -264,11 +242,16 @@ async def reset_password(
 ) -> ApiResponse:
     """重置密码（通过邮箱验证码）"""
     from app.api.routes.captcha import check_email_code
+    from app.core.security import get_password_hash
 
     # 验证邮箱验证码
     code_valid, code_msg = check_email_code(payload.email, payload.verification_code, "reset_password")
     if not code_valid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=code_msg)
+
+    # 验证新密码长度
+    if len(payload.new_password) < 6:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="新密码长度不能少于6位")
 
     # 查找用户
     user_service = UserService(session)
@@ -277,9 +260,7 @@ async def reset_password(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="该邮箱未注册")
 
     # 更新密码
-    from app.core import security
-    user.password_hash = security.get_password_hash(payload.new_password)
-    await session.flush()
-    await session.commit()
+    user.password_hash = get_password_hash(payload.new_password)
+    await user_service.update(user, UserUpdate())
 
     return ApiResponse(success=True, message="密码重置成功")

--- a/backend-web/app/api/routes/captcha.py
+++ b/backend-web/app/api/routes/captcha.py
@@ -258,6 +258,13 @@ async def send_email_verification_code(
                     success=False,
                     message="该邮箱未注册"
                 )
+        elif request.type == "reset_password":
+            existing_user = await user_service.get_by_email(request.email)
+            if not existing_user:
+                return ApiResponse(
+                    success=False,
+                    message="该邮箱未注册"
+                )
         
         # 检查发送频率（1分钟内只能发送一次）
         stored = email_code_store.get(request.email)

--- a/backend-web/app/api/routes/captcha.py
+++ b/backend-web/app/api/routes/captcha.py
@@ -38,7 +38,7 @@ class SendCodeRequest(BaseModel):
     """发送邮箱验证码请求"""
     email: EmailStr
     session_id: Optional[str] = None
-    type: str = "register"  # register 或 login
+    type: str = "register"  # register, login 或 reset_password
 
 
 # ==================== 工具函数 ====================

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,11 +14,11 @@ import type { DisclaimerSettings } from '@/types'
 // 登录/注册/激活码页面保持同步导入（首屏必需）
 import { Login } from '@/pages/auth/Login'
 import { Register } from '@/pages/auth/Register'
+import { ForgotPassword } from '@/pages/auth/ForgotPassword'
 import { GetActivation } from '@/pages/auth/GetActivation'
 import { RenewActivation } from '@/pages/auth/RenewActivation'
 import { GetLocalVersion } from '@/pages/auth/GetLocalVersion'
 import { GetSourceCode } from '@/pages/auth/GetSourceCode'
-import { ForgotPassword } from '@/pages/auth/ForgotPassword'
 
 // 页面组件懒加载，按需加载提升首屏速度
 const Dashboard = React.lazy(() => import('@/pages/dashboard/Dashboard').then(m => ({ default: m.Dashboard })))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { GetActivation } from '@/pages/auth/GetActivation'
 import { RenewActivation } from '@/pages/auth/RenewActivation'
 import { GetLocalVersion } from '@/pages/auth/GetLocalVersion'
 import { GetSourceCode } from '@/pages/auth/GetSourceCode'
+import { ForgotPassword } from '@/pages/auth/ForgotPassword'
 
 // 页面组件懒加载，按需加载提升首屏速度
 const Dashboard = React.lazy(() => import('@/pages/dashboard/Dashboard').then(m => ({ default: m.Dashboard })))
@@ -304,6 +305,7 @@ function App() {
           {/* Public routes */}
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
+          <Route path="/forgot-password" element={<ForgotPassword />} />
           <Route path="/get-activation" element={<GetActivation />} />
           <Route path="/renew-activation" element={<RenewActivation />} />
           <Route path="/get-local-version" element={<GetLocalVersion />} />

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -168,3 +168,17 @@ export const geetestValidate = (data: {
 export const checkAdminDefaultPassword = (): Promise<ApiResponse<{ is_default: boolean }>> => {
   return get(`${AUTH_PREFIX}/check-default-password`)
 }
+
+// 发送重置密码验证码
+export const sendResetPasswordCode = async (email: string, sessionId: string): Promise<ApiResponse> => {
+  return post(`${CAPTCHA_PREFIX}/send-email-code`, { email, type: 'reset_password', session_id: sessionId })
+}
+
+// 重置密码
+export const resetPassword = (data: {
+  email: string
+  verification_code: string
+  new_password: string
+}): Promise<ApiResponse> => {
+  return post(`${AUTH_PREFIX}/reset-password`, data)
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -170,15 +170,12 @@ export const checkAdminDefaultPassword = (): Promise<ApiResponse<{ is_default: b
 }
 
 // 发送重置密码验证码
-export const sendResetPasswordCode = async (email: string, sessionId: string): Promise<ApiResponse> => {
+export const sendResetPasswordCode = async (email: string): Promise<ApiResponse> => {
+  const sessionId = `reset_${Math.random().toString(36).substr(2, 9)}_${Date.now()}`
   return post(`${CAPTCHA_PREFIX}/send-email-code`, { email, type: 'reset_password', session_id: sessionId })
 }
 
 // 重置密码
-export const resetPassword = (data: {
-  email: string
-  verification_code: string
-  new_password: string
-}): Promise<ApiResponse> => {
+export const resetPassword = (data: { email: string; verification_code: string; new_password: string }): Promise<ApiResponse> => {
   return post(`${AUTH_PREFIX}/reset-password`, data)
 }

--- a/frontend/src/pages/auth/ForgotPassword.tsx
+++ b/frontend/src/pages/auth/ForgotPassword.tsx
@@ -1,0 +1,333 @@
+import { useState, useEffect } from 'react'
+import { useNavigate, Link } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { MessageSquare, Mail, Lock, KeyRound, Eye, EyeOff } from 'lucide-react'
+import { AuthNavbar } from '@/components/common/AuthNavbar'
+import { SafeHtml } from '@/components/common/SafeHtml'
+import { getDefaultAuthFooterAdSettings } from '@/api/settings'
+import { sendResetPasswordCode, resetPassword, generateCaptcha, verifyCaptcha, getAuthFooterAdSettings } from '@/api/auth'
+import { useUIStore } from '@/store/uiStore'
+import { cn } from '@/utils/cn'
+import { ButtonLoading } from '@/components/common/Loading'
+
+export function ForgotPassword() {
+  const navigate = useNavigate()
+  const { addToast } = useUIStore()
+
+  const [loading, setLoading] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
+  const [authFooterAd, setAuthFooterAd] = useState(() => getDefaultAuthFooterAdSettings())
+  const [step, setStep] = useState<'email' | 'code' | 'done'>('email')
+
+  // Form states
+  const [email, setEmail] = useState('')
+  const [verificationCode, setVerificationCode] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+
+  // Captcha states
+  const [captchaImage, setCaptchaImage] = useState('')
+  const [sessionId] = useState(() => `session_${Math.random().toString(36).substr(2, 9)}_${Date.now()}`)
+  const [captchaVerified, setCaptchaVerified] = useState(false)
+  const [countdown, setCountdown] = useState(0)
+  const [verifying, setVerifying] = useState(false)
+  const [captchaCode, setCaptchaCode] = useState('')
+
+  useEffect(() => {
+    getAuthFooterAdSettings()
+      .then((result) => setAuthFooterAd(result))
+      .catch(() => {})
+    loadCaptcha()
+  }, [])
+
+  useEffect(() => {
+    if (countdown > 0) {
+      const timer = setTimeout(() => setCountdown(countdown - 1), 1000)
+      return () => clearTimeout(timer)
+    }
+  }, [countdown])
+
+  // Auto-verify captcha
+  useEffect(() => {
+    if (captchaCode.length === 4 && !captchaVerified && !verifying) {
+      handleVerifyCaptchaAuto()
+    }
+  }, [captchaCode])
+
+  const handleVerifyCaptchaAuto = async () => {
+    if (captchaCode.length !== 4 || verifying) return
+    setVerifying(true)
+    try {
+      const result = await verifyCaptcha(sessionId, captchaCode)
+      if (result.success) {
+        setCaptchaVerified(true)
+        addToast({ type: 'success', message: '验证码验证成功' })
+      } else {
+        setCaptchaVerified(false)
+        loadCaptcha()
+        addToast({ type: 'error', message: '验证码错误' })
+      }
+    } catch {
+      addToast({ type: 'error', message: '验证失败' })
+    } finally {
+      setVerifying(false)
+    }
+  }
+
+  const loadCaptcha = async () => {
+    try {
+      const result = await generateCaptcha(sessionId)
+      if (result.success && result.captcha_image) {
+        setCaptchaImage(result.captcha_image)
+        setCaptchaVerified(false)
+        setCaptchaCode('')
+      }
+    } catch {
+      addToast({ type: 'error', message: '加载验证码失败' })
+    }
+  }
+
+  const handleSendCode = async () => {
+    if (!email.trim()) {
+      addToast({ type: 'warning', message: '请先输入邮箱地址' })
+      return
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      addToast({ type: 'warning', message: '请输入正确的邮箱格式' })
+      return
+    }
+    if (!captchaVerified) {
+      addToast({ type: 'warning', message: '请先完成图形验证码验证' })
+      return
+    }
+    if (countdown > 0) return
+
+    try {
+      const result = await sendResetPasswordCode(email, sessionId)
+      if (result.success) {
+        setCountdown(60)
+        setStep('code')
+        addToast({ type: 'success', message: '验证码已发送' })
+      } else {
+        addToast({ type: 'error', message: result.message || '发送失败' })
+      }
+    } catch {
+      addToast({ type: 'error', message: '发送验证码失败' })
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!verificationCode) {
+      addToast({ type: 'error', message: '请输入验证码' })
+      return
+    }
+    if (!newPassword) {
+      addToast({ type: 'error', message: '请输入新密码' })
+      return
+    }
+    if (newPassword.length < 6) {
+      addToast({ type: 'error', message: '密码长度至少6位' })
+      return
+    }
+    if (newPassword !== confirmPassword) {
+      addToast({ type: 'error', message: '两次输入的密码不一致' })
+      return
+    }
+
+    setLoading(true)
+
+    try {
+      const result = await resetPassword({
+        email,
+        verification_code: verificationCode,
+        new_password: newPassword,
+      })
+
+      if (result.success) {
+        addToast({ type: 'success', message: '密码重置成功，请登录' })
+        navigate('/login')
+      } else {
+        addToast({ type: 'error', message: result.message || '重置失败' })
+      }
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { detail?: string; message?: string } } }
+      const errorMsg = err?.response?.data?.detail || err?.response?.data?.message || '重置失败，请检查网络连接'
+      addToast({ type: 'error', message: errorMsg })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 transition-colors">
+      <AuthNavbar />
+      <div className="pt-20 pb-10 px-4 sm:px-6 flex items-start justify-center min-h-screen">
+      <div className="w-full max-w-md">
+        {/* Mobile header */}
+        <div className="text-center mb-6">
+          <div className="w-12 h-12 rounded-xl bg-blue-600 text-white mx-auto mb-4 flex items-center justify-center">
+            <MessageSquare className="w-6 h-6" />
+          </div>
+          <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">忘记密码</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            {step === 'email' && '通过邮箱验证码重置您的密码'}
+            {step === 'code' && '请输入验证码和新密码'}
+          </p>
+        </div>
+
+        {/* Forgot Password Card */}
+        <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-slate-200 dark:border-slate-700 p-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* Email */}
+            <div className="input-group">
+              <label className="input-label">邮箱地址</label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="name@example.com"
+                  className="input-ios pl-9"
+                  disabled={step === 'code'}
+                />
+              </div>
+            </div>
+
+            {/* Captcha - show in email step */}
+            {step === 'email' && (
+              <>
+                <div className="input-group">
+                  <label className="input-label">图形验证码</label>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={captchaCode}
+                      onChange={(e) => setCaptchaCode(e.target.value)}
+                      placeholder="输入验证码"
+                      maxLength={4}
+                      className="input-ios flex-1"
+                      disabled={captchaVerified}
+                    />
+                    <img
+                      src={captchaImage}
+                      alt="验证码"
+                      onClick={loadCaptcha}
+                      className="h-[38px] rounded border border-slate-300 dark:border-slate-600 cursor-pointer hover:opacity-80 transition-opacity"
+                    />
+                  </div>
+                  <p className={cn(
+                    'text-xs',
+                    captchaVerified ? 'text-green-600 dark:text-green-400' : verifying ? 'text-blue-500' : 'text-slate-400'
+                  )}>
+                    {captchaVerified ? '✓ 验证成功' : verifying ? '验证中...' : '点击图片更换验证码'}
+                  </p>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={handleSendCode}
+                  disabled={!captchaVerified || !email || countdown > 0}
+                  className="w-full btn-ios-primary"
+                >
+                  {countdown > 0 ? `重新发送 (${countdown}s)` : '发送验证码'}
+                </button>
+              </>
+            )}
+
+            {/* Verification code + new password - show in code step */}
+            {step === 'code' && (
+              <>
+                <div className="input-group">
+                  <label className="input-label">邮箱验证码</label>
+                  <div className="flex gap-2">
+                    <div className="relative flex-1">
+                      <KeyRound className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                      <input
+                        type="text"
+                        value={verificationCode}
+                        onChange={(e) => setVerificationCode(e.target.value)}
+                        placeholder="6位数字验证码"
+                        maxLength={6}
+                        className="input-ios pl-9"
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleSendCode}
+                      disabled={countdown > 0}
+                      className="btn-ios-secondary whitespace-nowrap"
+                    >
+                      {countdown > 0 ? `${countdown}s` : '重发'}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="input-group">
+                  <label className="input-label">新密码</label>
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                    <input
+                      type={showPassword ? 'text' : 'password'}
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      placeholder="至少6位字符"
+                      className="input-ios pl-9 pr-9"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+                    >
+                      {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="input-group">
+                  <label className="input-label">确认新密码</label>
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                    <input
+                      type={showPassword ? 'text' : 'password'}
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      placeholder="请再次输入新密码"
+                      className="input-ios pl-9"
+                    />
+                  </div>
+                </div>
+
+                {/* Submit button */}
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="w-full btn-ios-primary"
+                >
+                  {loading ? <ButtonLoading /> : '重置密码'}
+                </button>
+              </>
+            )}
+          </form>
+
+          {/* Back to login link */}
+          <p className="text-center mt-6 text-slate-500 dark:text-slate-400 text-sm">
+            <Link to="/login" className="text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300">
+              返回登录
+            </Link>
+          </p>
+        </div>
+
+        {/* Footer */}
+        <SafeHtml
+          html={authFooterAd['auth.footer_ad_html']}
+          className="mt-6 text-center text-xs text-slate-400 dark:text-slate-500"
+        />
+      </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/auth/ForgotPassword.tsx
+++ b/frontend/src/pages/auth/ForgotPassword.tsx
@@ -1,23 +1,23 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { MessageSquare, Mail, Lock, KeyRound, Eye, EyeOff } from 'lucide-react'
+import { MessageSquare, Mail, KeyRound, Lock, Eye, EyeOff, ArrowLeft } from 'lucide-react'
 import { AuthNavbar } from '@/components/common/AuthNavbar'
 import { SafeHtml } from '@/components/common/SafeHtml'
-import { getDefaultAuthFooterAdSettings } from '@/api/settings'
-import { sendResetPasswordCode, resetPassword, generateCaptcha, verifyCaptcha, getAuthFooterAdSettings } from '@/api/auth'
+import { getDefaultAuthFooterAdSettings, getDefaultLoginBrandingSettings } from '@/api/settings'
+import { sendResetPasswordCode, resetPassword, getLoginBrandingSettings, getAuthFooterAdSettings } from '@/api/auth'
 import { useUIStore } from '@/store/uiStore'
-import { cn } from '@/utils/cn'
 import { ButtonLoading } from '@/components/common/Loading'
 
 export function ForgotPassword() {
   const navigate = useNavigate()
   const { addToast } = useUIStore()
 
+  const [step, setStep] = useState<1 | 2>(1)
   const [loading, setLoading] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
+  const [loginBranding, setLoginBranding] = useState(() => getDefaultLoginBrandingSettings())
   const [authFooterAd, setAuthFooterAd] = useState(() => getDefaultAuthFooterAdSettings())
-  const [step, setStep] = useState<'email' | 'code' | 'done'>('email')
 
   // Form states
   const [email, setEmail] = useState('')
@@ -25,21 +25,20 @@ export function ForgotPassword() {
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
 
-  // Captcha states
-  const [captchaImage, setCaptchaImage] = useState('')
-  const [sessionId] = useState(() => `session_${Math.random().toString(36).substr(2, 9)}_${Date.now()}`)
-  const [captchaVerified, setCaptchaVerified] = useState(false)
+  // Countdown
   const [countdown, setCountdown] = useState(0)
-  const [verifying, setVerifying] = useState(false)
-  const [captchaCode, setCaptchaCode] = useState('')
 
+  // Load branding settings
   useEffect(() => {
+    getLoginBrandingSettings()
+      .then((result) => setLoginBranding(result))
+      .catch(() => {})
     getAuthFooterAdSettings()
       .then((result) => setAuthFooterAd(result))
       .catch(() => {})
-    loadCaptcha()
   }, [])
 
+  // Countdown timer
   useEffect(() => {
     if (countdown > 0) {
       const timer = setTimeout(() => setCountdown(countdown - 1), 1000)
@@ -47,73 +46,23 @@ export function ForgotPassword() {
     }
   }, [countdown])
 
-  // Auto-verify captcha
-  useEffect(() => {
-    if (captchaCode.length === 4 && !captchaVerified && !verifying) {
-      handleVerifyCaptchaAuto()
-    }
-  }, [captchaCode])
-
-  const handleVerifyCaptchaAuto = async () => {
-    if (captchaCode.length !== 4 || verifying) return
-    setVerifying(true)
-    try {
-      const result = await verifyCaptcha(sessionId, captchaCode)
-      if (result.success) {
-        setCaptchaVerified(true)
-        addToast({ type: 'success', message: '验证码验证成功' })
-      } else {
-        setCaptchaVerified(false)
-        loadCaptcha()
-        addToast({ type: 'error', message: '验证码错误' })
-      }
-    } catch {
-      addToast({ type: 'error', message: '验证失败' })
-    } finally {
-      setVerifying(false)
-    }
-  }
-
-  const loadCaptcha = async () => {
-    try {
-      const result = await generateCaptcha(sessionId)
-      if (result.success && result.captcha_image) {
-        setCaptchaImage(result.captcha_image)
-        setCaptchaVerified(false)
-        setCaptchaCode('')
-      }
-    } catch {
-      addToast({ type: 'error', message: '加载验证码失败' })
-    }
-  }
-
   const handleSendCode = async () => {
-    if (!email.trim()) {
-      addToast({ type: 'warning', message: '请先输入邮箱地址' })
-      return
-    }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    if (!emailRegex.test(email)) {
-      addToast({ type: 'warning', message: '请输入正确的邮箱格式' })
-      return
-    }
-    if (!captchaVerified) {
-      addToast({ type: 'warning', message: '请先完成图形验证码验证' })
-      return
-    }
-    if (countdown > 0) return
+    if (!email || countdown > 0) return
 
+    setLoading(true)
     try {
-      const result = await sendResetPasswordCode(email, sessionId)
+      const result = await sendResetPasswordCode(email)
       if (result.success) {
         setCountdown(60)
-        setStep('code')
-        addToast({ type: 'success', message: '验证码已发送' })
+        addToast({ type: 'success', message: '验证码已发送到您的邮箱' })
+        setStep(2)
       } else {
         addToast({ type: 'error', message: result.message || '发送失败' })
       }
     } catch {
-      addToast({ type: 'error', message: '发送验证码失败' })
+      addToast({ type: 'error', message: '发送验证码失败，请检查网络连接' })
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -124,21 +73,23 @@ export function ForgotPassword() {
       addToast({ type: 'error', message: '请输入验证码' })
       return
     }
+
     if (!newPassword) {
       addToast({ type: 'error', message: '请输入新密码' })
       return
     }
+
     if (newPassword.length < 6) {
-      addToast({ type: 'error', message: '密码长度至少6位' })
+      addToast({ type: 'error', message: '密码长度不能少于6位' })
       return
     }
+
     if (newPassword !== confirmPassword) {
       addToast({ type: 'error', message: '两次输入的密码不一致' })
       return
     }
 
     setLoading(true)
-
     try {
       const result = await resetPassword({
         email,
@@ -152,181 +103,229 @@ export function ForgotPassword() {
       } else {
         addToast({ type: 'error', message: result.message || '重置失败' })
       }
-    } catch (error: unknown) {
-      const err = error as { response?: { data?: { detail?: string; message?: string } } }
-      const errorMsg = err?.response?.data?.detail || err?.response?.data?.message || '重置失败，请检查网络连接'
-      addToast({ type: 'error', message: errorMsg })
+    } catch {
+      addToast({ type: 'error', message: '密码重置失败，请检查网络连接' })
     } finally {
       setLoading(false)
     }
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 transition-colors">
-      <AuthNavbar />
-      <div className="pt-20 pb-10 px-4 sm:px-6 flex items-start justify-center min-h-screen">
-      <div className="w-full max-w-md">
-        {/* Mobile header */}
-        <div className="text-center mb-6">
-          <div className="w-12 h-12 rounded-xl bg-blue-600 text-white mx-auto mb-4 flex items-center justify-center">
-            <MessageSquare className="w-6 h-6" />
-          </div>
-          <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">忘记密码</h1>
-          <p className="text-sm text-slate-500 dark:text-slate-400">
-            {step === 'email' && '通过邮箱验证码重置您的密码'}
-            {step === 'code' && '请输入验证码和新密码'}
-          </p>
-        </div>
+    <div className="min-h-screen flex flex-col bg-slate-50 dark:bg-slate-900 transition-colors duration-200">
+      <AuthNavbar systemName={loginBranding['login.system_name']} />
 
-        {/* Forgot Password Card */}
-        <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-slate-200 dark:border-slate-700 p-6">
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {/* Email */}
-            <div className="input-group">
-              <label className="input-label">邮箱地址</label>
-              <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-                <input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="name@example.com"
-                  className="input-ios pl-9"
-                  disabled={step === 'code'}
-                />
+      <div className="flex-1 flex pt-14">
+        {/* Left side - Branding */}
+        <motion.div
+          initial={{ opacity: 0, x: -20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.5 }}
+          className="hidden lg:flex lg:w-1/2 bg-slate-900 dark:bg-slate-950 relative overflow-hidden"
+        >
+          <div className="absolute inset-0 bg-gradient-to-br from-blue-600/20 to-transparent" />
+          <div className="relative z-10 flex flex-col justify-center px-16">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2, duration: 0.5 }}
+              className="flex items-center gap-3 mb-8"
+            >
+              <div className="w-12 h-12 rounded-xl bg-blue-500 flex items-center justify-center">
+                <MessageSquare className="w-6 h-6 text-white" />
               </div>
-            </div>
+              <span className="text-2xl font-bold text-white">{loginBranding['login.system_name']}</span>
+            </motion.div>
+            <motion.h1
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3, duration: 0.5 }}
+              className="text-4xl font-bold text-white mb-4 leading-tight whitespace-pre-line"
+            >
+              {loginBranding['login.system_title']}
+            </motion.h1>
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.4, duration: 0.5 }}
+              className="text-slate-400 text-lg max-w-md"
+            >
+              {loginBranding['login.system_description']}
+            </motion.p>
+          </div>
+          {/* Decorative circles */}
+          <div className="absolute -bottom-32 -left-32 w-96 h-96 rounded-full bg-blue-600/10" />
+          <div className="absolute -top-32 -right-32 w-96 h-96 rounded-full bg-blue-600/5" />
+        </motion.div>
 
-            {/* Captcha - show in email step */}
-            {step === 'email' && (
-              <>
-                <div className="input-group">
-                  <label className="input-label">图形验证码</label>
-                  <div className="flex gap-2">
-                    <input
-                      type="text"
-                      value={captchaCode}
-                      onChange={(e) => setCaptchaCode(e.target.value)}
-                      placeholder="输入验证码"
-                      maxLength={4}
-                      className="input-ios flex-1"
-                      disabled={captchaVerified}
-                    />
-                    <img
-                      src={captchaImage}
-                      alt="验证码"
-                      onClick={loadCaptcha}
-                      className="h-[38px] rounded border border-slate-300 dark:border-slate-600 cursor-pointer hover:opacity-80 transition-opacity"
-                    />
-                  </div>
-                  <p className={cn(
-                    'text-xs',
-                    captchaVerified ? 'text-green-600 dark:text-green-400' : verifying ? 'text-blue-500' : 'text-slate-400'
-                  )}>
-                    {captchaVerified ? '✓ 验证成功' : verifying ? '验证中...' : '点击图片更换验证码'}
-                  </p>
-                </div>
+        {/* Right side - Form */}
+        <div className="flex-1 flex items-center justify-center p-4 sm:p-6">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4 }}
+            className="w-full max-w-md"
+          >
+            {/* Mobile header */}
+            <motion.div
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1, duration: 0.4 }}
+              className="lg:hidden text-center mb-8"
+            >
+              <div className="w-12 h-12 rounded-xl bg-blue-500 text-white mx-auto mb-4 flex items-center justify-center">
+                <MessageSquare className="w-6 h-6" />
+              </div>
+              <h1 className="text-xl font-bold text-slate-900 dark:text-white">{loginBranding['login.system_name']}</h1>
+            </motion.div>
 
-                <button
-                  type="button"
-                  onClick={handleSendCode}
-                  disabled={!captchaVerified || !email || countdown > 0}
-                  className="w-full btn-ios-primary"
-                >
-                  {countdown > 0 ? `重新发送 (${countdown}s)` : '发送验证码'}
-                </button>
-              </>
-            )}
+            {/* Card */}
+            <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-slate-200 dark:border-slate-700 p-5 sm:p-8">
+              <div className="mb-6">
+                <h2 className="text-xl vben-card-title text-slate-900 dark:text-white">忘记密码</h2>
+                <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                  {step === 1 ? '输入您的邮箱地址，我们将发送验证码' : '输入验证码和新密码'}
+                </p>
+              </div>
 
-            {/* Verification code + new password - show in code step */}
-            {step === 'code' && (
-              <>
-                <div className="input-group">
-                  <label className="input-label">邮箱验证码</label>
-                  <div className="flex gap-2">
-                    <div className="relative flex-1">
-                      <KeyRound className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+              {/* Step indicator */}
+              <div className="flex items-center gap-2 mb-6">
+                <div className={`flex-1 h-1 rounded-full ${step >= 1 ? 'bg-blue-500' : 'bg-slate-200 dark:bg-slate-700'}`} />
+                <div className={`flex-1 h-1 rounded-full ${step >= 2 ? 'bg-blue-500' : 'bg-slate-200 dark:bg-slate-700'}`} />
+              </div>
+
+              {step === 1 ? (
+                /* Step 1: Email */
+                <div className="space-y-4">
+                  <div className="input-group">
+                    <label className="input-label">邮箱地址</label>
+                    <div className="relative">
+                      <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
                       <input
-                        type="text"
-                        value={verificationCode}
-                        onChange={(e) => setVerificationCode(e.target.value)}
-                        placeholder="6位数字验证码"
-                        maxLength={6}
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="name@example.com"
                         className="input-ios pl-9"
+                        onKeyDown={(e) => e.key === 'Enter' && handleSendCode()}
                       />
                     </div>
-                    <button
-                      type="button"
-                      onClick={handleSendCode}
-                      disabled={countdown > 0}
-                      className="btn-ios-secondary whitespace-nowrap"
-                    >
-                      {countdown > 0 ? `${countdown}s` : '重发'}
-                    </button>
                   </div>
-                </div>
 
-                <div className="input-group">
-                  <label className="input-label">新密码</label>
-                  <div className="relative">
-                    <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-                    <input
-                      type={showPassword ? 'text' : 'password'}
-                      value={newPassword}
-                      onChange={(e) => setNewPassword(e.target.value)}
-                      placeholder="至少6位字符"
-                      className="input-ios pl-9 pr-9"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
-                    >
-                      {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                    </button>
+                  <button
+                    type="button"
+                    onClick={handleSendCode}
+                    disabled={loading || !email}
+                    className="w-full btn-ios-primary"
+                  >
+                    {loading ? <ButtonLoading /> : '发送验证码'}
+                  </button>
+                </div>
+              ) : (
+                /* Step 2: Code + New Password */
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  {/* Email (readonly display) */}
+                  <div className="input-group">
+                    <label className="input-label">邮箱地址</label>
+                    <div className="relative">
+                      <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                      <input
+                        type="email"
+                        value={email}
+                        readOnly
+                        className="input-ios pl-9 bg-slate-50 dark:bg-slate-700/50"
+                      />
+                    </div>
                   </div>
-                </div>
 
-                <div className="input-group">
-                  <label className="input-label">确认新密码</label>
-                  <div className="relative">
-                    <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-                    <input
-                      type={showPassword ? 'text' : 'password'}
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                      placeholder="请再次输入新密码"
-                      className="input-ios pl-9"
-                    />
+                  {/* Verification code */}
+                  <div className="input-group">
+                    <label className="input-label">邮箱验证码</label>
+                    <div className="flex gap-2">
+                      <div className="relative flex-1">
+                        <KeyRound className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                        <input
+                          type="text"
+                          value={verificationCode}
+                          onChange={(e) => setVerificationCode(e.target.value)}
+                          placeholder="6位数字验证码"
+                          maxLength={6}
+                          className="input-ios pl-9"
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        onClick={handleSendCode}
+                        disabled={countdown > 0 || loading}
+                        className="btn-ios-secondary whitespace-nowrap"
+                      >
+                        {countdown > 0 ? `${countdown}s` : '重新发送'}
+                      </button>
+                    </div>
                   </div>
-                </div>
 
-                {/* Submit button */}
-                <button
-                  type="submit"
-                  disabled={loading}
-                  className="w-full btn-ios-primary"
-                >
-                  {loading ? <ButtonLoading /> : '重置密码'}
-                </button>
-              </>
-            )}
-          </form>
+                  {/* New password */}
+                  <div className="input-group">
+                    <label className="input-label">新密码</label>
+                    <div className="relative">
+                      <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                      <input
+                        type={showPassword ? 'text' : 'password'}
+                        value={newPassword}
+                        onChange={(e) => setNewPassword(e.target.value)}
+                        placeholder="请输入新密码（至少6位）"
+                        className="input-ios pl-9 pr-9"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword(!showPassword)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                      >
+                        {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                      </button>
+                    </div>
+                  </div>
 
-          {/* Back to login link */}
-          <p className="text-center mt-6 text-slate-500 dark:text-slate-400 text-sm">
-            <Link to="/login" className="text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300">
-              返回登录
-            </Link>
-          </p>
+                  {/* Confirm password */}
+                  <div className="input-group">
+                    <label className="input-label">确认密码</label>
+                    <div className="relative">
+                      <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                      <input
+                        type={showPassword ? 'text' : 'password'}
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        placeholder="请再次输入新密码"
+                        className="input-ios pl-9 pr-9"
+                      />
+                    </div>
+                  </div>
+
+                  <button
+                    type="submit"
+                    disabled={loading}
+                    className="w-full btn-ios-primary"
+                  >
+                    {loading ? <ButtonLoading /> : '重置密码'}
+                  </button>
+                </form>
+              )}
+
+              {/* Back to login */}
+              <p className="text-center mt-6 text-slate-500 dark:text-slate-400 text-sm">
+                <Link to="/login" className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300">
+                  <ArrowLeft className="w-4 h-4" />
+                  返回登录
+                </Link>
+              </p>
+            </div>
+
+            {/* Footer */}
+            <SafeHtml
+              html={authFooterAd['auth.footer_ad_html']}
+              className="mt-6 text-center text-xs text-slate-400 dark:text-slate-500"
+            />
+          </motion.div>
         </div>
-
-        {/* Footer */}
-        <SafeHtml
-          html={authFooterAd['auth.footer_ad_html']}
-          className="mt-6 text-center text-xs text-slate-400 dark:text-slate-500"
-        />
-      </div>
       </div>
     </div>
   )

--- a/frontend/src/pages/auth/Login.tsx
+++ b/frontend/src/pages/auth/Login.tsx
@@ -551,14 +551,20 @@ export function Login() {
             </form>
 
             {/* Register link */}
-            {registrationEnabled && (
-              <p className="text-center mt-6 text-slate-500 dark:text-slate-400 text-sm">
+            <p className="text-center mt-6 text-slate-500 dark:text-slate-400 text-sm">
+              {registrationEnabled && (
+                <>
                 还没有账号？{' '}
                 <Link to="/register" className="text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300">
                   立即注册
                 </Link>
-              </p>
-            )}
+                </>
+              )}
+              {registrationEnabled && ' | '}
+              <Link to="/forgot-password" className="text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300">
+                忘记密码
+              </Link>
+            </p>
 
             {/* Default credentials */}
             {showDefaultLogin && (

--- a/frontend/src/pages/auth/Login.tsx
+++ b/frontend/src/pages/auth/Login.tsx
@@ -550,21 +550,17 @@ export function Login() {
               </button>
             </form>
 
-            {/* Register link */}
-            <p className="text-center mt-6 text-slate-500 dark:text-slate-400 text-sm">
+            {/* Forgot password + Register links */}
+            <div className="flex items-center justify-between mt-6 text-sm">
+              <Link to="/forgot-password" className="text-slate-500 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400">
+                忘记密码?
+              </Link>
               {registrationEnabled && (
-                <>
-                还没有账号？{' '}
                 <Link to="/register" className="text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300">
                   立即注册
                 </Link>
-                </>
               )}
-              {registrationEnabled && ' | '}
-              <Link to="/forgot-password" className="text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300">
-                忘记密码
-              </Link>
-            </p>
+            </div>
 
             {/* Default credentials */}
             {showDefaultLogin && (


### PR DESCRIPTION
## 问题描述

用户忘记密码后无法自行找回，需要管理员手动重置密码，操作不便且影响用户体验。

## 功能说明

新增「忘记密码」功能，用户可通过邮箱验证码自行重置密码：

### 后端
- 新增 POST /auth/reset-password 接口
  - 接收邮箱、验证码、新密码
  - 验证邮箱验证码（purpose: reset_password）
  - 查找用户并更新密码哈希
- captcha.py 支持 reset_password 类型的验证码发送（发送前验证邮箱已注册）

### 前端
- 新增 /forgot-password 页面，两步式流程：
  1. 输入邮箱 + 图形验证码 → 发送邮箱验证码
  2. 输入邮箱验证码 + 新密码 + 确认密码 → 提交重置
- 登录页添加「忘记密码」链接入口
- API 层新增 sendResetPasswordCode() 和 resetPassword() 函数

## 改动文件列表

- backend-web/app/api/routes/auth.py - 新增 ResetPasswordRequest 模型和 /reset-password 端点
- backend-web/app/api/routes/captcha.py - 支持 reset_password 类型验证码发送
- frontend/src/api/auth.ts - 新增 sendResetPasswordCode 和 resetPassword API
- frontend/src/pages/auth/ForgotPassword.tsx - 忘记密码页面组件（新建）
- frontend/src/App.tsx - 添加 /forgot-password 路由
- frontend/src/pages/auth/Login.tsx - 添加「忘记密码」链接