### PR TITLE
feat: 支持多关键词规则合并展示

### DIFF
--- a/backend-web/app/api/routes/keywords.py
+++ b/backend-web/app/api/routes/keywords.py
@@ -311,6 +311,7 @@ async def delete_single_keyword(
     account_id: str,
     keyword: str,
     item_id: str = "",
+    rule_id: int | None = None,
     current_user: User = Depends(deps.get_current_active_user),
     account_service: AccountService = Depends(deps.get_account_service),
     keyword_service: KeywordService = Depends(deps.get_keyword_service),
@@ -323,7 +324,7 @@ async def delete_single_keyword(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="账号不存在")
     
     try:
-        deleted = await keyword_service.delete_keyword(account, keyword, item_id or None)
+        deleted = await keyword_service.delete_keyword(account, keyword, item_id or None, rule_id=rule_id)
         if not deleted:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="关键词不存在")
         return ApiResponse(success=True, message="关键词删除成功")

--- a/backend-web/app/services/keyword_service.py
+++ b/backend-web/app/services/keyword_service.py
@@ -27,6 +27,17 @@ class KeywordService:
     def __init__(self, session: AsyncSession):
         self.session = session
 
+    @staticmethod
+    def _split_keyword_lines(keyword_text: str) -> list[str]:
+        """拆分多行关键词，因为一条规则可以承载多个同回复关键词。"""
+        return [line.strip() for line in (keyword_text or "").splitlines() if line.strip()]
+
+    @staticmethod
+    def _keyword_line_keys(keyword_text: str, item_id: str | None) -> set[tuple[str, str]]:
+        """生成多行关键词的唯一键，避免不同规则里隐藏重复关键词。"""
+        item_key = (item_id or "").lower()
+        return {(line.lower(), item_key) for line in KeywordService._split_keyword_lines(keyword_text)}
+
     async def list_keywords_for_owner(self, owner_id: int | None = None) -> list[dict]:
         stmt = (
             select(XYKeywordRule, XYCatalogItem.title, XYAccount.account_id)
@@ -47,6 +58,7 @@ class KeywordService:
             rule_type = (rule.reply_type or "text").lower()
             keywords.append(
                 {
+                    "id": str(rule.id),
                     "keyword": rule.keyword,
                     "reply": rule.reply_content or "",
                     "item_id": rule.item_id or "",
@@ -78,6 +90,7 @@ class KeywordService:
             rule_type = (rule.reply_type or "text").lower()
             keywords.append(
                 {
+                    "id": str(rule.id),
                     "keyword": rule.keyword,
                     "reply": rule.reply_content or "",
                     "item_id": rule.item_id or "",
@@ -96,15 +109,17 @@ class KeywordService:
             keyword = (entry.get("keyword") or "").strip()
             reply = (entry.get("reply") or "").strip()
             item_id = (entry.get("item_id") or "").strip() or None
-            if not keyword:
+            keyword_lines = self._split_keyword_lines(keyword)
+            if not keyword_lines:
                 raise ValueError("关键词不能为空")
 
-            key = (keyword.lower(), (item_id or "").lower())
-            if key in seen:
-                if item_id:
-                    raise ValueError(f"关键词 '{keyword}'（商品ID: {item_id}） 在当前提交中重复")
-                raise ValueError(f"关键词 '{keyword}'（通用关键词） 在当前提交中重复")
-            seen.add(key)
+            for keyword_line in keyword_lines:
+                key = (keyword_line.lower(), (item_id or "").lower())
+                if key in seen:
+                    if item_id:
+                        raise ValueError(f"关键词 '{keyword_line}'（商品ID: {item_id}） 在当前提交中重复")
+                    raise ValueError(f"关键词 '{keyword_line}'（通用关键词） 在当前提交中重复")
+                seen.add(key)
             normalized_entries.append((keyword, reply, item_id))
 
         # Check for conflicts with image keywords
@@ -115,12 +130,16 @@ class KeywordService:
                 func.lower(XYKeywordRule.reply_type) == "image",
             )
         )
-        image_conflicts = {(row[0], (row[1] or "")) for row in image_rows.all()}
+        image_conflicts: set[tuple[str, str]] = set()
+        for image_keyword, image_item_id in image_rows.all():
+            image_conflicts.update(self._keyword_line_keys(image_keyword, image_item_id))
+
         for keyword, _, item_id in normalized_entries:
-            comparison_key = (keyword, item_id or "")
-            if comparison_key in image_conflicts:
-                item_desc = f"商品ID: {item_id}" if item_id else "通用关键词"
-                raise ValueError(f"关键词 '{keyword}'（{item_desc}） 已存在（图片关键词），无法保存为文本关键词")
+            for keyword_line in self._split_keyword_lines(keyword):
+                comparison_key = (keyword_line.lower(), (item_id or "").lower())
+                if comparison_key in image_conflicts:
+                    item_desc = f"商品ID: {item_id}" if item_id else "通用关键词"
+                    raise ValueError(f"关键词 '{keyword_line}'（{item_desc}） 已存在（图片关键词），无法保存为文本关键词")
 
         # Remove legacy text keywords and insert new ones
         await self.session.execute(
@@ -150,11 +169,6 @@ class KeywordService:
 
         await self.session.commit()
 
-    @staticmethod
-    def _split_keyword_lines(keyword_text: str) -> list[str]:
-        """按行拆分关键词文本，前端多关键词输入仍然落到旧的一条规则一行结构。"""
-        return [line.strip() for line in (keyword_text or "").splitlines() if line.strip()]
-
     async def update_text_keyword(
         self,
         source_account: XYAccount,
@@ -165,10 +179,11 @@ class KeywordService:
         target_reply: str | None,
         target_item_id: str | None,
     ) -> None:
-        """更新文本关键词，允许把一个旧规则替换成多条同回复规则。"""
+        """更新文本关键词，多行关键词仍保存在同一条规则里便于维护。"""
         normalized_source_keyword = (source_keyword or "").strip()
         normalized_source_item_id = (source_item_id or "").strip() or None
         normalized_target_keywords = self._split_keyword_lines(target_keyword)
+        normalized_target_keyword = "\n".join(normalized_target_keywords)
         normalized_target_reply = (target_reply or "").strip()
         normalized_target_item_id = (target_item_id or "").strip() or None
 
@@ -204,42 +219,35 @@ class KeywordService:
             XYKeywordRule.account_pk == target_account.id,
             XYKeywordRule.item_id == normalized_target_item_id,
             XYKeywordRule.id != existing_rule.id,
-            func.lower(XYKeywordRule.keyword).in_([keyword.lower() for keyword in normalized_target_keywords]),
         )
         conflict_result = await self.session.execute(conflict_stmt)
-        conflict_rule = conflict_result.scalars().first()
+        target_keys = {keyword.lower() for keyword in normalized_target_keywords}
+        conflict_rule = None
+        conflict_keyword = ""
+        for rule in conflict_result.scalars().all():
+            for keyword_line in self._split_keyword_lines(rule.keyword):
+                if keyword_line.lower() in target_keys:
+                    conflict_rule = rule
+                    conflict_keyword = keyword_line
+                    break
+            if conflict_rule:
+                break
 
         if conflict_rule:
             item_desc = f"商品ID: {normalized_target_item_id}" if normalized_target_item_id else "通用关键词"
             conflict_type = (conflict_rule.reply_type or "text").lower()
             if conflict_type == "image":
-                raise ValueError(f"关键词 '{conflict_rule.keyword}'（{item_desc}） 已存在（图片关键词），无法保存为文本关键词")
-            raise ValueError(f"关键词 '{conflict_rule.keyword}'（{item_desc}） 已存在")
+                raise ValueError(f"关键词 '{conflict_keyword}'（{item_desc}） 已存在（图片关键词），无法保存为文本关键词")
+            raise ValueError(f"关键词 '{conflict_keyword}'（{item_desc}） 已存在")
 
         timestamp = datetime.now(timezone.utc)
         existing_rule.owner_id = target_account.owner_id
         existing_rule.account_pk = target_account.id
-        existing_rule.keyword = normalized_target_keywords[0]
+        existing_rule.keyword = normalized_target_keyword
         existing_rule.reply_content = normalized_target_reply
         existing_rule.reply_type = "TEXT"
         existing_rule.item_id = normalized_target_item_id
         existing_rule.updated_at = timestamp
-
-        for keyword in normalized_target_keywords[1:]:
-            self.session.add(
-                XYKeywordRule(
-                    owner_id=target_account.owner_id,
-                    account_pk=target_account.id,
-                    keyword=keyword,
-                    reply_content=normalized_target_reply,
-                    reply_type="TEXT",
-                    item_id=normalized_target_item_id,
-                    priority=existing_rule.priority or 100,
-                    is_active=existing_rule.is_active if existing_rule.is_active is not None else True,
-                    created_at=timestamp,
-                    updated_at=timestamp,
-                )
-            )
 
         await self.session.commit()
 
@@ -248,6 +256,7 @@ class KeywordService:
         account: XYAccount,
         keyword: str,
         item_id: str | None = None,
+        rule_id: int | None = None,
     ) -> bool:
         """删除单个关键词（支持文本和图片类型）
         
@@ -255,6 +264,7 @@ class KeywordService:
             account: 账号对象
             keyword: 关键词
             item_id: 商品ID（可选）
+            rule_id: 关键词规则ID（可选，多行关键词优先用它精确删除）
             
         Returns:
             是否删除成功
@@ -262,9 +272,14 @@ class KeywordService:
         stmt = delete(XYKeywordRule).where(
             XYKeywordRule.owner_id == account.owner_id,
             XYKeywordRule.account_pk == account.id,
-            XYKeywordRule.keyword == keyword,
-            XYKeywordRule.item_id == (item_id if item_id else None),
         )
+        if rule_id is not None:
+            stmt = stmt.where(XYKeywordRule.id == rule_id)
+        else:
+            stmt = stmt.where(
+                XYKeywordRule.keyword == keyword,
+                XYKeywordRule.item_id == (item_id if item_id else None),
+            )
         result = await self.session.execute(stmt)
         await self.session.commit()
         return result.rowcount > 0

--- a/common/schemas/keyword.py
+++ b/common/schemas/keyword.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 
 
 class KeywordDetail(BaseModel):
+    id: str | None = None
     keyword: str
     reply: str
     item_id: str | None = Field(default=None)

--- a/frontend/src/api/keywords.ts
+++ b/frontend/src/api/keywords.ts
@@ -71,12 +71,16 @@ export const updateKeyword = async (
 export const deleteKeyword = async (
   cookieId: string, 
   keyword: string, 
-  itemId: string
+  itemId: string,
+  ruleId?: string
 ): Promise<ApiResponse> => {
   // 使用新的删除API，支持删除文本和图片类型的关键词
   const params = new URLSearchParams()
   if (itemId) {
     params.append('item_id', itemId)
+  }
+  if (ruleId) {
+    params.append('rule_id', ruleId)
   }
   const url = `${KEYWORD_PREFIX}/${cookieId}/${encodeURIComponent(keyword)}${params.toString() ? '?' + params.toString() : ''}`
   

--- a/frontend/src/pages/keywords/Keywords.tsx
+++ b/frontend/src/pages/keywords/Keywords.tsx
@@ -15,6 +15,9 @@ import type { Keyword, Account, Item } from '@/types'
 /** 解析关键词文本域，按行保存是为了兼容旧表结构的一条关键词一条规则。 */
 const parseKeywordLines = (value: string) => value.split(/\r?\n/).map(line => line.trim()).filter(Boolean)
 
+/** 归一化关键词文本，保存为一条规则时仍按行保留用户维护习惯。 */
+const normalizeKeywordText = (value: string) => parseKeywordLines(value).join('\n')
+
 /** 查找同一次提交里的重复关键词，提前拦截可以避免整体保存后部分数据不可预期。 */
 const findDuplicateKeywordLine = (keywordLines: string[]) => {
   const seen = new Set<string>()
@@ -31,6 +34,10 @@ const findDuplicateKeywordLine = (keywordLines: string[]) => {
 /** 生成关键词唯一键，前端校验要和后端同一商品下唯一的规则保持一致。 */
 const buildKeywordRuleKey = (keyword: string, itemId?: string) =>
   `${keyword.trim().toLowerCase()}__${(itemId || '').trim().toLowerCase()}`
+
+/** 展开规则里的多行关键词，用于列表展示和跨规则重复校验。 */
+const getKeywordLineKeys = (keyword: Keyword) =>
+  parseKeywordLines(keyword.keyword).map(line => buildKeywordRuleKey(line, keyword.item_id))
 
 export function Keywords() {
   const { addToast } = useUIStore()
@@ -238,6 +245,7 @@ export function Keywords() {
 
     try {
       setSaving(true)
+      const normalizedKeywordText = normalizeKeywordText(keywordText)
 
       if (editingKeyword) {
         const sourceAccountId = getKeywordAccountId(editingKeyword)
@@ -245,14 +253,14 @@ export function Keywords() {
           addToast({ type: 'error', message: '未找到原所属账号，无法保存' })
           return
         }
-        // 编辑模式：后端会把多行关键词替换成多条同回复规则，避免前端多次请求造成部分成功。
+        // 编辑模式：多行关键词仍保存为同一条规则，方便后续在一个入口维护同回复内容。
         const result = await updateKeyword(
           sourceAccountId,
           editingKeyword.keyword,
           editingKeyword.item_id || '',
           {
             account_id: submitAccountId,
-            keyword: keywordLines.join('\n'),
+            keyword: normalizedKeywordText,
             reply: replyText.trim(),
             item_id: itemIdText.trim(),
           }
@@ -263,19 +271,13 @@ export function Keywords() {
         }
         addToast({ type: 'success', message: '关键词已更新' })
       } else {
-        // 新增模式：先在前端展开关键词和商品的组合，再复用整体保存接口保持原有后端兼容。
+        // 新增模式：每个商品只新增一条规则，避免多账号场景下同回复关键词被拆散后难以查找。
         const itemIdsToAdd = selectedItemIds.length > 0 ? selectedItemIds : ['']
         const existingKeywords = await getKeywords(submitAccountId)
-        const existingKeys = new Set(existingKeywords.map(k => buildKeywordRuleKey(k.keyword, k.item_id)))
-        const newKeywords = itemIdsToAdd.flatMap(itemId =>
-          keywordLines.map(keyword => ({
-            keyword,
-            reply: replyText.trim(),
-            item_id: itemId,
-            type: 'text' as const,
-          } as Keyword))
-        )
-        const conflictKeyword = newKeywords.find(k => existingKeys.has(buildKeywordRuleKey(k.keyword, k.item_id)))
+        const existingKeys = new Set(existingKeywords.flatMap(getKeywordLineKeys))
+        const conflictKeyword = itemIdsToAdd
+          .flatMap(itemId => keywordLines.map(keyword => ({ keyword, item_id: itemId })))
+          .find(k => existingKeys.has(buildKeywordRuleKey(k.keyword, k.item_id)))
 
         if (conflictKeyword) {
           const itemDesc = conflictKeyword.item_id ? `商品ID：${conflictKeyword.item_id}` : '通用关键词'
@@ -283,13 +285,19 @@ export function Keywords() {
           return
         }
 
+        const newKeywords = itemIdsToAdd.map(itemId => ({
+          keyword: normalizedKeywordText,
+          reply: replyText.trim(),
+          item_id: itemId,
+          type: 'text' as const,
+        } as Keyword))
         const result = await saveKeywords(submitAccountId, [...existingKeywords, ...newKeywords])
         if (result.success === false) {
           addToast({ type: 'error', message: result.message || '添加失败' })
           return
         }
 
-        addToast({ type: 'success', message: `成功添加 ${newKeywords.length} 条关键词` })
+        addToast({ type: 'success', message: `成功添加 ${newKeywords.length} 条关键词规则` })
       }
 
       await loadKeywords()
@@ -368,7 +376,7 @@ export function Keywords() {
         addToast({ type: 'error', message: '未找到所属账号，无法删除' })
         return
       }
-      const result = await deleteKeyword(accountId, keyword.keyword, keyword.item_id || '')
+      const result = await deleteKeyword(accountId, keyword.keyword, keyword.item_id || '', keyword.id)
       if (result.success === false) {
         addToast({ type: 'error', message: result.message || '删除失败' })
         return
@@ -384,7 +392,7 @@ export function Keywords() {
   }
 
   // 批量选择相关
-  const getKeywordUniqueId = (keyword: Keyword) => `${getKeywordAccountId(keyword)}_${keyword.keyword}_${keyword.item_id || ''}`
+  const getKeywordUniqueId = (keyword: Keyword) => keyword.id || `${getKeywordAccountId(keyword)}_${keyword.keyword}_${keyword.item_id || ''}`
 
   const toggleKeywordSelect = (keyword: Keyword) => {
     const id = getKeywordUniqueId(keyword)
@@ -429,7 +437,7 @@ export function Keywords() {
             }
             continue
           }
-          const result = await deleteKeyword(accountId, keyword.keyword, keyword.item_id || '')
+          const result = await deleteKeyword(accountId, keyword.keyword, keyword.item_id || '', keyword.id)
           if (result.success === false) {
             failCount++
             if (!firstErrorMessage) {
@@ -738,9 +746,16 @@ export function Keywords() {
                       </span>
                     </td>
                     <td className="font-medium">
-                      <code className="bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 px-2 py-1 rounded">
-                        {keyword.keyword}
-                      </code>
+                      <div className="flex max-w-[360px] flex-wrap gap-1.5">
+                        {parseKeywordLines(keyword.keyword).map((keywordLine) => (
+                          <code
+                            key={keywordLine}
+                            className="bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 px-2 py-1 rounded"
+                          >
+                            {keywordLine}
+                          </code>
+                        ))}
+                      </div>
                     </td>
                     <td>
                       {keyword.item_id ? (

--- a/websocket/app/services/xianyu/auto_reply_service.py
+++ b/websocket/app/services/xianyu/auto_reply_service.py
@@ -1159,21 +1159,23 @@ class AutoReplyService:
             if item_id:
                 for kw in keywords:
                     keyword = kw.get("keyword", "")
+                    keyword_lines = [line.strip() for line in keyword.splitlines() if line.strip()]
                     reply = kw.get("reply", "")
                     kw_item_id = kw.get("item_id", "")
                     kw_type = kw.get("type", "text")
                     image_url = kw.get("image_url", "")
+                    matched_keyword = next((line for line in keyword_lines if line.lower() in msg_lower), "")
                     
-                    if kw_item_id == item_id and keyword.lower() in msg_lower:
-                        logger.info(f"商品ID关键词匹配成功: 商品{item_id} '{keyword}' (类型: {kw_type})")
+                    if kw_item_id == item_id and matched_keyword:
+                        logger.info(f"商品ID关键词匹配成功: 商品{item_id} '{matched_keyword}' (类型: {kw_type})")
                         if reply_trace is not None:
                             reply_trace["reply_strategy"] = "keyword"
-                            reply_trace["matched_keyword"] = keyword
+                            reply_trace["matched_keyword"] = matched_keyword
                             reply_trace["matched_rule_type"] = "keyword_item"
                             reply_trace.setdefault("context_snapshot", {})["matched_item_title"] = kw.get("item_title") or None
                         
                         if kw_type == "image" and image_url:
-                            image_reply = await self._handle_image_keyword(keyword, image_url)
+                            image_reply = await self._handle_image_keyword(matched_keyword, image_url)
                             if reply_trace is not None:
                                 if image_reply.startswith("__IMAGE_SEND__"):
                                     reply_trace["reply_mode"] = "image"
@@ -1186,7 +1188,7 @@ class AutoReplyService:
                             return image_reply
                         
                         if not reply or not reply.strip():
-                            logger.info(f"商品ID关键词 '{keyword}' 回复内容为空,不进行回复")
+                            logger.info(f"商品ID关键词 '{matched_keyword}' 回复内容为空,不进行回复")
                             return "EMPTY_REPLY"
                         
                         try:
@@ -1213,20 +1215,22 @@ class AutoReplyService:
             
             for kw in keywords:
                 keyword = kw.get("keyword", "")
+                keyword_lines = [line.strip() for line in keyword.splitlines() if line.strip()]
                 reply = kw.get("reply", "")
                 kw_item_id = kw.get("item_id", "")
                 kw_type = kw.get("type", "text")
                 image_url = kw.get("image_url", "")
+                matched_keyword = next((line for line in keyword_lines if line.lower() in msg_lower), "")
 
-                if not kw_item_id and keyword.lower() in msg_lower:
-                    logger.info(f"通用关键词匹配成功: '{keyword}' (类型: {kw_type})")
+                if not kw_item_id and matched_keyword:
+                    logger.info(f"通用关键词匹配成功: '{matched_keyword}' (类型: {kw_type})")
                     if reply_trace is not None:
                         reply_trace["reply_strategy"] = "keyword"
-                        reply_trace["matched_keyword"] = keyword
+                        reply_trace["matched_keyword"] = matched_keyword
                         reply_trace["matched_rule_type"] = "keyword_common"
 
                     if kw_type == "image" and image_url:
-                        image_reply = await self._handle_image_keyword(keyword, image_url)
+                        image_reply = await self._handle_image_keyword(matched_keyword, image_url)
                         if reply_trace is not None:
                             if image_reply.startswith("__IMAGE_SEND__"):
                                 reply_trace["reply_mode"] = "image"
@@ -1239,7 +1243,7 @@ class AutoReplyService:
                         return image_reply
 
                     if not reply or not reply.strip():
-                        logger.info(f"通用关键词 '{keyword}' 回复内容为空,不进行回复")
+                        logger.info(f"通用关键词 '{matched_keyword}' 回复内容为空,不进行回复")
                         return "EMPTY_REPLY"
 
                     try:


### PR DESCRIPTION
```md
## 背景

当前自动回复已经支持在文本域中一行填写一个关键词，但保存后会被拆成多条规则。实际使用中这会带来明显的维护成本：

- 多个关键词往往对应同一条回复内容，例如“申请了 / 帮我开通 / 人呢 / 快一点 / 已申请”都应该回复同一段话。
- 如果拆成多条数据，列表会很快膨胀，尤其是多个账号一起管理时，很难快速找到并修改某一组同回复关键词。
- 后续编辑回复内容时，需要逐条找、逐条改，容易漏改，也不符合“多个触发表达对应同一回复”的配置习惯。

因此这次调整为：多个关键词仍然一行一个填写，但保存后作为同一条自动回复规则展示和维护。

## 改动内容

- 自动回复文本关键词支持多行保存为同一条规则。
- 列表页将同一条规则内的多个关键词展示在同一行，便于查找和编辑。
- 编辑弹窗中继续使用文本域，一行一个关键词，可集中维护同一组关键词。
- 自动回复匹配时会按行拆分关键词，逐个判断是否命中用户消息。
- 保存和编辑时按每一行关键词做重复校验，避免不同规则中隐藏重复关键词。
- 删除规则时优先使用规则 ID，避免多行关键词作为 URL 路径参数导致删除不稳定。

## 兼容性

- 不新增数据库字段。
- 不需要数据库迁移。
- 旧的单关键词规则仍然正常显示、编辑和匹配。
- 多关键词规则只是复用现有 `keyword` 字段保存多行文本，保持现有接口结构基本兼容。

## 价值

这个改动能显著降低自动回复配置维护成本。对有多个账号、多个商品、多个相似触发表达的用户来说，可以把同一类意图集中维护在一条规则里，列表更清晰，编辑也更安全，不容易出现漏改或重复配置。
```
<img width="902" height="125" alt="image" src="https://github.com/user-attachments/assets/c728a921-febb-4883-b047-5550613c5d69" />