### PR TITLE
feat: 支持多关键词回复和 API 卡券响应字段

### DIFF
--- a/backend-web/app/services/card_service.py
+++ b/backend-web/app/services/card_service.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from common.models.card import Card
 from common.services.card_matcher import CardMatcher
+from common.utils.response_field import extract_card_api_response_content
 
 
 from common.utils.time_utils import safe_isoformat
@@ -932,14 +933,13 @@ class CardService:
     async def _call_card_api(self, card: Card) -> Optional[str]:
         """调用卡券API获取内容
         
-        Args:
+        参数:
             card: 卡券对象
             
-        Returns:
+        返回:
             API返回的内容或None
         """
         try:
-            import json
             import httpx
             
             if not card.api_config:
@@ -963,17 +963,8 @@ class CardService:
                     response = await client.post(url, headers=headers, json=body)
                 
                 response.raise_for_status()
-                
-                # 尝试解析JSON响应
-                try:
-                    data = response.json()
-                    # 支持自定义响应字段
-                    field = config.get("response_field", "data")
-                    if field in data:
-                        return str(data[field])
-                    return json.dumps(data, ensure_ascii=False)
-                except Exception:
-                    return response.text
+                response_field = config.get("response_field") or config.get("responseField")
+                return extract_card_api_response_content(response.text, response_field)
                     
         except Exception as e:
             logger.error(f"调用卡券API失败: {e}")

--- a/backend-web/app/services/keyword_service.py
+++ b/backend-web/app/services/keyword_service.py
@@ -22,7 +22,7 @@ from common.models.xy_keyword_rule import XYKeywordRule
 
 
 class KeywordService:
-    """Business logic for keyword CRUD compatible with the legacy API."""
+    """关键词增删改查服务，保持旧接口和旧表结构兼容。"""
 
     def __init__(self, session: AsyncSession):
         self.session = session
@@ -150,6 +150,11 @@ class KeywordService:
 
         await self.session.commit()
 
+    @staticmethod
+    def _split_keyword_lines(keyword_text: str) -> list[str]:
+        """按行拆分关键词文本，前端多关键词输入仍然落到旧的一条规则一行结构。"""
+        return [line.strip() for line in (keyword_text or "").splitlines() if line.strip()]
+
     async def update_text_keyword(
         self,
         source_account: XYAccount,
@@ -160,14 +165,23 @@ class KeywordService:
         target_reply: str | None,
         target_item_id: str | None,
     ) -> None:
+        """更新文本关键词，允许把一个旧规则替换成多条同回复规则。"""
         normalized_source_keyword = (source_keyword or "").strip()
         normalized_source_item_id = (source_item_id or "").strip() or None
-        normalized_target_keyword = (target_keyword or "").strip()
+        normalized_target_keywords = self._split_keyword_lines(target_keyword)
         normalized_target_reply = (target_reply or "").strip()
         normalized_target_item_id = (target_item_id or "").strip() or None
 
-        if not normalized_target_keyword:
+        if not normalized_target_keywords:
             raise ValueError("关键词不能为空")
+
+        seen_keywords: set[str] = set()
+        for keyword in normalized_target_keywords:
+            keyword_key = keyword.lower()
+            if keyword_key in seen_keywords:
+                item_desc = f"商品ID: {normalized_target_item_id}" if normalized_target_item_id else "通用关键词"
+                raise ValueError(f"关键词 '{keyword}'（{item_desc}） 在当前提交中重复")
+            seen_keywords.add(keyword_key)
 
         if source_account.owner_id != target_account.owner_id:
             raise ValueError("所属账号只能修改为同一用户下的账号")
@@ -188,9 +202,9 @@ class KeywordService:
         conflict_stmt = select(XYKeywordRule).where(
             XYKeywordRule.owner_id == target_account.owner_id,
             XYKeywordRule.account_pk == target_account.id,
-            XYKeywordRule.keyword == normalized_target_keyword,
             XYKeywordRule.item_id == normalized_target_item_id,
             XYKeywordRule.id != existing_rule.id,
+            func.lower(XYKeywordRule.keyword).in_([keyword.lower() for keyword in normalized_target_keywords]),
         )
         conflict_result = await self.session.execute(conflict_stmt)
         conflict_rule = conflict_result.scalars().first()
@@ -199,16 +213,33 @@ class KeywordService:
             item_desc = f"商品ID: {normalized_target_item_id}" if normalized_target_item_id else "通用关键词"
             conflict_type = (conflict_rule.reply_type or "text").lower()
             if conflict_type == "image":
-                raise ValueError(f"关键词 '{normalized_target_keyword}'（{item_desc}） 已存在（图片关键词），无法保存为文本关键词")
-            raise ValueError(f"关键词 '{normalized_target_keyword}'（{item_desc}） 已存在")
+                raise ValueError(f"关键词 '{conflict_rule.keyword}'（{item_desc}） 已存在（图片关键词），无法保存为文本关键词")
+            raise ValueError(f"关键词 '{conflict_rule.keyword}'（{item_desc}） 已存在")
 
+        timestamp = datetime.now(timezone.utc)
         existing_rule.owner_id = target_account.owner_id
         existing_rule.account_pk = target_account.id
-        existing_rule.keyword = normalized_target_keyword
+        existing_rule.keyword = normalized_target_keywords[0]
         existing_rule.reply_content = normalized_target_reply
         existing_rule.reply_type = "TEXT"
         existing_rule.item_id = normalized_target_item_id
-        existing_rule.updated_at = datetime.now(timezone.utc)
+        existing_rule.updated_at = timestamp
+
+        for keyword in normalized_target_keywords[1:]:
+            self.session.add(
+                XYKeywordRule(
+                    owner_id=target_account.owner_id,
+                    account_pk=target_account.id,
+                    keyword=keyword,
+                    reply_content=normalized_target_reply,
+                    reply_type="TEXT",
+                    item_id=normalized_target_item_id,
+                    priority=existing_rule.priority or 100,
+                    is_active=existing_rule.is_active if existing_rule.is_active is not None else True,
+                    created_at=timestamp,
+                    updated_at=timestamp,
+                )
+            )
 
         await self.session.commit()
 

--- a/common/services/card_delivery_content.py
+++ b/common/services/card_delivery_content.py
@@ -29,6 +29,7 @@ from common.services.delivery_utils import (
     recursive_replace_params,
     replace_order_context_variables,
 )
+from common.utils.response_field import extract_card_api_response_content
 
 # API 取卡最大重试次数
 _API_MAX_RETRIES = 4
@@ -104,6 +105,7 @@ async def get_api_card_content(
         timeout = api_config.get('timeout', _API_DEFAULT_TIMEOUT)
         headers = api_config.get('headers', '{}')
         params = api_config.get('params', '{}')
+        response_field = api_config.get('response_field') or api_config.get('responseField')
 
         if isinstance(headers, str):
             headers = json.loads(headers)
@@ -135,14 +137,7 @@ async def get_api_card_content(
                 return None
 
         if status_code == 200:
-            try:
-                result = json.loads(response_text)
-                if isinstance(result, dict):
-                    content = result.get('data') or result.get('content') or result.get('card') or str(result)
-                else:
-                    content = str(result)
-            except Exception:
-                content = response_text
+            content = extract_card_api_response_content(response_text, response_field)
             logger.info(f"API调用成功，返回内容长度: {len(content)}")
             return content
 

--- a/common/utils/response_field.py
+++ b/common/utils/response_field.py
@@ -1,0 +1,112 @@
+"""API 响应字段取值工具"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+RESPONSE_FIELD_EMPTY_MESSAGE = "响应字段取值失败为空"
+_MISSING = object()
+
+
+def extract_card_api_response_content(response_text: str, response_field: str | None = None) -> str:
+    """从卡券 API 响应里提取发货内容，集中处理旧逻辑和新响应字段路径。"""
+    normalized_field = (response_field or "").strip()
+    if normalized_field:
+        try:
+            response_data = json.loads(response_text)
+        except Exception:
+            return RESPONSE_FIELD_EMPTY_MESSAGE
+
+        value = get_response_field_value(response_data, normalized_field)
+        return stringify_response_value(value)
+
+    try:
+        response_data = json.loads(response_text)
+        if isinstance(response_data, dict):
+            value = response_data.get("data") or response_data.get("content") or response_data.get("card") or response_data
+            return stringify_response_value(value)
+        return stringify_response_value(response_data)
+    except Exception:
+        return response_text
+
+
+def get_response_field_value(data: Any, field_path: str) -> Any:
+    """按类 lodash get 的路径读取响应值，支持 data.cards[0].key 这类常见写法。"""
+    current = data
+    tokens = parse_response_field_path(field_path)
+    if not tokens:
+        return _MISSING
+
+    for token in tokens:
+        if isinstance(token, int):
+            if not isinstance(current, list) or token < 0 or token >= len(current):
+                return _MISSING
+            current = current[token]
+            continue
+
+        if not isinstance(current, dict) or token not in current:
+            return _MISSING
+        current = current[token]
+
+    return current
+
+
+def parse_response_field_path(field_path: str) -> list[str | int]:
+    """把点号和数组下标路径拆成令牌，避免在业务代码里重复解析字符串。"""
+    tokens: list[str | int] = []
+    buffer = ""
+    index = 0
+
+    while index < len(field_path):
+        char = field_path[index]
+        if char == ".":
+            if buffer:
+                tokens.append(buffer)
+                buffer = ""
+            index += 1
+            continue
+
+        if char == "[":
+            if buffer:
+                tokens.append(buffer)
+                buffer = ""
+
+            end_index = field_path.find("]", index)
+            if end_index == -1:
+                return []
+
+            raw_index = field_path[index + 1:end_index].strip()
+            if raw_index.isdigit():
+                tokens.append(int(raw_index))
+            else:
+                tokens.append(raw_index.strip("\"'"))
+            index = end_index + 1
+            continue
+
+        buffer += char
+        index += 1
+
+    if buffer:
+        tokens.append(buffer)
+
+    return tokens
+
+
+def stringify_response_value(value: Any) -> str:
+    """把取到的响应值转成最终发货文本，缺失或空字符串按约定返回提示。"""
+    if value is _MISSING or value is None:
+        return RESPONSE_FIELD_EMPTY_MESSAGE
+
+    if isinstance(value, str):
+        if not value.strip():
+            return RESPONSE_FIELD_EMPTY_MESSAGE
+        return value
+
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+
+    if isinstance(value, bool):
+        return json.dumps(value, ensure_ascii=False)
+
+    return str(value)

--- a/frontend/src/api/cards.ts
+++ b/frontend/src/api/cards.ts
@@ -27,6 +27,7 @@ export interface CardData {
     timeout?: number
     headers?: string
     params?: string
+    response_field?: string
   }
   text_content?: string
   data_content?: string

--- a/frontend/src/pages/cards/CardDetailModal.tsx
+++ b/frontend/src/pages/cards/CardDetailModal.tsx
@@ -107,6 +107,9 @@ export function CardDetailModal({ card, onClose, zIndex = 60 }: CardDetailModalP
               {card.api_config.params && (
                 <DetailRow label="请求参数" value={card.api_config.params} multiline />
               )}
+              {card.api_config.response_field && (
+                <DetailRow label="响应取值字段" value={card.api_config.response_field} />
+              )}
             </div>
           )}
 

--- a/frontend/src/pages/cards/CardFormModal.tsx
+++ b/frontend/src/pages/cards/CardFormModal.tsx
@@ -48,6 +48,7 @@ interface CardFormData {
   apiTimeout: number
   apiHeaders: string
   apiParams: string
+  apiResponseField: string
   textContent: string
   dataContent: string
   imageUrls: string[]
@@ -90,6 +91,7 @@ export function cardToFormData(card: CardData): CardFormData {
     apiTimeout: card.api_config?.timeout || 60,
     apiHeaders: card.api_config?.headers || '',
     apiParams: card.api_config?.params || '',
+    apiResponseField: card.api_config?.response_field || '',
     textContent: card.text_content || '',
     dataContent: card.data_content || '',
     imageUrls: imageUrlsList,
@@ -122,6 +124,7 @@ export const emptyCardFormData: CardFormData = {
   apiTimeout: 60,
   apiHeaders: '',
   apiParams: '',
+  apiResponseField: '',
   textContent: '',
   dataContent: '',
   imageUrls: [],
@@ -293,6 +296,7 @@ export function CardFormModal({ cardId, initialData, onClose, onSaved }: CardFor
           timeout: formData.apiTimeout,
           headers: formData.apiHeaders.trim() || undefined,
           params: formData.apiParams.trim() || undefined,
+          response_field: formData.apiResponseField.trim() || undefined,
         }
       } else if (formData.type === 'text') {
         cardData.text_content = formData.textContent.trim()
@@ -423,6 +427,19 @@ export function CardFormModal({ cardId, initialData, onClose, onSaved }: CardFor
                       </div>
                     </div>
                   )}
+                </div>
+                <div>
+                  <label className="input-label">响应取值字段</label>
+                  <input
+                    type="text"
+                    value={formData.apiResponseField}
+                    onChange={(e) => updateField('apiResponseField', e.target.value)}
+                    className="input-ios"
+                    placeholder="data.cards[0].key"
+                  />
+                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                    留空时按旧逻辑取 data、content 或 card；填写后按路径从接口响应里取值
+                  </p>
                 </div>
               </div>
             )}

--- a/frontend/src/pages/keywords/Keywords.tsx
+++ b/frontend/src/pages/keywords/Keywords.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import type { FormEvent, ChangeEvent } from 'react'
 import { motion } from 'framer-motion'
 import { MessageSquare, RefreshCw, Plus, Edit2, Trash2, Upload, Download, Info, Image, CheckSquare, Square, Search, ChevronLeft, ChevronRight } from 'lucide-react'
-import { getKeywords, deleteKeyword, addKeyword, updateKeyword, exportKeywords, importKeywords as importKeywordsApi, addImageKeyword } from '@/api/keywords'
+import { getKeywords, deleteKeyword, saveKeywords, updateKeyword, exportKeywords, importKeywords as importKeywordsApi, addImageKeyword } from '@/api/keywords'
 import { getAccountDetails } from '@/api/accounts'
 import { getItems } from '@/api/items'
 import { useUIStore } from '@/store/uiStore'
@@ -11,6 +11,26 @@ import { useAuthStore } from '@/store/authStore'
 import { Select } from '@/components/common/Select'
 import { ConfirmModal } from '@/components/common/ConfirmModal'
 import type { Keyword, Account, Item } from '@/types'
+
+/** 解析关键词文本域，按行保存是为了兼容旧表结构的一条关键词一条规则。 */
+const parseKeywordLines = (value: string) => value.split(/\r?\n/).map(line => line.trim()).filter(Boolean)
+
+/** 查找同一次提交里的重复关键词，提前拦截可以避免整体保存后部分数据不可预期。 */
+const findDuplicateKeywordLine = (keywordLines: string[]) => {
+  const seen = new Set<string>()
+  for (const keyword of keywordLines) {
+    const key = keyword.toLowerCase()
+    if (seen.has(key)) {
+      return keyword
+    }
+    seen.add(key)
+  }
+  return ''
+}
+
+/** 生成关键词唯一键，前端校验要和后端同一商品下唯一的规则保持一致。 */
+const buildKeywordRuleKey = (keyword: string, itemId?: string) =>
+  `${keyword.trim().toLowerCase()}__${(itemId || '').trim().toLowerCase()}`
 
 export function Keywords() {
   const { addToast } = useUIStore()
@@ -193,14 +213,21 @@ export function Keywords() {
     e.preventDefault()
 
     const submitAccountId = editingKeyword ? formAccountId : selectedAccount
+    const keywordLines = parseKeywordLines(keywordText)
+    const duplicateKeyword = findDuplicateKeywordLine(keywordLines)
 
     if (!submitAccountId) {
       addToast({ type: 'warning', message: '请先选择账号' })
       return
     }
 
-    if (!keywordText.trim()) {
+    if (keywordLines.length === 0) {
       addToast({ type: 'warning', message: '请输入关键词' })
+      return
+    }
+
+    if (duplicateKeyword) {
+      addToast({ type: 'warning', message: `关键词"${duplicateKeyword}"重复，请检查后再保存` })
       return
     }
 
@@ -218,14 +245,14 @@ export function Keywords() {
           addToast({ type: 'error', message: '未找到原所属账号，无法保存' })
           return
         }
-        // 编辑模式：单个更新
+        // 编辑模式：后端会把多行关键词替换成多条同回复规则，避免前端多次请求造成部分成功。
         const result = await updateKeyword(
           sourceAccountId,
           editingKeyword.keyword,
           editingKeyword.item_id || '',
           {
             account_id: submitAccountId,
-            keyword: keywordText.trim(),
+            keyword: keywordLines.join('\n'),
             reply: replyText.trim(),
             item_id: itemIdText.trim(),
           }
@@ -236,36 +263,33 @@ export function Keywords() {
         }
         addToast({ type: 'success', message: '关键词已更新' })
       } else {
-        // 新增模式：支持多选商品
+        // 新增模式：先在前端展开关键词和商品的组合，再复用整体保存接口保持原有后端兼容。
         const itemIdsToAdd = selectedItemIds.length > 0 ? selectedItemIds : ['']
-        let successCount = 0
-        let failCount = 0
+        const existingKeywords = await getKeywords(submitAccountId)
+        const existingKeys = new Set(existingKeywords.map(k => buildKeywordRuleKey(k.keyword, k.item_id)))
+        const newKeywords = itemIdsToAdd.flatMap(itemId =>
+          keywordLines.map(keyword => ({
+            keyword,
+            reply: replyText.trim(),
+            item_id: itemId,
+            type: 'text' as const,
+          } as Keyword))
+        )
+        const conflictKeyword = newKeywords.find(k => existingKeys.has(buildKeywordRuleKey(k.keyword, k.item_id)))
 
-        for (const itemId of itemIdsToAdd) {
-          try {
-            const result = await addKeyword(submitAccountId, {
-              keyword: keywordText.trim(),
-              reply: replyText.trim(),
-              item_id: itemId,
-            })
-            if (result.success === false) {
-              failCount++
-            } else {
-              successCount++
-            }
-          } catch {
-            failCount++
-          }
-        }
-
-        if (failCount === 0) {
-          addToast({ type: 'success', message: `成功添加 ${successCount} 条关键词` })
-        } else if (successCount > 0) {
-          addToast({ type: 'warning', message: `添加 ${successCount} 条成功，${failCount} 条失败` })
-        } else {
-          addToast({ type: 'error', message: '添加失败' })
+        if (conflictKeyword) {
+          const itemDesc = conflictKeyword.item_id ? `商品ID：${conflictKeyword.item_id}` : '通用关键词'
+          addToast({ type: 'error', message: `关键词"${conflictKeyword.keyword}"（${itemDesc}）已存在` })
           return
         }
+
+        const result = await saveKeywords(submitAccountId, [...existingKeywords, ...newKeywords])
+        if (result.success === false) {
+          addToast({ type: 'error', message: result.message || '添加失败' })
+          return
+        }
+
+        addToast({ type: 'success', message: `成功添加 ${newKeywords.length} 条关键词` })
       }
 
       await loadKeywords()
@@ -862,13 +886,15 @@ export function Keywords() {
                 </div>
                 <div>
                   <label className="input-label">关键词</label>
-                  <input
-                    type="text"
+                  <textarea
                     value={keywordText}
                     onChange={(e) => setKeywordText(e.target.value)}
-                    className="input-ios"
-                    placeholder="请输入关键词"
+                    className="input-ios h-24 resize-none"
+                    placeholder="请输入关键词，一行一个"
                   />
+                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                    一行一个关键词，多个关键词会对应同一条回复内容
+                  </p>
                 </div>
                 <div>
                   <label className="input-label">商品ID（可选）</label>

--- a/websocket/app/services/xianyu/auto_delivery_handler.py
+++ b/websocket/app/services/xianyu/auto_delivery_handler.py
@@ -23,6 +23,7 @@ from app.services.xianyu.delivery_utils import (
 )
 from app.services.xianyu.yifan_api_handler import YifanApiHandler
 from common.utils.fish_nick_utils import get_buyer_fish_nick
+from common.utils.response_field import extract_card_api_response_content
 
 
 class AutoDeliveryHandler:
@@ -2496,6 +2497,7 @@ class AutoDeliveryHandler:
             timeout = api_config.get('timeout', 10)
             headers = api_config.get('headers', '{}')
             params = api_config.get('params', '{}')
+            response_field = api_config.get('response_field') or api_config.get('responseField')
 
             # 解析headers和params
             if isinstance(headers, str):
@@ -2536,17 +2538,7 @@ class AutoDeliveryHandler:
                     return None
 
             if status_code == 200:
-                # 尝试解析JSON响应，如果失败则使用原始文本
-                try:
-                    result = json.loads(response_text)
-                    # 如果返回的是对象，尝试提取常见的内容字段
-                    if isinstance(result, dict):
-                        content = result.get('data') or result.get('content') or result.get('card') or str(result)
-                    else:
-                        content = str(result)
-                except Exception:
-                    content = response_text
-
+                content = extract_card_api_response_content(response_text, response_field)
                 logger.info(f"API调用成功，返回内容长度: {len(content)}")
                 return content
             else:


### PR DESCRIPTION
## 背景

这个需求在自动回复和自动发货场景里比较高频：

1. 自动回复里经常会有多个表达对应同一条回复，比如“多少钱 / 价格 / 怎么卖”都应该回复同一段内容。当前只能一条关键词配一条回复，配置量会快速膨胀，也不方便批量维护。
2. API 卡密场景里，用户通常已经有自己的后台接口能生成卡密，但不同系统返回字段不统一。现在系统默认只取 data/content/card，遇到 `data.cards[0].key` 这类结构时，就必须额外为自动发货再包一层接口，非常麻烦，也增加了维护成本。

## 改动

- 自动回复关键词添加/编辑改为文本域，一行一个关键词。
- 多个关键词会保存为多条旧结构规则，共用同一条回复内容，兼容现有数据和匹配逻辑。
- API 卡券配置新增“响应取值字段”，支持类似 lodash get 的路径格式，例如：`data.cards[0].key`。
- 响应字段为空时保持旧逻辑，仍按 `data/content/card` 取值。
- 响应字段取不到、为空或 JSON 解析失败时，返回固定提示：`响应字段取值失败为空`。
- 自动发货、提货公共服务、后台取卡内容入口统一复用同一套响应字段解析逻辑。

## 兼容性

- 不新增数据库字段。
- 不做迁移。
- 旧关键词、旧 API 卡券配置都可以继续按原逻辑使用。