### PR TITLE
增强默认回复 API payload 的消息上下文

### DIFF
--- a/common/utils/default_reply_api.py
+++ b/common/utils/default_reply_api.py
@@ -145,16 +145,27 @@ async def call_reply_api(
     message: str,
     api_url: str,
     timeout: Optional[int] = DEFAULT_API_TIMEOUT,
+    chat_id: Optional[str] = None,
+    item_id: Optional[str] = None,
+    send_user_id: Optional[str] = None,
+    send_user_name: Optional[str] = None,
+    msg_time: Optional[str] = None,
 ) -> Optional[str]:
     """调用外部 API 获取默认回复内容。
 
-    POST 请求体: ``{"account_id": "...", "message": "..."}``
+    默认 POST 请求体: ``{"account_id": "...", "message": "..."}``
+    如果传入上下文字段，则额外透传，便于外部系统按会话、商品和买家管理状态。
 
     Args:
         account_id: 闲鱼账号标识
         message: 买家发来的消息内容
         api_url: 外部 API 地址
         timeout: 请求超时时间（秒）
+        chat_id: 会话ID
+        item_id: 商品ID
+        send_user_id: 买家ID
+        send_user_name: 买家昵称
+        msg_time: 消息时间
 
     Returns:
         外部 API 返回的回复文本；失败/超时/无内容时返回 None
@@ -166,6 +177,14 @@ async def call_reply_api(
 
     timeout_seconds = normalize_api_timeout(timeout)
     payload = {"account_id": account_id, "message": message}
+    context_payload = {
+        "chat_id": chat_id,
+        "item_id": item_id,
+        "send_user_id": send_user_id,
+        "send_user_name": send_user_name,
+        "msg_time": msg_time,
+    }
+    payload.update({key: value for key, value in context_payload.items() if value is not None})
 
     try:
         client_timeout = aiohttp.ClientTimeout(total=timeout_seconds)

--- a/websocket/app/services/xianyu/auto_reply_service.py
+++ b/websocket/app/services/xianyu/auto_reply_service.py
@@ -682,6 +682,7 @@ class AutoReplyService:
                     send_message=send_message,
                     chat_id=chat_id,
                     item_id=item_id,
+                    msg_time=msg_time,
                 )
                 
                 if reply:
@@ -1050,6 +1051,7 @@ class AutoReplyService:
         send_message: str,
         chat_id: str,
         item_id: Optional[str] = None,
+        msg_time: str = "",
     ) -> Optional[str]:
         """获取自动回复(主入口)
         
@@ -1061,6 +1063,7 @@ class AutoReplyService:
             send_message: 发送的消息内容
             chat_id: 会话ID
             item_id: 商品ID(可选)
+            msg_time: 消息时间
             
         Returns:
             回复内容,None表示不回复
@@ -1095,7 +1098,7 @@ class AutoReplyService:
                     return ai_reply
                 
                 default_reply = await self.get_default_reply(
-                    session, send_user_name, send_user_id, send_message, chat_id, item_id
+                    session, send_user_name, send_user_id, send_message, chat_id, item_id, msg_time
                 )
                 if default_reply:
                     if default_reply == "EMPTY_REPLY":
@@ -1367,6 +1370,10 @@ class AutoReplyService:
         settings: dict,
         settings_item_id: Optional[str],
         chat_id: str,
+        send_user_id: str,
+        send_user_name: str,
+        item_id: Optional[str],
+        msg_time: str,
         reply_trace: Optional[dict],
     ) -> Optional[str]:
         """调用外部 API 获取默认回复内容并处理结果。
@@ -1380,6 +1387,11 @@ class AutoReplyService:
             message=send_message,
             api_url=api_url,
             timeout=api_timeout,
+            chat_id=chat_id,
+            item_id=item_id or "",
+            send_user_id=send_user_id,
+            send_user_name=send_user_name,
+            msg_time=msg_time,
         )
 
         # 失败/无有效内容：不回复（不记录 reply_once，便于下次重试）
@@ -1412,6 +1424,7 @@ class AutoReplyService:
         send_message: str,
         chat_id: str,
         item_id: Optional[str] = None,
+        msg_time: str = "",
     ) -> Optional[str]:
         """获取默认回复
         
@@ -1427,6 +1440,7 @@ class AutoReplyService:
             send_message: 发送的消息内容
             chat_id: 会话ID
             item_id: 商品ID(可选)
+            msg_time: 消息时间
             
         Returns:
             回复内容,None表示不回复,"EMPTY_REPLY"表示回复为空
@@ -1479,6 +1493,10 @@ class AutoReplyService:
                         settings=settings,
                         settings_item_id=settings_item_id,
                         chat_id=chat_id,
+                        send_user_id=send_user_id,
+                        send_user_name=send_user_name,
+                        item_id=item_id,
+                        msg_time=msg_time,
                         reply_trace=reply_trace,
                     )
 
@@ -1515,6 +1533,10 @@ class AutoReplyService:
                                 settings=settings,
                                 settings_item_id=settings_item_id,
                                 chat_id=chat_id,
+                                send_user_id=send_user_id,
+                                send_user_name=send_user_name,
+                                item_id=item_id,
+                                msg_time=msg_time,
                                 reply_trace=reply_trace,
                             )
                         # 持锁后重新核对 reply_once：前一条同会话消息可能刚已回复并记录
@@ -1538,6 +1560,10 @@ class AutoReplyService:
                             settings=settings,
                             settings_item_id=settings_item_id,
                             chat_id=chat_id,
+                            send_user_id=send_user_id,
+                            send_user_name=send_user_name,
+                            item_id=item_id,
+                            msg_time=msg_time,
                             reply_trace=reply_trace,
                         )
                 except Exception as lock_exc:
@@ -1553,6 +1579,10 @@ class AutoReplyService:
                         settings=settings,
                         settings_item_id=settings_item_id,
                         chat_id=chat_id,
+                        send_user_id=send_user_id,
+                        send_user_name=send_user_name,
+                        item_id=item_id,
+                        msg_time=msg_time,
                         reply_trace=reply_trace,
                     )
 


### PR DESCRIPTION
## 背景

当前默认回复 API 会把买家消息 POST 到外部接口，但 request payload 只有 `account_id` 和 `message`。这对简单接口足够，但外部客服系统、CRM、自动回复服务如果需要按会话管理上下文、按商品区分回复或做买家级处理，会缺少必要信息。

本 PR 在保持向后兼容的前提下，为默认回复 API payload 增加通用消息上下文字段。

## 改动内容

- 默认回复 API request payload 新增以下可选字段：
  - `chat_id`
  - `item_id`
  - `send_user_id`
  - `send_user_name`
  - `msg_time`
- 保留原有 `account_id` 和 `message` 字段。
- 保持默认回复 API 响应解析逻辑不变，仍支持：
  - 纯文本响应
  - JSON 响应中的 `reply`
  - JSON 响应中的 `data`
  - JSON 响应中的 `content`
  - JSON 响应中的 `message`

## 兼容性

这个改动对现有外部接口是向后兼容的。

如果外部服务只读取 `account_id` 和 `message`，可以直接忽略新增 JSON 字段，不需要改造。

## 安全性

本 PR 不放宽默认回复 API 的 URL 安全校验：

- 仍然只允许 `http` / `https`
- 仍然拒绝内网、回环、链路本地、保留、多播和未指定地址
- 仍然拒绝跟随 HTTP 30x 重定向

也没有改变默认回复 API 的响应协议。

## 验证

已在本地执行：

```text
python -m py_compile common/utils/default_reply_api.py websocket/app/services/xianyu/auto_reply_service.py
git diff --check
```

另外使用本地临时脚本验证了：

- 完整上下文 payload 会包含 `chat_id`、`item_id`、`send_user_id`、`send_user_name`、`msg_time`
- 未传上下文字段时仍保持旧 payload：`account_id` + `message`
- URL 安全校验失败时不会发起请求
- HTTP 30x 重定向仍会被拒绝
- loopback 地址仍会被拒绝
