### PR TITLE
fix: 修复删除账户后商品无法删除的问题

### DIFF
--- a/backend-web/app/api/routes/items.py
+++ b/backend-web/app/api/routes/items.py
@@ -719,8 +719,10 @@ async def delete_item_unified(
     owner_id, _ = resolve_owner_scope(current_user)
 
     account = None
-    if payload.cookie_id:
-        account = await account_service.get_account_for_user(owner_id, payload.cookie_id)
+    # 将 "null"、空字符串等无效值统一视为未传入 cookie_id
+    cookie_id = payload.cookie_id
+    if cookie_id and cookie_id.lower() not in ("null", ""):
+        account = await account_service.get_account_for_user(owner_id, cookie_id)
         if not account:
             return ApiResponse(success=False, message="账号不存在")
 
@@ -766,18 +768,21 @@ async def batch_delete_items(
     accounts = await account_service.list_accounts(owner_id)
     account_map = {account.account_id: account for account in accounts}
     removed = 0
-    not_found_accounts = []
     not_found_items = []
     for entry in payload.items:
-        account = account_map.get(entry.cookie_id)
-        if not account:
-            not_found_accounts.append(entry.cookie_id)
-            continue
-        if await item_service.delete_item(account, entry.item_id):
+        # 将 "null"、空字符串等无效 cookie_id 视为未指定账号（孤儿商品场景）
+        cookie_id = entry.cookie_id
+        account = None
+        if cookie_id and cookie_id.lower() not in ("null", ""):
+            account = account_map.get(cookie_id)
+
+        # 使用 delete_item_smart 统一处理，兼容孤儿商品
+        result = await item_service.delete_item_smart(owner_id, entry.item_id, account)
+        if result == "ok":
             removed += 1
         else:
             not_found_items.append(entry.item_id)
-    logger.info(f"批量删除商品: 请求={len(payload.items)}, 成功={removed}, 账号未找到={not_found_accounts}, 商品未找到={not_found_items}")
+    logger.info(f"批量删除商品: 请求={len(payload.items)}, 成功={removed}, 商品未找到={not_found_items}")
     if removed == 0 and len(payload.items) > 0:
         return ApiResponse(success=False, message=f"未能删除任何商品（共 {len(payload.items)} 个），请检查商品是否存在")
     return ApiResponse(success=True, message=f"已删除 {removed} 个商品")


### PR DESCRIPTION
## 问题描述

删除账户后，商品管理无法删除商品，提示删除失败。

## 问题根因

当账户删除后，商品的 `cookie_id` 变成字符串 `"null"`，而后端代码 `if payload.cookie_id:` 会将非空字符串视为有效值，尝试查找不存在的账号，导致返回 "账号不存在" 错误。

## 修复方案

1. **后端修复** (`items.py`):
   - 将 `"null"`、空字符串等无效值统一视为未传入 `cookie_id`
   - 进入孤儿商品处理逻辑

2. **批量删除修复** (`items.py`):
   - 批量删除接口也支持删除孤儿商品
   - 使用 `delete_item_smart` 方法统一处理

3. **新增 `delete_item_smart` 方法** (`item_service.py`):
   - 支持删除孤儿商品（账号已删除的商品）
   - 自动检测账号是否存在，如果不存在则直接按商品 ID 删除

## 测试

已在本地服务器上测试通过，删除账户后的商品可以正常删除。

Fixes #219