### PR TITLE
fix: 卡券管理页面卡券关联商品弹窗组件商品列表无法滚动

### DIFF
--- a/frontend/src/pages/cards/CardItemRelationModal.tsx
+++ b/frontend/src/pages/cards/CardItemRelationModal.tsx
@@ -126,7 +126,7 @@ export function CardItemRelationModal({ cardId, cardName, onClose, onSaved, read
           <div className="modal-body flex-1 overflow-hidden p-0">
             <div className="grid grid-cols-2 gap-0 h-full" style={{ height: '60vh' }}>
               {/* 左侧：商品列表 */}
-              <div className="flex flex-col border-r border-gray-200 dark:border-gray-700">
+              <div className="flex flex-col overflow-hidden border-r border-gray-200 dark:border-gray-700">
                 <div className="flex-shrink-0 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
                   <div className="flex items-center justify-between mb-2">
                     <h3 className="font-medium text-gray-900 dark:text-white text-sm">待选商品</h3>
@@ -214,7 +214,7 @@ export function CardItemRelationModal({ cardId, cardName, onClose, onSaved, read
               </div>
 
               {/* 右侧：已选商品 */}
-              <div className="flex flex-col">
+              <div className="flex overflow-hidden flex-col">
                 <div className="flex-shrink-0 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-green-50 dark:bg-green-900/20">
                   <div className="flex items-center justify-between mb-2">
                     <h3 className="font-medium text-green-700 dark:text-green-400 text-sm">{readonly ? '已关联商品' : '已选商品'}</h3>


### PR DESCRIPTION
修复卡券管理页面卡券关联商品弹窗组件商品列表无法滚动的问题。

复现步骤：

1. 进入卡券管理页面
2. 点击随意卡券的关联商品功能

<img width="1239" height="786" alt="1" src="https://github.com/user-attachments/assets/e75ae669-b2bf-4ea6-ba81-9d082f2323e4" />

修复后：

<img width="1231" height="819" alt="2" src="https://github.com/user-attachments/assets/b507fba0-d4cd-4ce1-8829-fa14de8018cc" />
