### PR TITLE
feat: 新增素材库 AI 铺货功能，发货相关设置对齐闲鱼网页端

### DIFF
--- a/backend-web/app/api/routes/product_publish.py
+++ b/backend-web/app/api/routes/product_publish.py
@@ -9,6 +9,7 @@
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Dict, List, Optional
 
 import uuid
@@ -18,9 +19,15 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_active_user, get_db_session
+from app.services.ai_listing_service import (
+    AiListingConfigService,
+    AiListingGenerationService,
+    ai_listing_config_to_dict,
+)
+from app.services.ai_listing_task_status_service import AiListingTaskStatusService
 from app.services.product_publish_service import ProductMaterialService
 from app.services.publish_batch_status_service import PublishBatchStatusService
-from app.services.publish_execution_service import PublishExecutorService, PublishLogService
+from app.services.publish_execution_service import PublishExecutorService, PublishLogService, _log_to_dict
 from common.models.user import User, UserRole
 from common.schemas.common import ApiResponse
 from common.utils.local_image_upload import ImageUploadError, save_uploaded_image
@@ -87,6 +94,36 @@ class BatchPublishRequest(BaseModel):
     """批量发布请求"""
     account_ids: List[str] = Field(..., min_length=1, description="账号ID列表")
     material_ids: List[int] = Field(..., min_length=1, description="素材ID列表")
+
+
+class AiListingConfigRequest(BaseModel):
+    """AI铺货配置请求"""
+    name: str = Field(..., min_length=1, max_length=100, description="配置名称")
+    prompt: str = Field(..., min_length=1, description="商品生成提示词")
+    reference_text: Optional[str] = Field(None, description="参考文案")
+    price_mode: str = Field("fixed", description="价格模式：fixed/range")
+    fixed_price: Optional[float] = Field(None, ge=0, description="固定价格")
+    price_min: Optional[float] = Field(None, ge=0, description="最低价格")
+    price_max: Optional[float] = Field(None, ge=0, description="最高价格")
+    text_api_url: str = Field(..., min_length=1, max_length=500, description="文案AI接口地址")
+    text_api_key: str = Field(..., min_length=1, description="文案AI Key")
+    text_model: str = Field(..., min_length=1, max_length=120, description="文案AI模型")
+    image_mode: str = Field("random", description="图片模式：ai/random")
+    image_api_url: Optional[str] = Field(None, max_length=500, description="图片AI接口地址")
+    image_api_key: Optional[str] = Field(None, description="图片AI Key")
+    image_model: Optional[str] = Field(None, max_length=120, description="图片AI模型")
+    image_prompt: Optional[str] = Field(None, description="图片生成提示词")
+    image_polish_enabled: bool = Field(False, description="是否启用图片提示词AI润色")
+    image_polish_sequential: bool = Field(False, description="多图是否保持关联")
+    random_images: List[str] = Field(default=[], description="随机图库")
+    random_image_count: int = Field(1, ge=1, le=9, description="随机选图数量")
+    material_defaults: Dict[str, Any] = Field(default={}, description="素材默认字段")
+
+
+class AiListingGenerateRequest(BaseModel):
+    """AI铺货生成请求"""
+    count: int = Field(..., ge=1, le=200, description="创建素材数量")
+    concurrency: int = Field(1, ge=1, le=10, description="并发创建数量")
 
 
 # ==================== 素材库接口 ====================
@@ -200,6 +237,129 @@ async def delete_material(
     if not deleted:
         return ApiResponse(success=False, message="素材不存在或无权删除")
     return ApiResponse(success=True, message="素材删除成功")
+
+
+# ==================== AI铺货接口 ====================
+
+@router.get("/ai-listing/configs", response_model=ApiResponse)
+async def list_ai_listing_configs(
+    current_user: User = Depends(get_current_active_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> Dict[str, Any]:
+    """查询AI铺货配置列表"""
+    svc = AiListingConfigService(session)
+    data = await svc.list_configs(current_user.id)
+    return ApiResponse(success=True, message="查询成功", data=data)
+
+
+@router.post("/ai-listing/configs", response_model=ApiResponse)
+async def create_ai_listing_config(
+    req: AiListingConfigRequest,
+    current_user: User = Depends(get_current_active_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> Dict[str, Any]:
+    """创建AI铺货配置"""
+    validation_error = _validate_ai_listing_config(req)
+    if validation_error:
+        return ApiResponse(success=False, message=validation_error)
+    svc = AiListingConfigService(session)
+    config = await svc.create(current_user.id, req.model_dump())
+    return ApiResponse(success=True, message="配置创建成功", data=ai_listing_config_to_dict(config))
+
+
+@router.put("/ai-listing/configs/{config_id}", response_model=ApiResponse)
+async def update_ai_listing_config(
+    config_id: int,
+    req: AiListingConfigRequest,
+    current_user: User = Depends(get_current_active_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> Dict[str, Any]:
+    """更新AI铺货配置"""
+    validation_error = _validate_ai_listing_config(req)
+    if validation_error:
+        return ApiResponse(success=False, message=validation_error)
+    svc = AiListingConfigService(session)
+    config = await svc.update(config_id, current_user.id, req.model_dump())
+    if not config:
+        return ApiResponse(success=False, message="配置不存在或无权修改")
+    return ApiResponse(success=True, message="配置更新成功", data=ai_listing_config_to_dict(config))
+
+
+@router.delete("/ai-listing/configs/{config_id}", response_model=ApiResponse)
+async def delete_ai_listing_config(
+    config_id: int,
+    current_user: User = Depends(get_current_active_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> Dict[str, Any]:
+    """删除AI铺货配置"""
+    svc = AiListingConfigService(session)
+    deleted = await svc.delete(config_id, current_user.id)
+    if not deleted:
+        return ApiResponse(success=False, message="配置不存在或无权删除")
+    return ApiResponse(success=True, message="配置删除成功")
+
+
+@router.post("/ai-listing/configs/{config_id}/generate", response_model=ApiResponse)
+async def start_ai_listing_generation(
+    config_id: int,
+    req: AiListingGenerateRequest,
+    current_user: User = Depends(get_current_active_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> Dict[str, Any]:
+    """启动AI铺货后台任务"""
+    svc = AiListingConfigService(session)
+    config = await svc.get(config_id, current_user.id)
+    if not config:
+        return ApiResponse(success=False, message="配置不存在或无权访问")
+    current_tasks = await AiListingTaskStatusService.list_user_tasks(current_user.id)
+    running_tasks = [item for item in current_tasks if not item.get("finished")]
+    if len(running_tasks) >= 5:
+        return ApiResponse(success=False, message="最多只能同时执行5个AI铺货任务，请等待已有任务完成后再继续")
+    task_id = str(uuid.uuid4())
+    await AiListingTaskStatusService.init_task(
+        task_id,
+        user_id=current_user.id,
+        config_id=config_id,
+        total=req.count,
+        config_name=config.name,
+    )
+    asyncio.create_task(
+        _run_ai_listing_background(
+            user_id=current_user.id,
+            config_id=config_id,
+            task_id=task_id,
+            count=req.count,
+            concurrency=req.concurrency,
+        )
+    )
+    return ApiResponse(
+        success=True,
+        message=f"AI铺货任务已提交，共 {req.count} 条素材",
+        data={"task_id": task_id, "total": req.count},
+    )
+
+
+@router.get("/ai-listing/tasks/{task_id}/status", response_model=ApiResponse)
+async def get_ai_listing_task_status(
+    task_id: str,
+    current_user: User = Depends(get_current_active_user),
+) -> Dict[str, Any]:
+    """查询AI铺货任务进度"""
+    snapshot = await AiListingTaskStatusService.get_task_snapshot(task_id)
+    if not snapshot:
+        return ApiResponse(success=False, message="AI铺货任务不存在或状态已失效")
+    if snapshot.get("user_id") != current_user.id:
+        return ApiResponse(success=False, message="AI铺货任务不存在或无权访问")
+    return ApiResponse(success=True, message="查询成功", data=snapshot)
+
+
+@router.get("/ai-listing/tasks", response_model=ApiResponse)
+async def list_ai_listing_tasks(
+    current_user: User = Depends(get_current_active_user),
+) -> Dict[str, Any]:
+    """查询当前用户的AI铺货任务列表"""
+    tasks = await AiListingTaskStatusService.list_user_tasks(current_user.id)
+    return ApiResponse(success=True, message="查询成功", data=tasks)
 
 
 # ==================== 发布接口 ====================
@@ -440,6 +600,28 @@ async def list_publish_logs(
     return ApiResponse(success=True, message="查询成功", data=data)
 
 
+@router.get("/logs/{log_id}", response_model=ApiResponse)
+async def get_publish_log(
+    log_id: int,
+    current_user: User = Depends(get_current_active_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> Dict[str, Any]:
+    """查询单条发布日志（管理员可查看任意日志）"""
+    svc = PublishLogService(session)
+    query_user_id = None if _is_admin(current_user) else current_user.id
+    log = await svc.get_log(log_id, query_user_id)
+    if not log:
+        return ApiResponse(success=False, message="发布日志不存在或无权访问")
+
+    data = _log_to_dict(log)
+    if _is_admin(current_user):
+        from sqlalchemy import select
+        stmt = select(User.username).where(User.id == log.user_id)
+        username = (await session.execute(stmt)).scalar_one_or_none()
+        data["username"] = username or "未知用户"
+    return ApiResponse(success=True, message="查询成功", data=data)
+
+
 @router.delete("/logs/clear", response_model=ApiResponse)
 async def clear_publish_logs(
     current_user: User = Depends(get_current_active_user),
@@ -520,6 +702,62 @@ async def upload_product_images(
 
 
 # ==================== 后台任务函数 ====================
+
+def _validate_ai_listing_config(req: AiListingConfigRequest) -> str | None:
+    """校验AI铺货配置"""
+    if req.price_mode not in {"fixed", "range"}:
+        return "价格模式不正确"
+    if req.price_mode == "fixed":
+        if not req.fixed_price or req.fixed_price <= 0:
+            return "固定价格必须大于0"
+    else:
+        if not req.price_min or not req.price_max or req.price_min <= 0 or req.price_max <= 0:
+            return "价格范围必须大于0"
+        if req.price_max < req.price_min:
+            return "最高价格不能小于最低价格"
+    if req.image_mode not in {"ai", "random"}:
+        return "图片模式不正确"
+    if req.image_mode == "random":
+        if not req.random_images:
+            return "随机选图模式请先上传图库图片"
+        if req.random_image_count > len(req.random_images):
+            return "随机选图数量不能大于图库图片数量"
+    else:
+        if not req.image_api_url or not req.image_api_key or not req.image_model:
+            return "AI生成图片模式请填写图片AI地址、Key和模型"
+        if not (req.image_prompt or "").strip():
+            return "AI生成图片模式请填写图片提示词"
+        if req.random_image_count > 1 and not req.image_polish_enabled:
+            return "AI多图生成必须开启图片提示词AI润色"
+        if req.image_polish_sequential and not req.image_polish_enabled:
+            return "多图保持关联需要先开启图片提示词AI润色"
+    return None
+
+
+async def _run_ai_listing_background(
+    user_id: int,
+    config_id: int,
+    task_id: str,
+    count: int,
+    concurrency: int,
+) -> None:
+    """后台异步执行AI铺货任务"""
+    import traceback
+
+    svc = AiListingGenerationService()
+    try:
+        await svc.run_generation_task(
+            user_id=user_id,
+            config_id=config_id,
+            task_id=task_id,
+            count=count,
+            concurrency=concurrency,
+        )
+    except Exception as e:
+        from loguru import logger
+        logger.error(f"AI铺货后台任务异常: {e}\n{traceback.format_exc()}")
+        await AiListingTaskStatusService.finish(task_id, "failed", f"AI铺货任务异常：{e}")
+
 
 async def _run_batch_publish_background(
     user_id: int,

--- a/backend-web/app/api/routes/product_publish.py
+++ b/backend-web/app/api/routes/product_publish.py
@@ -43,7 +43,7 @@ class MaterialCreateRequest(BaseModel):
     original_price: Optional[float] = Field(None, description="原价（划线价）")
     category: Optional[str] = Field(None, max_length=100, description="商品分类")
     images: List[str] = Field(default=[], description="图片URL列表（最多9张）")
-    delivery_method: str = Field("express", description="发货方式：express/pickup")
+    delivery_method: str = Field("express", description="发货方式：express/pickup/virtual")
     postage: float = Field(0, ge=0, description="邮费，0表示包邮")
     address: Optional[str] = Field(None, max_length=200, description="宝贝所在地")
     brand: Optional[str] = Field(None, max_length=100, description="品牌")
@@ -77,7 +77,7 @@ class PublishSingleRequest(BaseModel):
     category: Optional[str] = Field(None, description="商品分类")
     images: List[str] = Field(..., min_length=1, description="图片本地路径列表（至少1张）")
     address: Optional[str] = None
-    delivery_method: str = Field("express", description="发货方式：express/pickup")
+    delivery_method: str = Field("express", description="发货方式：express/pickup/virtual")
     postage: float = Field(0, ge=0, description="邮费，0表示包邮")
     brand: Optional[str] = Field(None, description="品牌")
     condition: str = Field("全新", description="成色")

--- a/backend-web/app/api/routes/product_publish.py
+++ b/backend-web/app/api/routes/product_publish.py
@@ -46,8 +46,8 @@ class MaterialCreateRequest(BaseModel):
     """创建素材请求"""
     title: str = Field(..., min_length=1, max_length=200, description="商品标题")
     description: str = Field(..., min_length=1, description="商品描述")
-    price: float = Field(..., gt=0, description="售价")
-    original_price: Optional[float] = Field(None, description="原价（划线价）")
+    price: float = Field(..., ge=0.01, multiple_of=0.01, description="售价")
+    original_price: Optional[float] = Field(None, ge=0.01, multiple_of=0.01, description="原价（划线价）")
     category: Optional[str] = Field(None, max_length=100, description="商品分类")
     images: List[str] = Field(default=[], description="图片URL列表（最多9张）")
     delivery_method: str = Field("express", description="发货方式：express/pickup")
@@ -62,8 +62,8 @@ class MaterialUpdateRequest(BaseModel):
     """更新素材请求（所有字段均可选）"""
     title: Optional[str] = Field(None, max_length=200)
     description: Optional[str] = None
-    price: Optional[float] = Field(None, gt=0)
-    original_price: Optional[float] = None
+    price: Optional[float] = Field(None, ge=0.01, multiple_of=0.01)
+    original_price: Optional[float] = Field(None, ge=0.01, multiple_of=0.01)
     category: Optional[str] = None
     images: Optional[List[str]] = None
     delivery_method: Optional[str] = None
@@ -102,9 +102,9 @@ class AiListingConfigRequest(BaseModel):
     prompt: str = Field(..., min_length=1, description="商品生成提示词")
     reference_text: Optional[str] = Field(None, description="参考文案")
     price_mode: str = Field("fixed", description="价格模式：fixed/range")
-    fixed_price: Optional[float] = Field(None, ge=0, description="固定价格")
-    price_min: Optional[float] = Field(None, ge=0, description="最低价格")
-    price_max: Optional[float] = Field(None, ge=0, description="最高价格")
+    fixed_price: Optional[float] = Field(None, ge=0.01, multiple_of=0.01, description="固定价格")
+    price_min: Optional[float] = Field(None, ge=0.01, multiple_of=0.01, description="最低价格")
+    price_max: Optional[float] = Field(None, ge=0.01, multiple_of=0.01, description="最高价格")
     text_api_url: str = Field(..., min_length=1, max_length=500, description="文案AI接口地址")
     text_api_key: str = Field(..., min_length=1, description="文案AI Key")
     text_model: str = Field(..., min_length=1, max_length=120, description="文案AI模型")
@@ -708,11 +708,11 @@ def _validate_ai_listing_config(req: AiListingConfigRequest) -> str | None:
     if req.price_mode not in {"fixed", "range"}:
         return "价格模式不正确"
     if req.price_mode == "fixed":
-        if not req.fixed_price or req.fixed_price <= 0:
-            return "固定价格必须大于0"
+        if not req.fixed_price or req.fixed_price < 0.01:
+            return "固定价格最小为0.01"
     else:
-        if not req.price_min or not req.price_max or req.price_min <= 0 or req.price_max <= 0:
-            return "价格范围必须大于0"
+        if not req.price_min or not req.price_max or req.price_min < 0.01 or req.price_max < 0.01:
+            return "价格范围最小为0.01"
         if req.price_max < req.price_min:
             return "最高价格不能小于最低价格"
     if req.image_mode not in {"ai", "random"}:

--- a/backend-web/app/api/routes/product_publish.py
+++ b/backend-web/app/api/routes/product_publish.py
@@ -43,7 +43,8 @@ class MaterialCreateRequest(BaseModel):
     original_price: Optional[float] = Field(None, description="原价（划线价）")
     category: Optional[str] = Field(None, max_length=100, description="商品分类")
     images: List[str] = Field(default=[], description="图片URL列表（最多9张）")
-    delivery_method: str = Field("express", description="发货方式：express/pickup/virtual")
+    delivery_method: str = Field("free_shipping", description="发货方式：free_shipping/distance_billing/fixed_fee/no_shipping")
+    support_pickup: bool = Field(False, description="是否支持自提")
     postage: float = Field(0, ge=0, description="邮费，0表示包邮")
     address: Optional[str] = Field(None, max_length=200, description="宝贝所在地")
     brand: Optional[str] = Field(None, max_length=100, description="品牌")
@@ -60,6 +61,7 @@ class MaterialUpdateRequest(BaseModel):
     category: Optional[str] = None
     images: Optional[List[str]] = None
     delivery_method: Optional[str] = None
+    support_pickup: Optional[bool] = None
     postage: Optional[float] = Field(None, ge=0)
     address: Optional[str] = None
     brand: Optional[str] = None
@@ -77,7 +79,8 @@ class PublishSingleRequest(BaseModel):
     category: Optional[str] = Field(None, description="商品分类")
     images: List[str] = Field(..., min_length=1, description="图片本地路径列表（至少1张）")
     address: Optional[str] = None
-    delivery_method: str = Field("express", description="发货方式：express/pickup/virtual")
+    delivery_method: str = Field("free_shipping", description="发货方式：free_shipping/distance_billing/fixed_fee/no_shipping")
+    support_pickup: bool = Field(False, description="是否支持自提")
     postage: float = Field(0, ge=0, description="邮费，0表示包邮")
     brand: Optional[str] = Field(None, description="品牌")
     condition: str = Field("全新", description="成色")

--- a/backend-web/app/services/ai_listing_service.py
+++ b/backend-web/app/services/ai_listing_service.py
@@ -1,0 +1,824 @@
+"""
+AI铺货服务
+
+负责AI铺货配置管理，并按配置生成商品素材。
+"""
+from __future__ import annotations
+
+import base64
+import asyncio
+import json
+import random
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Awaitable, Callable, TypeVar
+
+import httpx
+from loguru import logger
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.paths import get_upload_path
+from app.services.ai_listing_task_status_service import AiListingTaskStatusService
+from app.services.product_publish_service import ProductMaterialService
+from common.models.ai_listing_config import AiListingConfig
+from common.services.ai_provider_service import build_openai_url, clean_ai_text, ensure_success_response
+from common.utils.time_utils import safe_isoformat
+
+
+AI_LISTING_SYSTEM_PROMPT = """
+你是闲鱼商品铺货文案助手。请根据用户给出的商品方向、参考文案和价格规则，生成自然、真实、适合二手/闲置平台发布的商品素材。
+要求：
+1. 只输出 JSON，不要输出 Markdown 或解释。
+2. JSON 字段必须包含 title、description、price。
+3. title 控制在 20 个中文字符以内，且要富有变化，有吸引力。
+4. 如果用户提供了参考文案，description 必须尽量完整保留参考文案中的商品信息、卖点、状态、配件、场景、交易说明和表达重点，不要无故删减原有语义。
+5. 可以做自然改写，但不要明显压缩内容，description 的字数尽量接近参考文案，字数波动不要太大，但是句式内容需要变换。
+6. description 口吻自然真实，不要编造无法确认的官方承诺、保真承诺、售后承诺。
+7. price 必须遵守用户给出的固定价格或价格范围，且价格范围内应该是合理的数，吉利的数字，最多1位小数，尽量常见的9.9,8.8,6.8等等为尾数。
+8. 避免绝对化、违禁、虚假宣传表述。
+""".strip()
+
+AI_LISTING_IMAGE_POLISH_SYSTEM_PROMPT = """
+你是闲鱼商品图片提示词润色助手。你的任务是在不改变原意的前提下，把用户给出的图片要求整理成更稳定、更适合图片生成模型的提示词。
+要求：
+1. 只输出 JSON，不要输出 Markdown 或解释
+2. JSON 字段必须包含 prompts
+3. prompts 必须是字符串数组，每个元素对应一张图片的提示词
+4. 当用户要求生成 N 张图时，prompts 数组长度必须严格等于 N，不能缺少，不能合并，不能输出额外元素
+5. 必须保留原提示词中的主体、卖点、场景、风格、材质、用途等关键信息，不要改变商品类型，不要改变原本想表达的含义
+6. 可以补充少量有助于生图稳定性的商品展示描述，但不要删减关键语义，也不要把原提示词改成完全不同的内容
+7. 每张图都要符合闲鱼商品展示图语境，真实、自然、适合展示售卖商品，商品可能是虚拟物品，也可能是实物商品，如果是虚拟物品则生成海报图，如果是实物生成实拍图。
+""".strip()
+
+AI_LISTING_IMAGE_GENERATION_PREFIX = """
+闲鱼电商商品展示图，用于二手/闲置平台商品发布，商品可能是虚拟物品，也可能是实物商品。
+画面要求真实自然、主体明确、构图干净、突出商品本身与售卖信息，适合生成商品展示图，不要加入无关杂乱元素、夸张海报字或平台水印。
+""".strip()
+
+AI_REQUEST_RETRY_TIMES = 3
+AI_REQUEST_RETRY_BASE_DELAY_SECONDS = 1.0
+
+T = TypeVar("T")
+
+
+def _short_debug_text(value: Any, limit: int = 4000) -> str:
+    """压缩调试日志文本，避免日志过长"""
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}...(truncated {len(text) - limit} chars)"
+
+
+def _format_exception_message(exc: Exception) -> str:
+    text = str(exc or "").strip()
+    if text:
+        return text
+    return f"{exc.__class__.__name__}: {repr(exc)}"
+
+
+def _contains_any(text: str, keywords: tuple[str, ...]) -> bool:
+    normalized = str(text or "").lower()
+    return any(keyword in normalized for keyword in keywords)
+
+
+class AiListingConfigService:
+    """AI铺货配置 CRUD"""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, user_id: int, data: dict[str, Any]) -> AiListingConfig:
+        config = AiListingConfig(user_id=user_id, **self._normalize_config_payload(data))
+        self.session.add(config)
+        await self.session.commit()
+        await self.session.refresh(config)
+        return config
+
+    async def list_configs(self, user_id: int) -> list[dict[str, Any]]:
+        stmt = (
+            select(AiListingConfig)
+            .where(AiListingConfig.user_id == user_id)
+            .order_by(desc(AiListingConfig.created_at))
+        )
+        rows = (await self.session.execute(stmt)).scalars().all()
+        return [ai_listing_config_to_dict(row) for row in rows]
+
+    async def get(self, config_id: int, user_id: int) -> AiListingConfig | None:
+        stmt = select(AiListingConfig).where(
+            AiListingConfig.id == config_id,
+            AiListingConfig.user_id == user_id,
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def update(self, config_id: int, user_id: int, data: dict[str, Any]) -> AiListingConfig | None:
+        config = await self.get(config_id, user_id)
+        if not config:
+            return None
+        payload = self._normalize_config_payload(data, partial=True)
+        for key, value in payload.items():
+            setattr(config, key, value)
+        await self.session.commit()
+        await self.session.refresh(config)
+        return config
+
+    async def delete(self, config_id: int, user_id: int) -> bool:
+        config = await self.get(config_id, user_id)
+        if not config:
+            return False
+        await self.session.delete(config)
+        await self.session.commit()
+        return True
+
+    def _normalize_config_payload(self, data: dict[str, Any], partial: bool = False) -> dict[str, Any]:
+        fields = {
+            "name",
+            "prompt",
+            "reference_text",
+            "price_mode",
+            "fixed_price",
+            "price_min",
+            "price_max",
+            "text_api_url",
+            "text_api_key",
+            "text_model",
+            "image_mode",
+            "image_api_url",
+            "image_api_key",
+            "image_model",
+            "image_prompt",
+            "image_polish_enabled",
+            "image_polish_sequential",
+            "random_images",
+            "random_image_count",
+            "material_defaults",
+        }
+        payload = {key: data[key] for key in fields if key in data}
+        if not partial:
+            payload.setdefault("reference_text", None)
+            payload.setdefault("price_mode", "fixed")
+            payload.setdefault("image_mode", "random")
+            payload.setdefault("image_polish_enabled", False)
+            payload.setdefault("image_polish_sequential", False)
+            payload.setdefault("random_images", [])
+            payload.setdefault("random_image_count", 1)
+            payload.setdefault("material_defaults", {})
+        if "price_mode" in payload and payload["price_mode"] not in {"fixed", "range"}:
+            payload["price_mode"] = "fixed"
+        if "image_mode" in payload and payload["image_mode"] not in {"ai", "random"}:
+            payload["image_mode"] = "random"
+        if "random_image_count" in payload:
+            payload["random_image_count"] = max(1, min(int(payload["random_image_count"] or 1), 9))
+        if "image_polish_enabled" in payload:
+            payload["image_polish_enabled"] = bool(payload["image_polish_enabled"])
+        if "image_polish_sequential" in payload:
+            payload["image_polish_sequential"] = bool(payload["image_polish_sequential"])
+        image_mode = payload.get("image_mode")
+        random_image_count = int(payload.get("random_image_count") or 1)
+        if image_mode == "ai" and random_image_count > 1:
+            payload["image_polish_enabled"] = True
+        if "random_images" in payload:
+            payload["random_images"] = [str(url) for url in (payload["random_images"] or []) if str(url).strip()]
+        if "material_defaults" in payload:
+            payload["material_defaults"] = dict(payload["material_defaults"] or {})
+        return payload
+
+
+class AiListingGenerationService:
+    """AI铺货生成服务"""
+
+    def __init__(self, session: AsyncSession | None = None):
+        self.session = session
+
+    async def _run_with_retries(
+        self,
+        step_name: str,
+        action: Callable[[int, int], Awaitable[T]],
+    ) -> T:
+        total_attempts = AI_REQUEST_RETRY_TIMES + 1
+        last_error: Exception | None = None
+        for attempt in range(1, total_attempts + 1):
+            try:
+                if attempt > 1:
+                    logger.warning(
+                        "{} 重试开始 | attempt={}/{}",
+                        step_name,
+                        attempt,
+                        total_attempts,
+                    )
+                return await action(attempt, total_attempts)
+            except Exception as exc:
+                last_error = exc if isinstance(exc, Exception) else RuntimeError(str(exc))
+                logger.warning(
+                    "{} 失败 | attempt={}/{} | error={}",
+                    step_name,
+                    attempt,
+                    total_attempts,
+                    _format_exception_message(last_error),
+                )
+                if attempt >= total_attempts:
+                    break
+                await asyncio.sleep(AI_REQUEST_RETRY_BASE_DELAY_SECONDS * attempt)
+        assert last_error is not None
+        raise last_error
+
+    async def run_generation_task(
+        self,
+        user_id: int,
+        config_id: int,
+        task_id: str,
+        count: int,
+        concurrency: int = 1,
+    ) -> None:
+        config = await self._load_runtime_config(user_id, config_id)
+        if not config:
+            await AiListingTaskStatusService.finish(task_id, "failed", "AI铺货配置不存在")
+            return
+
+        concurrency = max(1, min(int(concurrency or 1), 10))
+        await AiListingTaskStatusService.mark_running(task_id, f"正在生成素材，并发数 {concurrency}")
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def worker(index: int) -> None:
+            async with semaphore:
+                await self._generate_one(user_id, config, task_id, index, count)
+
+        await asyncio.gather(*(worker(index) for index in range(count)))
+
+        snapshot = await AiListingTaskStatusService.get_task_snapshot(task_id) or {}
+        success = int(snapshot.get("success") or 0)
+        failed = int(snapshot.get("failed") or 0)
+        status = "success" if success > 0 and failed == 0 else "failed" if success == 0 else "partial_success"
+        await AiListingTaskStatusService.finish(task_id, status, f"生成完成：成功 {success} 条，失败 {failed} 条")
+
+    async def _load_runtime_config(self, user_id: int, config_id: int) -> Any | None:
+        from common.db.session import async_session_maker
+
+        if self.session is not None:
+            config = await AiListingConfigService(self.session).get(config_id, user_id)
+            if not config:
+                return None
+            return SimpleNamespace(**ai_listing_config_to_dict(config))
+
+        async with async_session_maker() as session:
+            config = await AiListingConfigService(session).get(config_id, user_id)
+            if not config:
+                return None
+            return SimpleNamespace(**ai_listing_config_to_dict(config))
+
+    async def _generate_one(
+        self,
+        user_id: int,
+        config: AiListingConfig,
+        task_id: str,
+        index: int,
+        total: int,
+    ) -> None:
+        try:
+            await AiListingTaskStatusService.update_stage(
+                task_id,
+                "text",
+                "正在生成文案",
+                f"正在生成第 {index + 1}/{total} 个素材文案",
+            )
+            generated = await self._generate_text(config, index + 1, total)
+            await AiListingTaskStatusService.update_stage(
+                task_id,
+                "text",
+                "文案生成完成",
+                f"第 {index + 1}/{total} 个素材文案已生成",
+                increment=True,
+            )
+            price = self._resolve_price(config, generated.get("price"))
+            images = await self._resolve_images(config, generated, price, task_id, index, total)
+            defaults = dict(config.material_defaults or {})
+            payload = {
+                **defaults,
+                "title": clean_ai_text(generated.get("title"))[:200],
+                "description": str(generated.get("description") or "").strip(),
+                "price": price,
+                "images": images,
+            }
+            payload.setdefault("condition", "全新")
+            payload.setdefault("delivery_method", "free_shipping")
+            payload.setdefault("support_pickup", False)
+            payload.setdefault("postage", 0)
+            if not payload["title"]:
+                raise ValueError("AI未返回商品标题")
+            if not payload["description"]:
+                raise ValueError("AI未返回商品描述")
+            if not payload["images"]:
+                raise ValueError("未生成或选择商品图片")
+            material = await self._create_material(user_id, payload)
+            await AiListingTaskStatusService.add_success(
+                task_id,
+                material.id,
+                f"已创建素材 {index + 1}/{total}",
+            )
+        except Exception as exc:
+            error_text = _format_exception_message(exc)
+            logger.warning(f"AI铺货生成第 {index + 1} 条失败: {error_text}")
+            await AiListingTaskStatusService.add_failed(task_id, f"第 {index + 1} 条失败：{error_text}")
+
+    async def _create_material(self, user_id: int, payload: dict[str, Any]):
+        from common.db.session import async_session_maker
+
+        async with async_session_maker() as session:
+            return await ProductMaterialService(session).create(user_id, payload)
+
+    async def _generate_text(self, config: AiListingConfig, index: int, total: int) -> dict[str, Any]:
+        price_rule = self._build_price_rule(config)
+        user_content = (
+            f"商品生成提示词：\n{config.prompt}\n\n"
+            f"参考文案：\n{config.reference_text or '无'}\n\n"
+            f"价格规则：{price_rule}\n\n"
+            "如果参考文案不为空，请以参考文案为主做保留式改写，尽量保留原有信息、语义重点和接近的字数。"
+        )
+        logger.info(
+            "AI铺货文案生成开始 | index={}/{} | model={} | url={} | user_content={}",
+            index,
+            total,
+            clean_ai_text(config.text_model),
+            build_openai_url(config.text_api_url, "/chat/completions"),
+            _short_debug_text(user_content),
+        )
+        return await self._chat_json(
+            config,
+            AI_LISTING_SYSTEM_PROMPT,
+            user_content,
+            "AI铺货文案接口",
+            temperature=0.8,
+            max_tokens=1200,
+        )
+
+    async def _chat_json(
+        self,
+        config: AiListingConfig,
+        system_prompt: str,
+        user_content: str,
+        provider_name: str,
+        temperature: float = 0.7,
+        max_tokens: int = 1200,
+    ) -> dict[str, Any]:
+        url = build_openai_url(config.text_api_url, "/chat/completions")
+        logger.info(
+            "{} 请求 | url={} | model={} | temperature={} | max_tokens={} | system_prompt={} | user_content={}",
+            provider_name,
+            url,
+            clean_ai_text(config.text_model),
+            temperature,
+            max_tokens,
+            _short_debug_text(system_prompt),
+            _short_debug_text(user_content),
+        )
+
+        async def do_request(attempt: int, total_attempts: int) -> dict[str, Any]:
+            logger.info(
+                "{} 执行请求 | attempt={}/{} | url={} | model={}",
+                provider_name,
+                attempt,
+                total_attempts,
+                url,
+                clean_ai_text(config.text_model),
+            )
+            async with httpx.AsyncClient(timeout=90.0) as client:
+                response = await client.post(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {clean_ai_text(config.text_api_key)}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": clean_ai_text(config.text_model),
+                        "messages": [
+                            {"role": "system", "content": system_prompt},
+                            {"role": "user", "content": user_content},
+                        ],
+                        "temperature": temperature,
+                        "max_tokens": max_tokens,
+                    },
+                )
+            ensure_success_response(response, provider_name)
+            result = response.json()
+            try:
+                content = result["choices"][0]["message"]["content"]
+            except Exception as exc:
+                raise RuntimeError(f"{provider_name}响应格式错误: {str(result)[:500]}") from exc
+            logger.info(
+                "{} 响应 | attempt={}/{} | status_code={} | raw_content={}",
+                provider_name,
+                attempt,
+                total_attempts,
+                response.status_code,
+                _short_debug_text(content),
+            )
+            parsed = self._parse_json_content(content)
+            logger.info(
+                "{} 解析结果 | attempt={}/{} | parsed_json={}",
+                provider_name,
+                attempt,
+                total_attempts,
+                _short_debug_text(json.dumps(parsed, ensure_ascii=False)),
+            )
+            return parsed
+
+        return await self._run_with_retries(provider_name, do_request)
+
+    def _parse_json_content(self, content: Any) -> dict[str, Any]:
+        text = str(content or "").strip()
+        if text.startswith("```"):
+            text = text.strip("`").strip()
+            if text.lower().startswith("json"):
+                text = text[4:].strip()
+        if "{" in text and "}" in text:
+            text = text[text.find("{"): text.rfind("}") + 1]
+        try:
+            data = json.loads(text)
+        except Exception as exc:
+            raise ValueError("AI返回内容不是有效JSON") from exc
+        if not isinstance(data, dict):
+            raise ValueError("AI返回JSON不是对象")
+        return data
+
+    def _build_price_rule(self, config: AiListingConfig) -> str:
+        if config.price_mode == "range":
+            return f"价格必须在 {float(config.price_min or 0):.2f} 到 {float(config.price_max or 0):.2f} 元之间"
+        return f"价格必须固定为 {float(config.fixed_price or 0):.2f} 元"
+
+    def _resolve_price(self, config: AiListingConfig, ai_price: Any) -> float:
+        if config.price_mode == "range":
+            low = float(config.price_min or 0)
+            high = float(config.price_max or 0)
+            if low <= 0 or high <= 0 or high < low:
+                raise ValueError("价格范围配置不正确")
+            try:
+                price = float(ai_price)
+            except Exception:
+                price = round(random.uniform(low, high), 2)
+            if price < low or price > high:
+                price = round(random.uniform(low, high), 2)
+            return round(price, 2)
+        price = float(config.fixed_price or 0)
+        if price <= 0:
+            raise ValueError("固定价格配置不正确")
+        return round(price, 2)
+
+    async def _resolve_images(
+        self,
+        config: AiListingConfig,
+        generated: dict[str, Any],
+        price: float,
+        task_id: str,
+        index: int,
+        total: int,
+    ) -> list[str]:
+        count = max(1, min(int(config.random_image_count or 1), 9))
+        if config.image_mode == "ai":
+            return await self._generate_images(config, generated, price, count, task_id, index, total)
+        images = [str(url) for url in (config.random_images or []) if str(url).strip()]
+        if not images:
+            raise ValueError("随机图库为空")
+        if count > len(images):
+            raise ValueError("随机选图数量不能大于图库图片数量")
+        await AiListingTaskStatusService.update_stage(
+            task_id,
+            "image_generate",
+            "正在准备图片",
+            f"正在为第 {index + 1}/{total} 个素材随机选图",
+        )
+        await AiListingTaskStatusService.update_stage(
+            task_id,
+            "image_polish",
+            "图片润色已跳过",
+            f"第 {index + 1}/{total} 个素材使用随机图片，无需润色",
+            increment=True,
+        )
+        await AiListingTaskStatusService.update_stage(
+            task_id,
+            "image_generate",
+            "图片准备完成",
+            f"第 {index + 1}/{total} 个素材随机选图完成",
+            increment=True,
+        )
+        if count == len(images):
+            return images[:]
+        return random.sample(images, count)
+
+    def _build_image_prompt_context(
+        self,
+        config: AiListingConfig,
+        generated: dict[str, Any],
+        price: float,
+    ) -> dict[str, str]:
+        return {
+            "title": clean_ai_text(generated.get("title")),
+            "description": str(generated.get("description") or "").strip(),
+            "price": f"{price:.2f}",
+        }
+
+    def _render_image_prompt_template(
+        self,
+        template: str,
+        context: dict[str, str],
+    ) -> str:
+        rendered = template
+        for key, value in context.items():
+            rendered = rendered.replace(f"{{{key}}}", value)
+        return rendered.strip()
+
+    def _compose_image_generation_prompt(self, prompt: str) -> str:
+        prompt = str(prompt or "").strip()
+        if not prompt:
+            return AI_LISTING_IMAGE_GENERATION_PREFIX
+        return f"{AI_LISTING_IMAGE_GENERATION_PREFIX}\n\n{prompt}"
+
+    def _resolve_image_size(self, prompt: str) -> str:
+        prompt_text = str(prompt or "")
+        if _contains_any(prompt_text, ("正方形", "方图", "方形", "1:1", "1比1", "1：1", "square")):
+            return "1024x1024"
+        if _contains_any(prompt_text, ("竖图", "竖版", "长图", "海报", "9:16", "3:4", "4:5", "9比16", "3比4", "4比5", "9：16", "3：4", "4：5", "portrait", "vertical")):
+            return "1024x1536"
+        if _contains_any(prompt_text, ("横图", "横版", "宽图", "16:9", "4:3", "16比9", "4比3", "16：9", "4：3", "landscape", "horizontal")):
+            return "1536x1024"
+        return "1024x1024"
+
+    async def _build_image_prompts(
+        self,
+        config: AiListingConfig,
+        generated: dict[str, Any],
+        price: float,
+        count: int,
+        task_id: str,
+        index: int,
+        total: int,
+    ) -> list[str]:
+        context = self._build_image_prompt_context(config, generated, price)
+        template = (config.image_prompt or "").strip()
+        base_prompt = self._render_image_prompt_template(template, context)
+        logger.info(
+            "AI铺货图片提示词渲染 | count={} | template={} | context={} | rendered_prompt={}",
+            count,
+            _short_debug_text(template),
+            _short_debug_text(json.dumps(context, ensure_ascii=False)),
+            _short_debug_text(base_prompt),
+        )
+        if not base_prompt:
+            raise ValueError("图片提示词不能为空")
+
+        if config.image_polish_enabled:
+            prompt_count = count if count > 1 else 1
+            await AiListingTaskStatusService.update_stage(
+                task_id,
+                "image_polish",
+                "正在润色图片提示词",
+                f"正在润色第 {index + 1}/{total} 个素材图片提示词",
+            )
+            sequential_instruction = (
+                "多图关联要求：多张图需要保持同一个商品主体，在风格、色调和关键细节上统一，同时每张图的构图可以略有变化。"
+                if config.image_polish_sequential and count > 1
+                else "多图关联要求：默认每张图独立生成，不需要强制保持多张图之间的统一性。"
+            )
+            user_content = (
+                f"原始图片提示词：\n{base_prompt}\n\n"
+                f"需要生成 {prompt_count} 条图片提示词\n"
+                f"{sequential_instruction}"
+            )
+            logger.info(
+                "AI铺货图片润色开始 | count={} | sequential={} | user_content={}",
+                prompt_count,
+                config.image_polish_sequential and count > 1,
+                _short_debug_text(user_content),
+            )
+            data = await self._chat_json(
+                config,
+                AI_LISTING_IMAGE_POLISH_SYSTEM_PROMPT,
+                user_content,
+                "AI铺货图片润色接口",
+                temperature=0.7,
+                max_tokens=1600,
+            )
+            prompts = self._normalize_prompt_list(data.get("prompts"), prompt_count, base_prompt)
+            logger.info(
+                "AI铺货图片润色完成 | prompt_count={} | prompts={}",
+                len(prompts),
+                _short_debug_text(json.dumps(prompts, ensure_ascii=False)),
+            )
+            await AiListingTaskStatusService.update_stage(
+                task_id,
+                "image_polish",
+                "图片提示词润色完成",
+                f"第 {index + 1}/{total} 个素材图片提示词已润色",
+                increment=True,
+            )
+            return prompts
+
+        logger.info(
+            "AI铺货图片提示词直出 | count={} | prompt={}",
+            count,
+            _short_debug_text(base_prompt),
+        )
+        await AiListingTaskStatusService.update_stage(
+            task_id,
+            "image_polish",
+            "图片润色已跳过",
+            f"第 {index + 1}/{total} 个素材直接使用原始图片提示词",
+            increment=True,
+        )
+        if count > 1:
+            return [base_prompt]
+        return [base_prompt]
+
+    def _normalize_prompt_list(self, prompts: Any, min_count: int, fallback: str) -> list[str]:
+        if isinstance(prompts, list):
+            values = [str(item).strip() for item in prompts if str(item).strip()]
+        elif isinstance(prompts, str) and prompts.strip():
+            values = [prompts.strip()]
+        else:
+            values = []
+        if not values:
+            values = [fallback]
+        while len(values) < min_count:
+            values.append(values[-1])
+        return values
+
+    async def _request_image_generation(
+        self,
+        config: AiListingConfig,
+        prompt: str,
+        count: int,
+    ) -> list[str]:
+        if not config.image_api_url or not config.image_api_key or not config.image_model:
+            raise ValueError("图片AI配置未填写完整")
+        url = build_openai_url(config.image_api_url, "/images/generations")
+        final_prompt = self._compose_image_generation_prompt(prompt)
+        image_size = self._resolve_image_size(prompt)
+        logger.info(
+            "AI铺货图片生成请求 | url={} | model={} | count={} | size={} | raw_prompt={} | final_prompt={}",
+            url,
+            clean_ai_text(config.image_model),
+            count,
+            image_size,
+            _short_debug_text(prompt),
+            _short_debug_text(final_prompt),
+        )
+
+        async def do_request(attempt: int, total_attempts: int) -> list[str]:
+            logger.info(
+                "AI铺货图片生成执行请求 | attempt={}/{} | url={} | model={} | count={}",
+                attempt,
+                total_attempts,
+                url,
+                clean_ai_text(config.image_model),
+                count,
+            )
+            async with httpx.AsyncClient(timeout=180.0) as client:
+                response = await client.post(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {clean_ai_text(config.image_api_key)}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": clean_ai_text(config.image_model),
+                        "prompt": final_prompt,
+                        "n": count,
+                        "size": image_size,
+                    },
+                )
+            ensure_success_response(response, "AI铺货图片接口")
+            result = response.json()
+            data = result.get("data") if isinstance(result, dict) else None
+            if not isinstance(data, list) or not data:
+                raise RuntimeError(f"图片AI响应格式错误: {str(result)[:500]}")
+            logger.info(
+                "AI铺货图片生成响应 | attempt={}/{} | status_code={} | image_items={}",
+                attempt,
+                total_attempts,
+                response.status_code,
+                len(data),
+            )
+            saved_urls: list[str] = []
+            async with httpx.AsyncClient(timeout=90.0) as client:
+                for item in data[:count]:
+                    if not isinstance(item, dict):
+                        continue
+                    if item.get("url"):
+                        saved_urls.append(await self._save_image_url(client, str(item["url"])))
+                    elif item.get("b64_json"):
+                        saved_urls.append(self._save_image_bytes(base64.b64decode(str(item["b64_json"])), ".png"))
+            logger.info(
+                "AI铺货图片保存完成 | attempt={}/{} | saved_count={} | saved_urls={}",
+                attempt,
+                total_attempts,
+                len(saved_urls),
+                _short_debug_text(json.dumps(saved_urls, ensure_ascii=False)),
+            )
+            return saved_urls
+
+        return await self._run_with_retries("AI铺货图片接口", do_request)
+
+    async def _generate_images(
+        self,
+        config: AiListingConfig,
+        generated: dict[str, Any],
+        price: float,
+        count: int,
+        task_id: str,
+        index: int,
+        total: int,
+    ) -> list[str]:
+        if count > 1 and not config.image_polish_enabled:
+            raise ValueError("AI多图生成必须开启图片提示词AI润色")
+        prompts = await self._build_image_prompts(config, generated, price, count, task_id, index, total)
+        if not prompts:
+            raise ValueError("图片提示词生成失败")
+        logger.info(
+            "AI铺货图片生成准备完成 | count={} | prompts={}",
+            count,
+            _short_debug_text(json.dumps(prompts, ensure_ascii=False)),
+        )
+        await AiListingTaskStatusService.update_stage(
+            task_id,
+            "image_generate",
+            "正在生成图片",
+            f"正在生成第 {index + 1}/{total} 个素材图片",
+        )
+        if len(prompts) == 1:
+            saved_urls = await self._request_image_generation(config, prompts[0], count)
+            await AiListingTaskStatusService.update_stage(
+                task_id,
+                "image_generate",
+                "图片生成完成",
+                f"第 {index + 1}/{total} 个素材已生成 {len(saved_urls)} 张图片",
+                increment=True,
+            )
+            return saved_urls
+
+        logger.info(
+            "AI铺货多图并发生成开始 | material_index={}/{} | prompt_count={}",
+            index + 1,
+            total,
+            min(len(prompts), count),
+        )
+        result_groups = await asyncio.gather(*[
+            self._request_image_generation(config, prompt, 1)
+            for prompt in prompts[:count]
+        ])
+        saved_urls = [url for group in result_groups for url in group]
+        await AiListingTaskStatusService.update_stage(
+            task_id,
+            "image_generate",
+            "图片生成完成",
+            f"第 {index + 1}/{total} 个素材已生成 {len(saved_urls[:count])} 张图片",
+            increment=True,
+        )
+        return saved_urls[:count]
+
+    async def _save_image_url(self, client: httpx.AsyncClient, url: str) -> str:
+        response = await client.get(url)
+        response.raise_for_status()
+        content_type = response.headers.get("content-type", "")
+        ext = ".png"
+        if "jpeg" in content_type or "jpg" in content_type:
+            ext = ".jpg"
+        elif "webp" in content_type:
+            ext = ".webp"
+        return self._save_image_bytes(response.content, ext)
+
+    def _save_image_bytes(self, content: bytes, ext: str) -> str:
+        upload_dir = get_upload_path("products")
+        filename = f"ai_listing_{uuid.uuid4().hex}{ext}"
+        filepath: Path = upload_dir / filename
+        filepath.write_bytes(content)
+        return f"/static/uploads/products/{filename}"
+
+
+def ai_listing_config_to_dict(config: AiListingConfig) -> dict[str, Any]:
+    """将AI铺货配置转为字典"""
+    return {
+        "id": config.id,
+        "user_id": config.user_id,
+        "name": config.name,
+        "prompt": config.prompt,
+        "reference_text": config.reference_text,
+        "price_mode": config.price_mode,
+        "fixed_price": float(config.fixed_price) if config.fixed_price is not None else None,
+        "price_min": float(config.price_min) if config.price_min is not None else None,
+        "price_max": float(config.price_max) if config.price_max is not None else None,
+        "text_api_url": config.text_api_url,
+        "text_api_key": config.text_api_key,
+        "text_model": config.text_model,
+        "image_mode": config.image_mode,
+        "image_api_url": config.image_api_url,
+        "image_api_key": config.image_api_key,
+        "image_model": config.image_model,
+        "image_prompt": config.image_prompt,
+        "image_polish_enabled": bool(config.image_polish_enabled),
+        "image_polish_sequential": bool(config.image_polish_sequential),
+        "random_images": config.random_images or [],
+        "random_image_count": int(config.random_image_count or 1),
+        "material_defaults": config.material_defaults or {},
+        "created_at": safe_isoformat(config.created_at),
+        "updated_at": safe_isoformat(config.updated_at),
+    }

--- a/backend-web/app/services/ai_listing_service.py
+++ b/backend-web/app/services/ai_listing_service.py
@@ -301,9 +301,12 @@ class AiListingGenerationService:
                 "images": images,
             }
             payload.setdefault("condition", "全新")
-            payload.setdefault("delivery_method", "free_shipping")
-            payload.setdefault("support_pickup", False)
+            if payload.get("delivery_method") not in {"express", "pickup"}:
+                payload["delivery_method"] = "express"
+            payload.pop("support_pickup", None)
             payload.setdefault("postage", 0)
+            if payload["delivery_method"] == "pickup":
+                payload["postage"] = 0
             if not payload["title"]:
                 raise ValueError("AI未返回商品标题")
             if not payload["description"]:

--- a/backend-web/app/services/ai_listing_task_status_service.py
+++ b/backend-web/app/services/ai_listing_task_status_service.py
@@ -1,0 +1,213 @@
+"""
+AI铺货任务状态缓存服务
+
+后台生成素材时维护进度，供前端轮询展示。
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from copy import deepcopy
+from typing import Any
+
+
+class AiListingTaskStatusService:
+    """AI铺货任务的内存状态缓存"""
+
+    _lock = asyncio.Lock()
+    _cache: dict[str, dict[str, Any]] = {}
+    _ttl_seconds = 24 * 60 * 60
+    _STAGE_WEIGHTS = {
+        "text": 0.25,
+        "image_polish": 0.25,
+        "image_generate": 0.40,
+        "material_create": 0.10,
+    }
+
+    @classmethod
+    async def init_task(cls, task_id: str, user_id: int, config_id: int, total: int, config_name: str = "") -> None:
+        async with cls._lock:
+            cls._cleanup_locked()
+            cls._cache[task_id] = {
+                "task_id": task_id,
+                "user_id": user_id,
+                "config_id": config_id,
+                "config_name": str(config_name or "").strip(),
+                "total": total,
+                "current": 0,
+                "success": 0,
+                "failed": 0,
+                "status": "pending",
+                "message": "等待开始",
+                "progress_percent": 0.0,
+                "active_stage": "pending",
+                "stage_label": "等待开始",
+                "stage_detail": "",
+                "step_counts": {
+                    "text": {"done": 0, "total": total},
+                    "image_polish": {"done": 0, "total": total},
+                    "image_generate": {"done": 0, "total": total},
+                    "material_create": {"done": 0, "total": total},
+                },
+                "created_material_ids": [],
+                "errors": [],
+                "finished": False,
+                "last_access": time.time(),
+            }
+
+    @classmethod
+    async def mark_running(cls, task_id: str, message: str = "正在生成素材") -> None:
+        await cls.update_task(
+            task_id,
+            status="running",
+            message=message,
+            active_stage="running",
+            stage_label=message,
+            finished=False,
+        )
+
+    @classmethod
+    async def update_stage(
+        cls,
+        task_id: str,
+        stage: str,
+        label: str,
+        detail: str = "",
+        increment: bool = False,
+    ) -> None:
+        async with cls._lock:
+            record = cls._cache.get(task_id)
+            if not record:
+                return
+            step_counts = record.setdefault("step_counts", {})
+            if stage not in step_counts:
+                total = int(record.get("total") or 0)
+                step_counts[stage] = {"done": 0, "total": total}
+            if increment:
+                stage_item = step_counts[stage]
+                stage_item["done"] = min(
+                    int(stage_item.get("done") or 0) + 1,
+                    int(stage_item.get("total") or 0),
+                )
+            record["active_stage"] = stage
+            record["stage_label"] = label
+            record["stage_detail"] = detail
+            record["message"] = detail or label
+            record["status"] = "running"
+            record["progress_percent"] = cls._compute_progress_percent(record)
+            record["last_access"] = time.time()
+
+    @classmethod
+    async def add_success(cls, task_id: str, material_id: int, message: str = "素材创建成功") -> None:
+        async with cls._lock:
+            record = cls._cache.get(task_id)
+            if not record:
+                return
+            record["current"] = int(record.get("current") or 0) + 1
+            record["success"] = int(record.get("success") or 0) + 1
+            step_counts = record.setdefault("step_counts", {})
+            material_stage = step_counts.setdefault(
+                "material_create",
+                {"done": 0, "total": int(record.get("total") or 0)},
+            )
+            material_stage["done"] = min(
+                int(material_stage.get("done") or 0) + 1,
+                int(material_stage.get("total") or 0),
+            )
+            record.setdefault("created_material_ids", []).append(material_id)
+            record["message"] = message
+            record["status"] = "running"
+            record["active_stage"] = "material_create"
+            record["stage_label"] = "素材入库完成"
+            record["stage_detail"] = message
+            record["progress_percent"] = cls._compute_progress_percent(record)
+            record["last_access"] = time.time()
+
+    @classmethod
+    async def add_failed(cls, task_id: str, error: str) -> None:
+        async with cls._lock:
+            record = cls._cache.get(task_id)
+            if not record:
+                return
+            record["current"] = int(record.get("current") or 0) + 1
+            record["failed"] = int(record.get("failed") or 0) + 1
+            errors = record.setdefault("errors", [])
+            errors.append(str(error)[:500])
+            record["message"] = str(error)[:200]
+            record["status"] = "running"
+            record["stage_detail"] = str(error)[:200]
+            record["progress_percent"] = cls._compute_progress_percent(record)
+            record["last_access"] = time.time()
+
+    @classmethod
+    async def finish(cls, task_id: str, status: str, message: str) -> None:
+        await cls.update_task(
+            task_id,
+            status=status,
+            message=message,
+            active_stage="finished",
+            stage_label="任务完成",
+            stage_detail=message,
+            progress_percent=100.0,
+            finished=True,
+        )
+
+    @classmethod
+    async def update_task(cls, task_id: str, **kwargs: Any) -> None:
+        async with cls._lock:
+            record = cls._cache.get(task_id)
+            if not record:
+                return
+            record.update(kwargs)
+            if "progress_percent" not in kwargs:
+                record["progress_percent"] = cls._compute_progress_percent(record)
+            record["last_access"] = time.time()
+
+    @classmethod
+    async def get_task_snapshot(cls, task_id: str) -> dict[str, Any] | None:
+        async with cls._lock:
+            cls._cleanup_locked()
+            record = cls._cache.get(task_id)
+            if not record:
+                return None
+            record["last_access"] = time.time()
+            snapshot = deepcopy(record)
+            snapshot.pop("last_access", None)
+            return snapshot
+
+    @classmethod
+    async def list_user_tasks(cls, user_id: int) -> list[dict[str, Any]]:
+        async with cls._lock:
+            cls._cleanup_locked()
+            tasks: list[dict[str, Any]] = []
+            for record in cls._cache.values():
+                if int(record.get("user_id") or 0) != int(user_id):
+                    continue
+                record["last_access"] = time.time()
+                snapshot = deepcopy(record)
+                snapshot.pop("last_access", None)
+                tasks.append(snapshot)
+            tasks.sort(key=lambda item: (bool(item.get("finished")), item.get("task_id", "")))
+            return tasks
+
+    @classmethod
+    def _cleanup_locked(cls) -> None:
+        now = time.time()
+        expired_ids = [
+            task_id
+            for task_id, record in cls._cache.items()
+            if now - float(record.get("last_access") or 0) > cls._ttl_seconds
+        ]
+        for task_id in expired_ids:
+            cls._cache.pop(task_id, None)
+
+    @classmethod
+    def _compute_progress_percent(cls, record: dict[str, Any]) -> float:
+        step_counts = record.get("step_counts") or {}
+        progress = 0.0
+        for stage, weight in cls._STAGE_WEIGHTS.items():
+            stage_item = step_counts.get(stage) or {}
+            total = max(1, int(stage_item.get("total") or record.get("total") or 1))
+            done = min(int(stage_item.get("done") or 0), total)
+            progress += (done / total) * weight
+        return round(min(progress, 1.0) * 100, 2)

--- a/backend-web/app/services/product_publish_service.py
+++ b/backend-web/app/services/product_publish_service.py
@@ -34,7 +34,8 @@ class ProductMaterialService:
             original_price=float(data["original_price"]) if data.get("original_price") else None,
             category=data.get("category"),
             images=data.get("images", []),
-            delivery_method=data.get("delivery_method", "express"),
+            delivery_method=data.get("delivery_method", "free_shipping"),
+            support_pickup=bool(data.get("support_pickup", False)),
             postage=float(data.get("postage", 0)),
             address=data.get("address"),
             brand=data.get("brand"),
@@ -129,7 +130,7 @@ class ProductMaterialService:
 
         updatable = [
             "title", "description", "price", "original_price", "category",
-            "images", "delivery_method", "postage", "address", "brand",
+            "images", "delivery_method", "support_pickup", "postage", "address", "brand",
             "condition", "remark",
         ]
         for field in updatable:
@@ -137,6 +138,8 @@ class ProductMaterialService:
                 value = data[field]
                 if field in ("price", "original_price", "postage"):
                     value = float(value) if value else (None if field == "original_price" else 0)
+                elif field == "support_pickup":
+                    value = bool(value)
                 setattr(material, field, value)
 
         await self.session.commit()
@@ -185,6 +188,7 @@ def _material_to_dict(m: ProductMaterial) -> dict:
         "category": m.category,
         "images": m.images or [],
         "delivery_method": m.delivery_method,
+        "support_pickup": bool(getattr(m, "support_pickup", False)),
         "postage": float(m.postage) if m.postage is not None else 0,
         "address": m.address,
         "brand": m.brand,

--- a/backend-web/app/services/publish_execution_service.py
+++ b/backend-web/app/services/publish_execution_service.py
@@ -89,6 +89,17 @@ class PublishLogService:
                 log.error_message = str(error_message)[:1000]
             await self.session.commit()
 
+    async def get_log(
+        self,
+        log_id: int,
+        user_id: int | None = None,
+    ) -> PublishLog | None:
+        """查询单条发布日志"""
+        stmt = select(PublishLog).where(PublishLog.id == log_id)
+        if user_id is not None:
+            stmt = stmt.where(PublishLog.user_id == user_id)
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
     async def list_logs(
         self,
         user_id: int = None,

--- a/backend-web/app/services/xianyu_publisher.py
+++ b/backend-web/app/services/xianyu_publisher.py
@@ -363,6 +363,8 @@ class XianyuPublisher:
             await asyncio.sleep(1)
 
             await self._set_delivery_method(item_data)
+            await self._fill_postage(item_data)
+            await self._set_support_pickup(item_data)
 
             await self._set_item_address(item_data)
 
@@ -1577,57 +1579,80 @@ class XianyuPublisher:
             logger.info("ℹ️ 未设置原价，跳过")
 
     async def _set_delivery_method(self, item_data: dict):
-        """按素材配置选择发货方式。
+        """按素材配置选择发货方式"""
+        delivery_method = str(item_data.get("delivery_method") or "free_shipping").strip().lower()
+        delivery_method_map = {
+            "free_shipping": "0",
+            "express": "0",
+            "distance_billing": "1",
+            "fixed_fee": "2",
+            "no_shipping": "3",
+            "virtual": "3",
+        }
+        radio_value = delivery_method_map.get(delivery_method, "0")
 
-        旧流程没有真正区分 express/pickup，统一点选「包邮」。配置为 virtual 时，
-        直接选择闲鱼发布页固定的「无需邮寄」单选项。
-        """
-        delivery_method = str(item_data.get("delivery_method") or "express").strip().lower()
-        if delivery_method == "virtual":
-            await self._set_no_shipping()
+        logger.info(f"\n[步骤12] 🚚 设置发货方式: {delivery_method} (value={radio_value})...")
+
+        delivery_radio = self.page.locator(f'label:has(input.ant-radio-input[value="{radio_value}"])').first
+        if await delivery_radio.count() == 0:
+            raise Exception(f'未找到发货方式选项 input.ant-radio-input[value="{radio_value}"]')
+
+        await delivery_radio.click()
+        logger.info("✅ 已选择发货方式")
+
+    async def _fill_postage(self, item_data: dict):
+        """填写一口价运费"""
+        delivery_method = str(item_data.get("delivery_method") or "free_shipping").strip().lower()
+        if delivery_method != "fixed_fee":
             return
 
-        await self._set_free_shipping()
+        postage = item_data.get("postage", 0)
+        logger.info(f"\n[步骤12.05] 🚚 输入一口价运费: {postage}")
 
-    async def _set_no_shipping(self):
-        """设置发货方式为无需邮寄"""
-        logger.info("\n[步骤12] 🚚 设置发货方式为无需邮寄...")
-
-        no_shipping_radio = self.page.locator('label:has(input.ant-radio-input[value="3"])').first
-        if await no_shipping_radio.count() == 0:
-            raise Exception("未找到无需邮寄选项 input.ant-radio-input[value=\"3\"]")
-
-        await no_shipping_radio.click()
-        logger.info("✅ 已选择无需邮寄")
-
-    async def _set_free_shipping(self) -> bool:
-        """设置发货方式为包邮（按原项目流程）"""
-        logger.info("\n[步骤12] 🚚 设置发货方式为包邮...")
-
-        free_shipping_selectors = [
-            'button:has-text("包邮")',
-            'div:has-text("包邮")',
-            '[class*="free-shipping"]',
-            '[class*="包邮"]',
+        postage_selectors = [
+            'input[placeholder*="邮费"]',
+            'input[placeholder*="运费"]',
+            'xpath=//*[contains(normalize-space(.), "邮费")]/following::input[1]',
+            'xpath=//*[contains(normalize-space(.), "运费")]/following::input[1]',
         ]
 
-        free_shipping_btn = None
-        for selector in free_shipping_selectors:
+        postage_input = None
+        for selector in postage_selectors:
             try:
-                free_shipping_btn = await self.page.query_selector(selector)
-                if free_shipping_btn:
-                    logger.info(f"✅ 找到包邮按钮: {selector}")
+                postage_input = await self.page.wait_for_selector(selector, timeout=2000)
+                if postage_input:
+                    logger.info(f"✅ 找到运费输入框: {selector}")
                     break
             except Exception:
                 continue
 
-        if free_shipping_btn:
-            await free_shipping_btn.click()
-            logger.info("✅ 已选择包邮")
-            return True
+        if not postage_input:
+            raise Exception("未找到一口价运费输入框")
 
-        logger.warning("⚠️ 未找到包邮按钮")
-        return False
+        await postage_input.fill(str(postage))
+        logger.info("✅ 已输入一口价运费")
+
+    async def _set_support_pickup(self, item_data: dict):
+        """设置支持自提开关"""
+        support_pickup = bool(item_data.get("support_pickup"))
+
+        logger.info(f"\n[步骤12.1] 🚚 设置支持自提: {'开启' if support_pickup else '关闭'}...")
+
+        pickup_switch = self.page.locator('div:has-text("支持自提")').locator('xpath=following-sibling::button[@role="switch"][1]').first
+        if await pickup_switch.count() == 0:
+            raise Exception('未找到支持自提开关 button[role="switch"]')
+
+        is_checked = (await pickup_switch.get_attribute("aria-checked")) == "true"
+        if is_checked == support_pickup:
+            logger.info("✅ 支持自提状态已符合预期")
+            return
+
+        await pickup_switch.click()
+        updated_checked = (await pickup_switch.get_attribute("aria-checked")) == "true"
+        if updated_checked != support_pickup:
+            raise Exception("切换支持自提开关失败")
+
+        logger.info(f"✅ 已{'开启' if support_pickup else '关闭'}支持自提")
 
     async def _click_publish_button(self, result: dict):
         """点击发布按钮并等待发布结果（按原项目流程）"""

--- a/backend-web/app/services/xianyu_publisher.py
+++ b/backend-web/app/services/xianyu_publisher.py
@@ -362,7 +362,7 @@ class XianyuPublisher:
             logger.info("\n[步骤11] ⏭️ 跳过服务选择...")
             await asyncio.sleep(1)
 
-            await self._set_free_shipping()
+            await self._set_delivery_method(item_data)
 
             await self._set_item_address(item_data)
 
@@ -1576,7 +1576,31 @@ class XianyuPublisher:
         else:
             logger.info("ℹ️ 未设置原价，跳过")
 
-    async def _set_free_shipping(self):
+    async def _set_delivery_method(self, item_data: dict):
+        """按素材配置选择发货方式。
+
+        旧流程没有真正区分 express/pickup，统一点选「包邮」。配置为 virtual 时，
+        直接选择闲鱼发布页固定的「无需邮寄」单选项。
+        """
+        delivery_method = str(item_data.get("delivery_method") or "express").strip().lower()
+        if delivery_method == "virtual":
+            await self._set_no_shipping()
+            return
+
+        await self._set_free_shipping()
+
+    async def _set_no_shipping(self):
+        """设置发货方式为无需邮寄"""
+        logger.info("\n[步骤12] 🚚 设置发货方式为无需邮寄...")
+
+        no_shipping_radio = self.page.locator('label:has(input.ant-radio-input[value="3"])').first
+        if await no_shipping_radio.count() == 0:
+            raise Exception("未找到无需邮寄选项 input.ant-radio-input[value=\"3\"]")
+
+        await no_shipping_radio.click()
+        logger.info("✅ 已选择无需邮寄")
+
+    async def _set_free_shipping(self) -> bool:
         """设置发货方式为包邮（按原项目流程）"""
         logger.info("\n[步骤12] 🚚 设置发货方式为包邮...")
 
@@ -1600,8 +1624,10 @@ class XianyuPublisher:
         if free_shipping_btn:
             await free_shipping_btn.click()
             logger.info("✅ 已选择包邮")
-        else:
-            logger.warning("⚠️ 未找到包邮按钮")
+            return True
+
+        logger.warning("⚠️ 未找到包邮按钮")
+        return False
 
     async def _click_publish_button(self, result: dict):
         """点击发布按钮并等待发布结果（按原项目流程）"""

--- a/common/db/init_database.py
+++ b/common/db/init_database.py
@@ -1176,7 +1176,8 @@ class DatabaseInitializer:
                 original_price DECIMAL(12,2) DEFAULT NULL COMMENT '原价（划线价）',
                 category VARCHAR(100) DEFAULT NULL COMMENT '商品分类',
                 images JSON DEFAULT NULL COMMENT '图片URL列表（最多9张）',
-                delivery_method VARCHAR(20) DEFAULT 'express' COMMENT '发货方式：express-快递, pickup-自提, virtual-无需邮寄',
+                delivery_method VARCHAR(20) DEFAULT 'free_shipping' COMMENT '发货方式：free_shipping-包邮, distance_billing-按距离计费, fixed_fee-一口价, no_shipping-无需邮寄',
+                support_pickup TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否支持自提：1是 0否',
                 postage DECIMAL(8,2) DEFAULT 0 COMMENT '邮费，0表示包邮',
                 address VARCHAR(200) DEFAULT NULL COMMENT '宝贝所在地',
                 brand VARCHAR(100) DEFAULT NULL COMMENT '品牌',
@@ -1799,6 +1800,9 @@ class DatabaseInitializer:
             ("resolved_address_id", "BIGINT DEFAULT NULL COMMENT '本次发布命中的地址池ID'", "error_message"),
             ("resolved_address_text", "VARCHAR(200) DEFAULT NULL COMMENT '本次发布实际使用的地址搜索词'", "resolved_address_id"),
             ("address_source", "VARCHAR(20) DEFAULT NULL COMMENT '地址来源：material/account_pool/global_pool'", "resolved_address_text"),
+        ],
+        "xy_product_materials": [
+            ("support_pickup", "TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否支持自提：1是 0否'", "delivery_method"),
         ],
         "xy_account_login_logs": [
             ("updated_cookie_names", "VARCHAR(500) DEFAULT NULL COMMENT '接口续期更新的Cookie字段名（逗号分隔）'", "error_message"),

--- a/common/db/init_database.py
+++ b/common/db/init_database.py
@@ -1176,7 +1176,7 @@ class DatabaseInitializer:
                 original_price DECIMAL(12,2) DEFAULT NULL COMMENT '原价（划线价）',
                 category VARCHAR(100) DEFAULT NULL COMMENT '商品分类',
                 images JSON DEFAULT NULL COMMENT '图片URL列表（最多9张）',
-                delivery_method VARCHAR(20) DEFAULT 'express' COMMENT '发货方式：express-快递, pickup-自提',
+                delivery_method VARCHAR(20) DEFAULT 'express' COMMENT '发货方式：express-快递, pickup-自提, virtual-无需邮寄',
                 postage DECIMAL(8,2) DEFAULT 0 COMMENT '邮费，0表示包邮',
                 address VARCHAR(200) DEFAULT NULL COMMENT '宝贝所在地',
                 brand VARCHAR(100) DEFAULT NULL COMMENT '品牌',

--- a/common/db/init_database.py
+++ b/common/db/init_database.py
@@ -1190,6 +1190,39 @@ class DatabaseInitializer:
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='商品素材库表';
         """,
 
+        # 37.1 AI铺货配置表
+        "xy_ai_listing_configs": """
+            CREATE TABLE IF NOT EXISTS xy_ai_listing_configs (
+                id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '主键ID',
+                user_id BIGINT NOT NULL COMMENT '所属用户ID',
+                name VARCHAR(100) NOT NULL COMMENT '配置名称',
+                prompt TEXT NOT NULL COMMENT '商品生成提示词',
+                reference_text TEXT DEFAULT NULL COMMENT '参考文案',
+                price_mode VARCHAR(20) DEFAULT 'fixed' COMMENT '价格模式：fixed/range',
+                fixed_price DECIMAL(12,2) DEFAULT NULL COMMENT '固定价格',
+                price_min DECIMAL(12,2) DEFAULT NULL COMMENT '最低价格',
+                price_max DECIMAL(12,2) DEFAULT NULL COMMENT '最高价格',
+                text_api_url VARCHAR(500) NOT NULL COMMENT '文案AI接口地址',
+                text_api_key TEXT NOT NULL COMMENT '文案AI Key',
+                text_model VARCHAR(120) NOT NULL COMMENT '文案AI模型',
+                image_mode VARCHAR(20) DEFAULT 'random' COMMENT '图片模式：ai/random',
+                image_api_url VARCHAR(500) DEFAULT NULL COMMENT '图片AI接口地址',
+                image_api_key TEXT DEFAULT NULL COMMENT '图片AI Key',
+                image_model VARCHAR(120) DEFAULT NULL COMMENT '图片AI模型',
+                image_prompt TEXT DEFAULT NULL COMMENT '图片生成提示词',
+                image_polish_enabled TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否启用图片提示词AI润色',
+                image_polish_sequential TINYINT(1) NOT NULL DEFAULT 0 COMMENT '多图是否保持关联',
+                random_images JSON DEFAULT NULL COMMENT '随机图库',
+                random_image_count INT DEFAULT 1 COMMENT '随机选图数量',
+                material_defaults JSON DEFAULT NULL COMMENT '素材默认字段',
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+                INDEX idx_user_id (user_id),
+                INDEX idx_created_at (created_at),
+                INDEX idx_ai_listing_user_created (user_id, created_at)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI铺货配置表';
+        """,
+
         # 38.1 定时求小红花执行日志表
         "xy_scheduled_red_flower_log": """
             CREATE TABLE IF NOT EXISTS `xy_scheduled_red_flower_log` (
@@ -1645,6 +1678,10 @@ class DatabaseInitializer:
             ("publish_days", "INT DEFAULT NULL COMMENT '上新天数筛选（searchFilter 的 publishDays，单位天，NULL/0=不限）'", "price_max"),
             ("proxy_url", "VARCHAR(255) DEFAULT NULL COMMENT '代理API地址（GET返回IP:PORT列表，取一个作HTTP代理；空=不使用代理）'", "collect_pages"),
             ("direct_order", "TINYINT(1) NOT NULL DEFAULT 0 COMMENT '采集后是否直接下单（开启则新采集商品立即用下单账号下单后再入库）'", "order_batch_size"),
+        ],
+        "xy_ai_listing_configs": [
+            ("image_polish_enabled", "TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否启用图片提示词AI润色'", "image_prompt"),
+            ("image_polish_sequential", "TINYINT(1) NOT NULL DEFAULT 0 COMMENT '多图是否保持关联'", "image_polish_enabled"),
         ],
         "xy_listing_monitor_logs": [
             ("used_account_ids", "JSON DEFAULT NULL COMMENT '本次执行实际使用过的账号ID列表（可能多个）'", "account_id"),

--- a/common/models/_exports.py
+++ b/common/models/_exports.py
@@ -41,6 +41,7 @@ from common.models.dock_code_binding import DockCodeBinding
 from common.models.agent_order import AgentOrder
 from common.models.settlement_record import SettlementRecord
 from common.models.product_material import ProductMaterial
+from common.models.ai_listing_config import AiListingConfig
 from common.models.publish_log import PublishLog
 from common.models.publish_address import PublishAddress
 from common.models.user_publish_address import UserPublishAddress
@@ -107,6 +108,7 @@ __all__ = [
     "SettlementRecord",
     "AgentOrder",
     "ProductMaterial",
+    "AiListingConfig",
     "PublishLog",
     "PublishAddress",
     "UserPublishAddress",

--- a/common/models/ai_listing_config.py
+++ b/common/models/ai_listing_config.py
@@ -1,0 +1,43 @@
+"""
+AI铺货配置模型
+
+保存用户的AI铺货参数，用于批量生成商品素材。
+"""
+from __future__ import annotations
+
+from sqlalchemy import BigInteger, Boolean, Index, Integer, JSON, Numeric, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from common.db.base_class import Base, TimestampMixin
+
+
+class AiListingConfig(TimestampMixin, Base):
+    """AI铺货配置表"""
+
+    __tablename__ = "xy_ai_listing_configs"
+    __table_args__ = (
+        Index("idx_ai_listing_user_created", "user_id", "created_at"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True, comment="主键ID")
+    user_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True, comment="所属用户ID")
+    name: Mapped[str] = mapped_column(String(100), nullable=False, comment="配置名称")
+    prompt: Mapped[str] = mapped_column(Text, nullable=False, comment="商品生成提示词")
+    reference_text: Mapped[str | None] = mapped_column(Text, comment="参考文案")
+    price_mode: Mapped[str] = mapped_column(String(20), default="fixed", comment="价格模式：fixed/range")
+    fixed_price: Mapped[float | None] = mapped_column(Numeric(12, 2), comment="固定价格")
+    price_min: Mapped[float | None] = mapped_column(Numeric(12, 2), comment="最低价格")
+    price_max: Mapped[float | None] = mapped_column(Numeric(12, 2), comment="最高价格")
+    text_api_url: Mapped[str] = mapped_column(String(500), nullable=False, comment="文案AI接口地址")
+    text_api_key: Mapped[str] = mapped_column(Text, nullable=False, comment="文案AI Key")
+    text_model: Mapped[str] = mapped_column(String(120), nullable=False, comment="文案AI模型")
+    image_mode: Mapped[str] = mapped_column(String(20), default="random", comment="图片模式：ai/random")
+    image_api_url: Mapped[str | None] = mapped_column(String(500), comment="图片AI接口地址")
+    image_api_key: Mapped[str | None] = mapped_column(Text, comment="图片AI Key")
+    image_model: Mapped[str | None] = mapped_column(String(120), comment="图片AI模型")
+    image_prompt: Mapped[str | None] = mapped_column(Text, comment="图片生成提示词")
+    image_polish_enabled: Mapped[bool] = mapped_column(Boolean, default=False, comment="是否启用图片提示词AI润色")
+    image_polish_sequential: Mapped[bool] = mapped_column(Boolean, default=False, comment="多图是否保持关联")
+    random_images: Mapped[list | None] = mapped_column(JSON, comment="随机图库")
+    random_image_count: Mapped[int] = mapped_column(Integer, default=1, comment="随机选图数量")
+    material_defaults: Mapped[dict | None] = mapped_column(JSON, comment="素材默认字段")

--- a/common/models/product_material.py
+++ b/common/models/product_material.py
@@ -30,7 +30,7 @@ class ProductMaterial(TimestampMixin, Base):
     original_price: Mapped[float | None] = mapped_column(Numeric(12, 2), comment="原价")
     category: Mapped[str | None] = mapped_column(String(100), comment="商品分类")
     images: Mapped[list | None] = mapped_column(JSON, comment="图片URL列表（最多9张）")
-    delivery_method: Mapped[str] = mapped_column(String(20), default="express", comment="发货方式：express-快递, pickup-自提")
+    delivery_method: Mapped[str] = mapped_column(String(20), default="express", comment="发货方式：express-快递, pickup-自提, virtual-无需邮寄")
     postage: Mapped[float] = mapped_column(Numeric(8, 2), default=0, comment="邮费，0表示包邮")
     address: Mapped[str | None] = mapped_column(String(200), comment="宝贝所在地")
     brand: Mapped[str | None] = mapped_column(String(100), comment="品牌")

--- a/common/models/product_material.py
+++ b/common/models/product_material.py
@@ -8,7 +8,7 @@
 """
 from __future__ import annotations
 
-from sqlalchemy import BigInteger, Index, JSON, Numeric, String, Text
+from sqlalchemy import BigInteger, Boolean, Index, JSON, Numeric, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from common.db.base_class import Base, TimestampMixin
@@ -30,7 +30,8 @@ class ProductMaterial(TimestampMixin, Base):
     original_price: Mapped[float | None] = mapped_column(Numeric(12, 2), comment="原价")
     category: Mapped[str | None] = mapped_column(String(100), comment="商品分类")
     images: Mapped[list | None] = mapped_column(JSON, comment="图片URL列表（最多9张）")
-    delivery_method: Mapped[str] = mapped_column(String(20), default="express", comment="发货方式：express-快递, pickup-自提, virtual-无需邮寄")
+    delivery_method: Mapped[str] = mapped_column(String(20), default="free_shipping", comment="发货方式：free_shipping-包邮, distance_billing-按距离计费, fixed_fee-一口价, no_shipping-无需邮寄")
+    support_pickup: Mapped[bool] = mapped_column(Boolean, default=False, comment="是否支持自提：1是 0否")
     postage: Mapped[float] = mapped_column(Numeric(8, 2), default=0, comment="邮费，0表示包邮")
     address: Mapped[str | None] = mapped_column(String(200), comment="宝贝所在地")
     brand: Mapped[str | None] = mapped_column(String(100), comment="品牌")

--- a/common/services/ai_provider_service.py
+++ b/common/services/ai_provider_service.py
@@ -8,6 +8,7 @@ AI服务商工具
 """
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import httpx
@@ -185,8 +186,12 @@ def normalize_openai_base_url(base_url: str) -> str:
     base = base.rstrip("/")
     if base.endswith("/chat/completions"):
         base = base[: -len("/chat/completions")]
+    if base.endswith("/images/generations"):
+        base = base[: -len("/images/generations")]
     if base.endswith("/models"):
         base = base[: -len("/models")]
+    if not re.search(r"/v[0-9A-Za-z._-]+$", base):
+        base = f"{base}/v1"
     return base
 
 

--- a/frontend/src/api/productPublish.ts
+++ b/frontend/src/api/productPublish.ts
@@ -55,8 +55,7 @@ export interface AiListingMaterialDefaults {
   category?: string
   condition?: string
   brand?: string
-  delivery_method?: ProductDeliveryMethod
-  support_pickup?: boolean
+  delivery_method?: 'express' | 'pickup'
   postage?: number
   address?: string
   remark?: string

--- a/frontend/src/api/productPublish.ts
+++ b/frontend/src/api/productPublish.ts
@@ -48,6 +48,90 @@ export interface MaterialCreateParams {
   remark?: string
 }
 
+export type AiListingPriceMode = 'fixed' | 'range'
+export type AiListingImageMode = 'ai' | 'random'
+
+export interface AiListingMaterialDefaults {
+  category?: string
+  condition?: string
+  brand?: string
+  delivery_method?: ProductDeliveryMethod
+  support_pickup?: boolean
+  postage?: number
+  address?: string
+  remark?: string
+}
+
+export interface AiListingConfig {
+  id: number
+  user_id: number
+  name: string
+  prompt: string
+  reference_text?: string | null
+  price_mode: AiListingPriceMode
+  fixed_price?: number | null
+  price_min?: number | null
+  price_max?: number | null
+  text_api_url: string
+  text_api_key: string
+  text_model: string
+  image_mode: AiListingImageMode
+  image_api_url?: string | null
+  image_api_key?: string | null
+  image_model?: string | null
+  image_prompt?: string | null
+  image_polish_enabled: boolean
+  image_polish_sequential: boolean
+  random_images: string[]
+  random_image_count: number
+  material_defaults: AiListingMaterialDefaults
+  created_at: string
+  updated_at: string
+}
+
+export interface AiListingConfigParams {
+  name: string
+  prompt: string
+  reference_text?: string
+  price_mode: AiListingPriceMode
+  fixed_price?: number | null
+  price_min?: number | null
+  price_max?: number | null
+  text_api_url: string
+  text_api_key: string
+  text_model: string
+  image_mode: AiListingImageMode
+  image_api_url?: string
+  image_api_key?: string
+  image_model?: string
+  image_prompt?: string
+  image_polish_enabled: boolean
+  image_polish_sequential: boolean
+  random_images: string[]
+  random_image_count: number
+  material_defaults: AiListingMaterialDefaults
+}
+
+export interface AiListingTaskStatus {
+  task_id: string
+  config_id: number
+  config_name?: string
+  total: number
+  current: number
+  success: number
+  failed: number
+  status: 'pending' | 'running' | 'success' | 'failed' | 'partial_success'
+  message: string
+  progress_percent?: number
+  active_stage?: string
+  stage_label?: string
+  stage_detail?: string
+  step_counts?: Record<string, { done: number; total: number }>
+  created_material_ids: number[]
+  errors: string[]
+  finished: boolean
+}
+
 export interface MaterialListResponse {
   success: boolean
   message: string
@@ -180,6 +264,35 @@ export const deleteMaterial = (id: number): Promise<ApiResponse> =>
 export const batchDeleteMaterials = (ids: number[]): Promise<ApiResponse> =>
   post(`${PREFIX}/materials/batch-delete`, { ids })
 
+// ==================== AI铺货接口 ====================
+
+export const getAiListingConfigs = (): Promise<ApiResponse<AiListingConfig[]>> =>
+  get(`${PREFIX}/ai-listing/configs`)
+
+export const createAiListingConfig = (params: AiListingConfigParams): Promise<ApiResponse<AiListingConfig>> =>
+  post(`${PREFIX}/ai-listing/configs`, params)
+
+export const updateAiListingConfig = (
+  id: number,
+  params: AiListingConfigParams
+): Promise<ApiResponse<AiListingConfig>> => put(`${PREFIX}/ai-listing/configs/${id}`, params)
+
+export const deleteAiListingConfig = (id: number): Promise<ApiResponse> =>
+  del(`${PREFIX}/ai-listing/configs/${id}`)
+
+export const startAiListingGeneration = (
+  configId: number,
+  count: number,
+  concurrency: number
+): Promise<ApiResponse<{ task_id: string; total: number }>> =>
+  post(`${PREFIX}/ai-listing/configs/${configId}/generate`, { count, concurrency })
+
+export const getAiListingTaskStatus = (taskId: string): Promise<ApiResponse<AiListingTaskStatus>> =>
+  get(`${PREFIX}/ai-listing/tasks/${taskId}/status`)
+
+export const getAiListingTasks = (): Promise<ApiResponse<AiListingTaskStatus[]>> =>
+  get(`${PREFIX}/ai-listing/tasks`)
+
 // ==================== 发布接口 ====================
 
 /** 单品发布（同步，超时时间需设长） */
@@ -239,6 +352,10 @@ export const getPublishLogs = (
   if (status) params.append('status', status)
   return get(`${PREFIX}/logs?${params}`)
 }
+
+/** 查询单条发布日志 */
+export const getPublishLog = (logId: number): Promise<ApiResponse<PublishLog>> =>
+  get(`${PREFIX}/logs/${logId}`)
 
 export const clearPublishLogs = async (): Promise<{ success: boolean; message: string }> => {
   return del<{ success: boolean; message: string }>(`${PREFIX}/logs/clear`)

--- a/frontend/src/api/productPublish.ts
+++ b/frontend/src/api/productPublish.ts
@@ -13,7 +13,7 @@ const PREFIX = '/api/v1/product-publish'
 
 // ==================== 类型定义 ====================
 
-export type ProductDeliveryMethod = 'express' | 'pickup' | 'virtual'
+export type ProductDeliveryMethod = 'free_shipping' | 'distance_billing' | 'fixed_fee' | 'no_shipping'
 
 export interface ProductMaterial {
   id: number
@@ -26,6 +26,7 @@ export interface ProductMaterial {
   category?: string | null
   images: string[]
   delivery_method: ProductDeliveryMethod
+  support_pickup: boolean
   postage: number
   address?: string | null
   brand?: string | null
@@ -43,6 +44,7 @@ export interface MaterialCreateParams {
   category?: string
   images: string[]
   delivery_method?: ProductDeliveryMethod
+  support_pickup?: boolean
   postage?: number
   address?: string
   brand?: string
@@ -195,6 +197,7 @@ export const publishSingle = (params: {
   images: string[]        // 本地绝对路径，由 uploadProductImages 返回
   address?: string
   delivery_method?: string
+  support_pickup?: boolean
   postage?: number
   brand?: string
   condition?: string

--- a/frontend/src/api/productPublish.ts
+++ b/frontend/src/api/productPublish.ts
@@ -13,6 +13,8 @@ const PREFIX = '/api/v1/product-publish'
 
 // ==================== 类型定义 ====================
 
+export type ProductDeliveryMethod = 'express' | 'pickup' | 'virtual'
+
 export interface ProductMaterial {
   id: number
   user_id: number
@@ -23,7 +25,7 @@ export interface ProductMaterial {
   original_price?: number | null
   category?: string | null
   images: string[]
-  delivery_method: 'express' | 'pickup'
+  delivery_method: ProductDeliveryMethod
   postage: number
   address?: string | null
   brand?: string | null
@@ -40,7 +42,7 @@ export interface MaterialCreateParams {
   original_price?: number | null
   category?: string
   images: string[]
-  delivery_method?: 'express' | 'pickup'
+  delivery_method?: ProductDeliveryMethod
   postage?: number
   address?: string
   brand?: string

--- a/frontend/src/pages/product-publish/AiListingModal.tsx
+++ b/frontend/src/pages/product-publish/AiListingModal.tsx
@@ -16,6 +16,11 @@ import {
 const CONDITIONS = ['全新', '99新', '95新', '9成新', '8成新', '7成新以下']
 const CATEGORIES = ['数码家电', '服饰鞋包', '家居日用', '图书音像', '美妆个护', '母婴用品', '运动户外', '食品生鲜', '虚拟商品', '其他']
 
+function normalizeMoney(value: number | null | undefined): number | null | undefined {
+  if (value === null || value === undefined || Number.isNaN(value)) return value
+  return Math.round(value * 100) / 100
+}
+
 const defaultForm: AiListingConfigParams = {
   name: '',
   prompt: '',
@@ -169,9 +174,9 @@ export function AiListingModal({ onClose, onTaskStarted }: Props) {
     if (!form.name.trim()) return '请填写配置名称'
     if (!form.prompt.trim()) return '请填写商品生成提示词'
     if (!form.text_api_url.trim() || !form.text_api_key.trim() || !form.text_model.trim()) return '请填写文案AI配置'
-    if (form.price_mode === 'fixed' && (!form.fixed_price || form.fixed_price <= 0)) return '请填写有效固定价格'
+    if (form.price_mode === 'fixed' && (!form.fixed_price || form.fixed_price < 0.01)) return '固定价格最小为0.01'
     if (form.price_mode === 'range') {
-      if (!form.price_min || !form.price_max || form.price_min <= 0 || form.price_max <= 0) return '请填写有效价格范围'
+      if (!form.price_min || !form.price_max || form.price_min < 0.01 || form.price_max < 0.01) return '价格范围最小为0.01'
       if (form.price_max < form.price_min) return '最高价格不能小于最低价格'
     }
     if (form.image_mode === 'random') {
@@ -201,11 +206,16 @@ export function AiListingModal({ onClose, onTaskStarted }: Props) {
     try {
       const payload = {
         ...form,
+        fixed_price: normalizeMoney(form.fixed_price) ?? null,
+        price_min: normalizeMoney(form.price_min) ?? null,
+        price_max: normalizeMoney(form.price_max) ?? null,
         image_polish_enabled: effectiveImagePolishEnabled,
         random_image_count: Math.max(1, Math.min(Number(form.random_image_count || 1), 9)),
         material_defaults: {
           ...form.material_defaults,
-          postage: form.material_defaults.delivery_method === 'express' ? Number(form.material_defaults.postage || 0) : 0,
+          postage: form.material_defaults.delivery_method === 'express'
+            ? (normalizeMoney(Number(form.material_defaults.postage || 0)) ?? 0)
+            : 0,
         },
       }
       const res = selectedId
@@ -471,17 +481,17 @@ export function AiListingModal({ onClose, onTaskStarted }: Props) {
                   {form.price_mode === 'fixed' ? (
                     <div className="input-group">
                       <label className="input-label">固定价格</label>
-                      <input type="number" className="input-ios" disabled={!isEditing} min="0" step="0.01" value={form.fixed_price || ''} onChange={e => setForm(f => ({ ...f, fixed_price: parseFloat(e.target.value) || null }))} />
+                      <input type="number" className="input-ios" disabled={!isEditing} min="0.01" step="0.01" value={form.fixed_price || ''} onChange={e => setForm(f => ({ ...f, fixed_price: parseFloat(e.target.value) || null }))} />
                     </div>
                   ) : (
                     <>
                       <div className="input-group">
                         <label className="input-label">最低价格</label>
-                        <input type="number" className="input-ios" disabled={!isEditing} min="0" step="0.01" value={form.price_min || ''} onChange={e => setForm(f => ({ ...f, price_min: parseFloat(e.target.value) || null }))} />
+                        <input type="number" className="input-ios" disabled={!isEditing} min="0.01" step="0.01" value={form.price_min || ''} onChange={e => setForm(f => ({ ...f, price_min: parseFloat(e.target.value) || null }))} />
                       </div>
                       <div className="input-group">
                         <label className="input-label">最高价格</label>
-                        <input type="number" className="input-ios" disabled={!isEditing} min="0" step="0.01" value={form.price_max || ''} onChange={e => setForm(f => ({ ...f, price_max: parseFloat(e.target.value) || null }))} />
+                        <input type="number" className="input-ios" disabled={!isEditing} min="0.01" step="0.01" value={form.price_max || ''} onChange={e => setForm(f => ({ ...f, price_max: parseFloat(e.target.value) || null }))} />
                       </div>
                     </>
                   )}

--- a/frontend/src/pages/product-publish/AiListingModal.tsx
+++ b/frontend/src/pages/product-publish/AiListingModal.tsx
@@ -11,7 +11,6 @@ import {
   uploadProductImages,
   type AiListingConfig,
   type AiListingConfigParams,
-  type ProductDeliveryMethod,
 } from '@/api/productPublish'
 
 const CONDITIONS = ['全新', '99新', '95新', '9成新', '8成新', '7成新以下']
@@ -41,8 +40,7 @@ const defaultForm: AiListingConfigParams = {
     category: '',
     condition: '全新',
     brand: '',
-    delivery_method: 'free_shipping',
-    support_pickup: false,
+    delivery_method: 'express',
     postage: 0,
     address: '',
     remark: '',
@@ -194,7 +192,7 @@ export function AiListingModal({ onClose, onTaskStarted }: Props) {
         random_image_count: Math.max(1, Math.min(Number(form.random_image_count || 1), 9)),
         material_defaults: {
           ...form.material_defaults,
-          postage: form.material_defaults.delivery_method === 'fixed_fee' ? Number(form.material_defaults.postage || 0) : 0,
+          postage: form.material_defaults.delivery_method === 'express' ? Number(form.material_defaults.postage || 0) : 0,
         },
       }
       const res = selectedId
@@ -626,26 +624,17 @@ export function AiListingModal({ onClose, onTaskStarted }: Props) {
                   </div>
                   <div className="input-group">
                     <label className="input-label">发货方式</label>
-                    <select className="input-ios" disabled={!isEditing} value={form.material_defaults.delivery_method || 'free_shipping'} onChange={e => updateDefaults({ delivery_method: e.target.value as ProductDeliveryMethod, postage: e.target.value === 'fixed_fee' ? form.material_defaults.postage : 0 })}>
-                      <option value="free_shipping">包邮</option>
-                      <option value="distance_billing">按距离计费</option>
-                      <option value="fixed_fee">一口价</option>
-                      <option value="no_shipping">无需邮寄</option>
+                    <select className="input-ios" disabled={!isEditing} value={form.material_defaults.delivery_method || 'express'} onChange={e => updateDefaults({ delivery_method: e.target.value as 'express' | 'pickup', postage: e.target.value === 'express' ? form.material_defaults.postage : 0 })}>
+                      <option value="express">快递发货</option>
+                      <option value="pickup">自提</option>
                     </select>
                   </div>
-                  {form.material_defaults.delivery_method === 'fixed_fee' && (
+                  {form.material_defaults.delivery_method === 'express' && (
                     <div className="input-group">
                       <label className="input-label">运费</label>
                       <input type="number" className="input-ios" disabled={!isEditing} min="0" step="0.01" value={form.material_defaults.postage || ''} onChange={e => updateDefaults({ postage: parseFloat(e.target.value) || 0 })} />
                     </div>
                   )}
-                  <div className="input-group">
-                    <label className="input-label">支持自提</label>
-                    <label className="switch-ios mt-2">
-                      <input type="checkbox" disabled={!isEditing} checked={Boolean(form.material_defaults.support_pickup)} onChange={e => updateDefaults({ support_pickup: e.target.checked })} />
-                      <span className="switch-slider"></span>
-                    </label>
-                  </div>
                   <div className="input-group md:col-span-3">
                     <label className="input-label">宝贝所在地</label>
                     <input className="input-ios" disabled={!isEditing} value={form.material_defaults.address || ''} onChange={e => updateDefaults({ address: e.target.value })} />

--- a/frontend/src/pages/product-publish/AiListingModal.tsx
+++ b/frontend/src/pages/product-publish/AiListingModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Bot, Loader2, Pencil, Plus, Save, Search, Trash2, Upload, X } from 'lucide-react'
+import { Bot, Copy, Loader2, Pencil, Plus, Save, Search, Trash2, Upload, X } from 'lucide-react'
 import { ConfirmModal } from '@/components/common/ConfirmModal'
 import { useUIStore } from '@/store/uiStore'
 import {
@@ -102,35 +102,37 @@ export function AiListingModal({ onClose, onTaskStarted }: Props) {
 
   useEffect(() => { loadConfigs() }, [])
 
+  const configToForm = (config: AiListingConfig): AiListingConfigParams => ({
+    name: config.name,
+    prompt: config.prompt,
+    reference_text: config.reference_text || '',
+    price_mode: config.price_mode,
+    fixed_price: config.fixed_price ?? null,
+    price_min: config.price_min ?? null,
+    price_max: config.price_max ?? null,
+    text_api_url: config.text_api_url,
+    text_api_key: config.text_api_key,
+    text_model: config.text_model,
+    image_mode: config.image_mode,
+    image_api_url: config.image_api_url || 'https://api.openai.com/v1',
+    image_api_key: config.image_api_key || '',
+    image_model: config.image_model || '',
+    image_prompt: config.image_prompt || '',
+    image_polish_enabled: Boolean(config.image_polish_enabled) || (config.image_mode === 'ai' && (config.random_image_count || 1) > 1),
+    image_polish_sequential: Boolean(config.image_polish_sequential),
+    random_images: config.random_images || [],
+    random_image_count: config.random_image_count || 1,
+    material_defaults: {
+      ...defaultForm.material_defaults,
+      ...(config.material_defaults || {}),
+    },
+  })
+
   const applyConfig = (config: AiListingConfig) => {
     setSelectedId(config.id)
     setDraftMode(false)
     setEditingId(null)
-    setForm({
-      name: config.name,
-      prompt: config.prompt,
-      reference_text: config.reference_text || '',
-      price_mode: config.price_mode,
-      fixed_price: config.fixed_price ?? null,
-      price_min: config.price_min ?? null,
-      price_max: config.price_max ?? null,
-      text_api_url: config.text_api_url,
-      text_api_key: config.text_api_key,
-      text_model: config.text_model,
-      image_mode: config.image_mode,
-      image_api_url: config.image_api_url || 'https://api.openai.com/v1',
-      image_api_key: config.image_api_key || '',
-      image_model: config.image_model || '',
-      image_prompt: config.image_prompt || '',
-      image_polish_enabled: Boolean(config.image_polish_enabled) || (config.image_mode === 'ai' && (config.random_image_count || 1) > 1),
-      image_polish_sequential: Boolean(config.image_polish_sequential),
-      random_images: config.random_images || [],
-      random_image_count: config.random_image_count || 1,
-      material_defaults: {
-        ...defaultForm.material_defaults,
-        ...(config.material_defaults || {}),
-      },
-    })
+    setForm(configToForm(config))
   }
 
   const createNew = () => {
@@ -146,6 +148,17 @@ export function AiListingModal({ onClose, onTaskStarted }: Props) {
   const startEdit = (config: AiListingConfig) => {
     applyConfig(config)
     setEditingId(config.id)
+  }
+
+  const duplicateConfig = (config: AiListingConfig) => {
+    setSelectedId(null)
+    setDraftMode(true)
+    setEditingId(null)
+    setForm({
+      ...configToForm(config),
+      name: `${config.name} - 副本`,
+    })
+    addToast({ type: 'info', message: '已复制铺货配置，请保存为新配置' })
   }
 
   const updateDefaults = (patch: Partial<AiListingConfigParams['material_defaults']>) => {
@@ -371,6 +384,16 @@ export function AiListingModal({ onClose, onTaskStarted }: Props) {
                             disabled={saving}
                           >
                             {editing && saving ? <Loader2 className="w-4 h-4 animate-spin text-blue-500" /> : editing ? <Save className="w-4 h-4 text-blue-500" /> : <Pencil className="w-4 h-4 text-blue-500" />}
+                          </button>
+                          <button
+                            className="table-action-btn"
+                            title="复制"
+                            onClick={e => {
+                              e.stopPropagation()
+                              duplicateConfig(config)
+                            }}
+                          >
+                            <Copy className="w-4 h-4 text-cyan-500" />
                           </button>
                           <button
                             className="table-action-btn"

--- a/frontend/src/pages/product-publish/AiListingModal.tsx
+++ b/frontend/src/pages/product-publish/AiListingModal.tsx
@@ -1,0 +1,706 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { Bot, Loader2, Pencil, Plus, Save, Search, Trash2, Upload, X } from 'lucide-react'
+import { ConfirmModal } from '@/components/common/ConfirmModal'
+import { useUIStore } from '@/store/uiStore'
+import {
+  createAiListingConfig,
+  deleteAiListingConfig,
+  getAiListingConfigs,
+  startAiListingGeneration,
+  updateAiListingConfig,
+  uploadProductImages,
+  type AiListingConfig,
+  type AiListingConfigParams,
+  type ProductDeliveryMethod,
+} from '@/api/productPublish'
+
+const CONDITIONS = ['全新', '99新', '95新', '9成新', '8成新', '7成新以下']
+const CATEGORIES = ['数码家电', '服饰鞋包', '家居日用', '图书音像', '美妆个护', '母婴用品', '运动户外', '食品生鲜', '虚拟商品', '其他']
+
+const defaultForm: AiListingConfigParams = {
+  name: '',
+  prompt: '',
+  reference_text: '',
+  price_mode: 'fixed',
+  fixed_price: null,
+  price_min: null,
+  price_max: null,
+  text_api_url: 'https://api.openai.com/v1',
+  text_api_key: '',
+  text_model: '',
+  image_mode: 'random',
+  image_api_url: 'https://api.openai.com/v1',
+  image_api_key: '',
+  image_model: '',
+  image_prompt: '',
+  image_polish_enabled: false,
+  image_polish_sequential: false,
+  random_images: [],
+  random_image_count: 1,
+  material_defaults: {
+    category: '',
+    condition: '全新',
+    brand: '',
+    delivery_method: 'free_shipping',
+    support_pickup: false,
+    postage: 0,
+    address: '',
+    remark: '',
+  },
+}
+
+interface Props {
+  onClose: () => void
+  onTaskStarted: (taskId: string, total: number, configId: number, configName: string) => void
+}
+
+export function AiListingModal({ onClose, onTaskStarted }: Props) {
+  const { addToast } = useUIStore()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [configs, setConfigs] = useState<AiListingConfig[]>([])
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [form, setForm] = useState<AiListingConfigParams>(defaultForm)
+  const [searchText, setSearchText] = useState('')
+  const [draftMode, setDraftMode] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [generateCount, setGenerateCount] = useState(1)
+  const [concurrency, setConcurrency] = useState(1)
+  const [starting, setStarting] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<AiListingConfig | null>(null)
+
+  const selectedConfig = configs.find(item => item.id === selectedId) || null
+  const hasSelection = draftMode || Boolean(selectedConfig)
+  const isEditing = draftMode || (selectedId !== null && editingId === selectedId)
+  const canStart = Boolean(selectedId && selectedConfig && !isEditing)
+  const forceImagePolish = form.image_mode === 'ai' && form.random_image_count > 1
+  const effectiveImagePolishEnabled = forceImagePolish || Boolean(form.image_polish_enabled)
+  const filteredConfigs = configs.filter(item =>
+    item.name.toLowerCase().includes(searchText.trim().toLowerCase())
+  )
+
+  const loadConfigs = async () => {
+    setLoading(true)
+    try {
+      const res = await getAiListingConfigs()
+      if (res.success && res.data) {
+        setConfigs(res.data)
+        if (selectedId && !res.data.some(item => item.id === selectedId)) {
+          setSelectedId(null)
+          setEditingId(null)
+        }
+      } else {
+        addToast({ type: 'error', message: res.message || '加载配置失败' })
+      }
+    } catch {
+      addToast({ type: 'error', message: '加载配置失败' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { loadConfigs() }, [])
+
+  const applyConfig = (config: AiListingConfig) => {
+    setSelectedId(config.id)
+    setDraftMode(false)
+    setEditingId(null)
+    setForm({
+      name: config.name,
+      prompt: config.prompt,
+      reference_text: config.reference_text || '',
+      price_mode: config.price_mode,
+      fixed_price: config.fixed_price ?? null,
+      price_min: config.price_min ?? null,
+      price_max: config.price_max ?? null,
+      text_api_url: config.text_api_url,
+      text_api_key: config.text_api_key,
+      text_model: config.text_model,
+      image_mode: config.image_mode,
+      image_api_url: config.image_api_url || 'https://api.openai.com/v1',
+      image_api_key: config.image_api_key || '',
+      image_model: config.image_model || '',
+      image_prompt: config.image_prompt || '',
+      image_polish_enabled: Boolean(config.image_polish_enabled) || (config.image_mode === 'ai' && (config.random_image_count || 1) > 1),
+      image_polish_sequential: Boolean(config.image_polish_sequential),
+      random_images: config.random_images || [],
+      random_image_count: config.random_image_count || 1,
+      material_defaults: {
+        ...defaultForm.material_defaults,
+        ...(config.material_defaults || {}),
+      },
+    })
+  }
+
+  const createNew = () => {
+    setSelectedId(null)
+    setDraftMode(true)
+    setEditingId(null)
+    setForm({
+      ...defaultForm,
+      material_defaults: { ...defaultForm.material_defaults },
+    })
+  }
+
+  const startEdit = (config: AiListingConfig) => {
+    applyConfig(config)
+    setEditingId(config.id)
+  }
+
+  const updateDefaults = (patch: Partial<AiListingConfigParams['material_defaults']>) => {
+    setForm(prev => ({ ...prev, material_defaults: { ...prev.material_defaults, ...patch } }))
+  }
+
+  const validateForm = () => {
+    if (!form.name.trim()) return '请填写配置名称'
+    if (!form.prompt.trim()) return '请填写商品生成提示词'
+    if (!form.text_api_url.trim() || !form.text_api_key.trim() || !form.text_model.trim()) return '请填写文案AI配置'
+    if (form.price_mode === 'fixed' && (!form.fixed_price || form.fixed_price <= 0)) return '请填写有效固定价格'
+    if (form.price_mode === 'range') {
+      if (!form.price_min || !form.price_max || form.price_min <= 0 || form.price_max <= 0) return '请填写有效价格范围'
+      if (form.price_max < form.price_min) return '最高价格不能小于最低价格'
+    }
+    if (form.image_mode === 'random') {
+      if (form.random_images.length === 0) return '请先上传随机图库'
+      if (form.random_image_count > form.random_images.length) return '随机选图数量不能大于图库数量'
+      if (form.random_image_count > 9) return '每个素材最多选择9张图片'
+    }
+    if (form.image_mode === 'ai' && (!form.image_api_url?.trim() || !form.image_api_key?.trim() || !form.image_model?.trim())) {
+      return '请填写图片AI配置'
+    }
+    if (form.image_mode === 'ai' && !(form.image_prompt || '').trim()) {
+      return '请填写图片提示词'
+    }
+    if (form.image_mode === 'ai' && forceImagePolish && !effectiveImagePolishEnabled) {
+      return 'AI多图生成必须开启图片提示词AI润色'
+    }
+    if (form.image_mode === 'ai' && form.image_polish_sequential && !effectiveImagePolishEnabled) {
+      return '多图保持关联需要先开启图片提示词AI润色'
+    }
+    return ''
+  }
+
+  const handleSave = async () => {
+    const error = validateForm()
+    if (error) { addToast({ type: 'warning', message: error }); return }
+    setSaving(true)
+    try {
+      const payload = {
+        ...form,
+        image_polish_enabled: effectiveImagePolishEnabled,
+        random_image_count: Math.max(1, Math.min(Number(form.random_image_count || 1), 9)),
+        material_defaults: {
+          ...form.material_defaults,
+          postage: form.material_defaults.delivery_method === 'fixed_fee' ? Number(form.material_defaults.postage || 0) : 0,
+        },
+      }
+      const res = selectedId
+        ? await updateAiListingConfig(selectedId, payload)
+        : await createAiListingConfig(payload)
+      if (!res.success || !res.data) {
+        addToast({ type: 'error', message: res.message || '保存配置失败' })
+        return
+      }
+      addToast({ type: 'success', message: selectedId ? '配置已保存' : '配置已创建' })
+      await loadConfigs()
+      applyConfig(res.data)
+    } catch {
+      addToast({ type: 'error', message: '保存配置失败' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDeleteConfig = async (config: AiListingConfig) => {
+    setDeleteTarget(config)
+  }
+
+  const confirmDeleteConfig = async () => {
+    if (!deleteTarget) return
+    setDeleting(true)
+    try {
+      const res = await deleteAiListingConfig(deleteTarget.id)
+      if (res.success) {
+        addToast({ type: 'success', message: '配置已删除' })
+        if (selectedId === deleteTarget.id) {
+          setSelectedId(null)
+          setEditingId(null)
+          setDraftMode(false)
+          setForm(defaultForm)
+        }
+        setDeleteTarget(null)
+        await loadConfigs()
+      } else {
+        addToast({ type: 'error', message: res.message || '删除配置失败' })
+      }
+    } catch {
+      addToast({ type: 'error', message: '删除配置失败' })
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const handleUploadImages = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!isEditing) return
+    const files = Array.from(e.target.files || [])
+    if (!files.length) return
+    setUploading(true)
+    try {
+      const urls: string[] = []
+      for (let index = 0; index < files.length; index += 9) {
+        const batch = files.slice(index, index + 9)
+        const res = await uploadProductImages(batch)
+        if (res.success && res.data) {
+          urls.push(...res.data.urls)
+        } else {
+          addToast({ type: 'error', message: res.message || '上传失败' })
+          return
+        }
+      }
+      setForm(prev => ({ ...prev, random_images: [...prev.random_images, ...urls] }))
+    } catch {
+      addToast({ type: 'error', message: '图片上传失败' })
+    } finally {
+      setUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  const removeRandomImage = (index: number) => {
+    if (!isEditing) return
+    setForm(prev => ({ ...prev, random_images: prev.random_images.filter((_, i) => i !== index) }))
+  }
+
+  const startGenerate = async () => {
+    if (!selectedId || !selectedConfig) { addToast({ type: 'warning', message: '请先选择已保存的配置' }); return }
+    if (isEditing) { addToast({ type: 'warning', message: '请先保存配置再开始铺货' }); return }
+    setStarting(true)
+    try {
+      const res = await startAiListingGeneration(selectedId, generateCount, concurrency)
+      if (res.success && res.data) {
+        addToast({ type: 'success', message: 'AI铺货任务已在后台开始' })
+        onTaskStarted(res.data.task_id, res.data.total, selectedId, selectedConfig.name)
+        onClose()
+      } else {
+        addToast({ type: 'error', message: res.message || '启动任务失败' })
+      }
+    } catch {
+      addToast({ type: 'error', message: '启动任务失败' })
+    } finally {
+      setStarting(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content max-w-6xl h-[90vh] max-h-[90vh] flex flex-col">
+        <div className="modal-header">
+          <h2 className="modal-title flex items-center gap-2"><Bot className="w-5 h-5" />AI铺货</h2>
+          <button className="modal-close" onClick={onClose}><X className="w-5 h-5" /></button>
+        </div>
+        <div className="modal-body flex-1 overflow-hidden min-h-0">
+          <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-4 h-full min-h-0">
+            <div className="border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden flex flex-col min-h-0">
+              <div className="p-3 border-b border-slate-200 dark:border-slate-700 flex items-center justify-between">
+                <span className="font-medium text-slate-700 dark:text-slate-200">铺货配置列表</span>
+                <button className="btn-ios-secondary btn-sm" onClick={createNew}><Plus className="w-3.5 h-3.5" />新增</button>
+              </div>
+              <div className="p-2 border-b border-slate-200 dark:border-slate-700">
+                <div className="relative">
+                  <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+                  <input
+                    className="input-ios pl-9"
+                    placeholder="搜索配置"
+                    value={searchText}
+                    onChange={e => setSearchText(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="flex-1 overflow-y-auto p-2 space-y-1">
+                {loading ? (
+                  <div className="py-8 text-center text-slate-400"><Loader2 className="w-5 h-5 animate-spin mx-auto" /></div>
+                ) : configs.length === 0 && !draftMode ? (
+                  <div className="py-8 text-center text-sm text-slate-400">暂无配置</div>
+                ) : (
+                  <>
+                    {draftMode && (
+                      <div className="flex items-center gap-2 px-2 py-2 rounded-md bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-200">
+                        <input type="radio" checked readOnly className="w-4 h-4" />
+                        <button className="flex-1 text-left min-w-0" onClick={createNew}>
+                          <span className="block truncate text-sm">{form.name || '未保存配置'}</span>
+                          <span className="block text-xs text-slate-400 mt-0.5">编辑中</span>
+                        </button>
+                        <button className="table-action-btn" title="保存" onClick={handleSave} disabled={saving}>
+                          {saving ? <Loader2 className="w-4 h-4 animate-spin text-blue-500" /> : <Save className="w-4 h-4 text-blue-500" />}
+                        </button>
+                        <button className="table-action-btn" title="删除" onClick={() => { setDraftMode(false); setForm(defaultForm) }}>
+                          <Trash2 className="w-4 h-4 text-red-500" />
+                        </button>
+                      </div>
+                    )}
+                    {filteredConfigs.map(config => {
+                      const active = selectedId === config.id && !draftMode
+                      const editing = editingId === config.id && !draftMode
+                      return (
+                        <div
+                          key={config.id}
+                          onClick={() => applyConfig(config)}
+                          className={`flex items-center gap-2 px-2 py-2 rounded-md transition-colors ${
+                            active
+                              ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-200'
+                              : 'hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-200'
+                          }`}
+                        >
+                          <input type="radio" checked={active} readOnly className="w-4 h-4" />
+                          <button className="flex-1 text-left min-w-0" onClick={() => applyConfig(config)}>
+                            <span className="block truncate text-sm">{config.name}</span>
+                            <span className="block text-xs text-slate-400 mt-0.5">{config.image_mode === 'ai' ? 'AI生成图片' : '随机选图'}</span>
+                          </button>
+                          <button
+                            className="table-action-btn"
+                            title={editing ? '保存' : '编辑'}
+                            onClick={e => {
+                              e.stopPropagation()
+                              if (editing) {
+                                handleSave()
+                              } else {
+                                startEdit(config)
+                              }
+                            }}
+                            disabled={saving}
+                          >
+                            {editing && saving ? <Loader2 className="w-4 h-4 animate-spin text-blue-500" /> : editing ? <Save className="w-4 h-4 text-blue-500" /> : <Pencil className="w-4 h-4 text-blue-500" />}
+                          </button>
+                          <button
+                            className="table-action-btn"
+                            title="删除"
+                            onClick={e => {
+                              e.stopPropagation()
+                              handleDeleteConfig(config)
+                            }}
+                          >
+                            <Trash2 className="w-4 h-4 text-red-500" />
+                          </button>
+                        </div>
+                      )
+                    })}
+                  </>
+                )}
+              </div>
+            </div>
+
+            <div className="overflow-y-auto pr-1 min-h-0">
+              {!hasSelection ? (
+                <div className="h-full flex flex-col items-center justify-center text-center text-slate-500 dark:text-slate-400">
+                  <div className="w-14 h-14 rounded-lg bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center mb-3">
+                    <Bot className="w-7 h-7 text-blue-500" />
+                  </div>
+                  <div className="text-base font-medium text-slate-700 dark:text-slate-200">请在配置列表添加并填写铺货配置</div>
+                  <div className="text-sm mt-1">保存配置后即可在底部开始 AI 铺货</div>
+                </div>
+              ) : (
+              <div className="space-y-5">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="input-group">
+                    <label className="input-label">配置名称</label>
+                    <input className="input-ios" disabled={!isEditing} value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} />
+                  </div>
+                  <div className="input-group">
+                    <label className="input-label">文案模型</label>
+                    <input className="input-ios" disabled={!isEditing} placeholder="如：gpt-4o-mini" value={form.text_model} onChange={e => setForm(f => ({ ...f, text_model: e.target.value }))} />
+                  </div>
+                  <div className="input-group">
+                    <label className="input-label">文案 API URL</label>
+                    <input
+                      className="input-ios"
+                      disabled={!isEditing}
+                      placeholder="如：https://api.openai.com/v1 或 https://example.com/v2"
+                      value={form.text_api_url}
+                      onChange={e => setForm(f => ({ ...f, text_api_url: e.target.value }))}
+                    />
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                      填写到 /vx 为止即可，例如 https://api.openai.com/v1，如未填写版本号会自动补为 /v1，末尾不要加 /
+                    </p>
+                  </div>
+                  <div className="input-group">
+                    <label className="input-label">文案 API Key</label>
+                    <input className="input-ios" disabled={!isEditing} type="password" value={form.text_api_key} onChange={e => setForm(f => ({ ...f, text_api_key: e.target.value }))} />
+                  </div>
+                  <div className="input-group md:col-span-2">
+                    <label className="input-label">商品生成提示词</label>
+                    <textarea className="input-ios" disabled={!isEditing} rows={3} value={form.prompt} onChange={e => setForm(f => ({ ...f, prompt: e.target.value }))} />
+                  </div>
+                  <div className="input-group md:col-span-2">
+                    <label className="input-label">参考文案</label>
+                    <textarea className="input-ios" disabled={!isEditing} rows={3} value={form.reference_text || ''} onChange={e => setForm(f => ({ ...f, reference_text: e.target.value }))} />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="input-group">
+                    <label className="input-label">价格模式</label>
+                    <select className="input-ios" disabled={!isEditing} value={form.price_mode} onChange={e => setForm(f => ({ ...f, price_mode: e.target.value as 'fixed' | 'range' }))}>
+                      <option value="fixed">固定价格</option>
+                      <option value="range">范围随机</option>
+                    </select>
+                  </div>
+                  {form.price_mode === 'fixed' ? (
+                    <div className="input-group">
+                      <label className="input-label">固定价格</label>
+                      <input type="number" className="input-ios" disabled={!isEditing} min="0" step="0.01" value={form.fixed_price || ''} onChange={e => setForm(f => ({ ...f, fixed_price: parseFloat(e.target.value) || null }))} />
+                    </div>
+                  ) : (
+                    <>
+                      <div className="input-group">
+                        <label className="input-label">最低价格</label>
+                        <input type="number" className="input-ios" disabled={!isEditing} min="0" step="0.01" value={form.price_min || ''} onChange={e => setForm(f => ({ ...f, price_min: parseFloat(e.target.value) || null }))} />
+                      </div>
+                      <div className="input-group">
+                        <label className="input-label">最高价格</label>
+                        <input type="number" className="input-ios" disabled={!isEditing} min="0" step="0.01" value={form.price_max || ''} onChange={e => setForm(f => ({ ...f, price_max: parseFloat(e.target.value) || null }))} />
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="input-group">
+                    <label className="input-label">图片模式</label>
+                    <select className="input-ios" disabled={!isEditing} value={form.image_mode} onChange={e => setForm(f => ({ ...f, image_mode: e.target.value as 'ai' | 'random' }))}>
+                      <option value="random">随机选图</option>
+                      <option value="ai">AI生成</option>
+                    </select>
+                  </div>
+                  <div className="input-group">
+                    <label className="input-label">每个素材图片数量</label>
+                    <input
+                      type="number"
+                      className="input-ios"
+                      disabled={!isEditing}
+                      min="1"
+                      max="9"
+                      value={form.random_image_count}
+                      onChange={e => setForm(f => {
+                        const nextCount = parseInt(e.target.value) || 1
+                        const shouldForce = f.image_mode === 'ai' && nextCount > 1
+                        return {
+                          ...f,
+                          random_image_count: nextCount,
+                          image_polish_enabled: shouldForce ? true : f.image_polish_enabled,
+                        }
+                      })}
+                    />
+                    {form.image_mode === 'random' ? (
+                      <p className="text-xs text-slate-500 mt-1">当选图数量等于图库总数时，每个商品会使用同一组图片</p>
+                    ) : (
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">AI生成时最多支持 9 张图，数量大于 1 时会强制开启图片提示词AI润色</p>
+                    )}
+                  </div>
+                  {form.image_mode === 'ai' ? (
+                    <>
+                      <div className="input-group">
+                        <label className="input-label">图片 API URL</label>
+                        <input
+                          className="input-ios"
+                          disabled={!isEditing}
+                          placeholder="如：https://api.openai.com/v1 或 https://example.com/v2"
+                          value={form.image_api_url || ''}
+                          onChange={e => setForm(f => ({ ...f, image_api_url: e.target.value }))}
+                        />
+                        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                          填写到 /vx 为止即可，例如 https://api.openai.com/v1，如未填写版本号会自动补为 /v1，末尾不要加 /
+                        </p>
+                      </div>
+                      <div className="input-group">
+                        <label className="input-label">图片 API Key</label>
+                        <input type="password" className="input-ios" disabled={!isEditing} value={form.image_api_key || ''} onChange={e => setForm(f => ({ ...f, image_api_key: e.target.value }))} />
+                      </div>
+                      <div className="input-group">
+                        <label className="input-label">图片模型</label>
+                        <input className="input-ios" disabled={!isEditing} value={form.image_model || ''} onChange={e => setForm(f => ({ ...f, image_model: e.target.value }))} />
+                      </div>
+                      <div className="input-group md:col-span-2">
+                        <label className="input-label">图片提示词</label>
+                        <textarea
+                          className="input-ios"
+                          disabled={!isEditing}
+                          rows={4}
+                          placeholder="可使用 {title} {description} {price}"
+                          value={form.image_prompt || ''}
+                          onChange={e => setForm(f => ({ ...f, image_prompt: e.target.value }))}
+                        />
+                        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                          只有你主动填写的变量才会注入到提示词中，可用变量有 {'{title}'} {'{description}'} {'{price}'}
+                        </p>
+                      </div>
+                      <div className="input-group rounded-lg border border-slate-200 dark:border-slate-700 px-3 py-2">
+                        <label className="input-label">图片提示词AI润色</label>
+                        <label className="switch-ios mt-2">
+                          <input
+                            type="checkbox"
+                            disabled={!isEditing || forceImagePolish}
+                            checked={effectiveImagePolishEnabled}
+                            onChange={e => setForm(f => ({
+                              ...f,
+                              image_polish_enabled: e.target.checked,
+                              image_polish_sequential: e.target.checked ? f.image_polish_sequential : false,
+                            }))}
+                          />
+                          <span className="switch-slider"></span>
+                        </label>
+                        <p className={`text-xs mt-1 ${forceImagePolish ? 'text-blue-600 dark:text-blue-300' : 'text-slate-500 dark:text-slate-400'}`}>
+                          {forceImagePolish
+                            ? '当前为多图生成，图片提示词AI润色已自动开启，且会复用文案模型输出对应数量的提示词数组'
+                            : '开启后会先将图片提示词润色为更稳定的生图文本'}
+                        </p>
+                      </div>
+                      <div className="input-group rounded-lg border border-slate-200 dark:border-slate-700 px-3 py-2">
+                        <label className="input-label">多图保持关联</label>
+                        <label className="switch-ios mt-2">
+                          <input
+                            type="checkbox"
+                            disabled={!isEditing || !effectiveImagePolishEnabled}
+                            checked={Boolean(form.image_polish_sequential)}
+                            onChange={e => setForm(f => ({ ...f, image_polish_sequential: e.target.checked }))}
+                          />
+                          <span className="switch-slider"></span>
+                        </label>
+                        <p
+                          className={`text-xs mt-1 ${
+                            effectiveImagePolishEnabled
+                              ? 'text-slate-500 dark:text-slate-400'
+                              : 'text-slate-400 dark:text-slate-500'
+                          }`}
+                        >
+                          {effectiveImagePolishEnabled
+                            ? '开启后多张商品图会共用同一主体设定，仅调整构图和展示角度'
+                            : '请先开启图片提示词AI润色后再使用'}
+                        </p>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="input-group md:col-span-2">
+                      <label className="input-label">随机图库</label>
+                      <div className="flex flex-wrap gap-2">
+                        {form.random_images.map((url, index) => (
+                          <div key={`${url}-${index}`} className="relative w-16 h-16 rounded-lg overflow-hidden border border-slate-200 dark:border-slate-600 group">
+                            <img src={url} alt="" className="w-full h-full object-cover" />
+                            {isEditing && (
+                              <button type="button" onClick={() => removeRandomImage(index)} className="absolute top-0.5 right-0.5 bg-black/60 hover:bg-red-500 text-white rounded p-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                                <Trash2 className="w-3 h-3" />
+                              </button>
+                            )}
+                          </div>
+                        ))}
+                        {isEditing && (
+                          <button type="button" className="w-16 h-16 border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-lg flex items-center justify-center text-slate-400 hover:border-blue-400 hover:text-blue-500" disabled={uploading} onClick={() => fileInputRef.current?.click()}>
+                            {uploading ? <Loader2 className="w-5 h-5 animate-spin" /> : <Upload className="w-5 h-5" />}
+                          </button>
+                        )}
+                      </div>
+                      <input ref={fileInputRef} type="file" accept="image/*" multiple className="hidden" onChange={handleUploadImages} />
+                    </div>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="input-group">
+                    <label className="input-label">商品分类</label>
+                    <select className="input-ios" disabled={!isEditing} value={form.material_defaults.category || ''} onChange={e => updateDefaults({ category: e.target.value })}>
+                      <option value="">请选择分类</option>
+                      {CATEGORIES.map(item => <option key={item} value={item}>{item}</option>)}
+                    </select>
+                  </div>
+                  <div className="input-group">
+                    <label className="input-label">成色</label>
+                    <select className="input-ios" disabled={!isEditing} value={form.material_defaults.condition || '全新'} onChange={e => updateDefaults({ condition: e.target.value })}>
+                      {CONDITIONS.map(item => <option key={item} value={item}>{item}</option>)}
+                    </select>
+                  </div>
+                  <div className="input-group">
+                    <label className="input-label">品牌</label>
+                    <input className="input-ios" disabled={!isEditing} value={form.material_defaults.brand || ''} onChange={e => updateDefaults({ brand: e.target.value })} />
+                  </div>
+                  <div className="input-group">
+                    <label className="input-label">发货方式</label>
+                    <select className="input-ios" disabled={!isEditing} value={form.material_defaults.delivery_method || 'free_shipping'} onChange={e => updateDefaults({ delivery_method: e.target.value as ProductDeliveryMethod, postage: e.target.value === 'fixed_fee' ? form.material_defaults.postage : 0 })}>
+                      <option value="free_shipping">包邮</option>
+                      <option value="distance_billing">按距离计费</option>
+                      <option value="fixed_fee">一口价</option>
+                      <option value="no_shipping">无需邮寄</option>
+                    </select>
+                  </div>
+                  {form.material_defaults.delivery_method === 'fixed_fee' && (
+                    <div className="input-group">
+                      <label className="input-label">运费</label>
+                      <input type="number" className="input-ios" disabled={!isEditing} min="0" step="0.01" value={form.material_defaults.postage || ''} onChange={e => updateDefaults({ postage: parseFloat(e.target.value) || 0 })} />
+                    </div>
+                  )}
+                  <div className="input-group">
+                    <label className="input-label">支持自提</label>
+                    <label className="switch-ios mt-2">
+                      <input type="checkbox" disabled={!isEditing} checked={Boolean(form.material_defaults.support_pickup)} onChange={e => updateDefaults({ support_pickup: e.target.checked })} />
+                      <span className="switch-slider"></span>
+                    </label>
+                  </div>
+                  <div className="input-group md:col-span-3">
+                    <label className="input-label">宝贝所在地</label>
+                    <input className="input-ios" disabled={!isEditing} value={form.material_defaults.address || ''} onChange={e => updateDefaults({ address: e.target.value })} />
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                      这里填写的地址仅做素材记录，实际发布时会自动从随机地址库分配宝贝所在地
+                    </p>
+                  </div>
+                  <div className="input-group md:col-span-3">
+                    <label className="input-label">备注</label>
+                    <input className="input-ios" disabled={!isEditing} value={form.material_defaults.remark || ''} onChange={e => updateDefaults({ remark: e.target.value })} />
+                  </div>
+                </div>
+              </div>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="modal-footer items-end">
+          <div className="flex-1 min-w-0">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[180px_180px_1fr] gap-4 items-end">
+              <div className="input-group">
+                <label className="input-label">创建素材数量</label>
+                <input type="number" min="1" max="200" className="input-ios" value={generateCount} onChange={e => setGenerateCount(Math.max(1, Math.min(parseInt(e.target.value) || 1, 200)))} />
+              </div>
+              <div className="input-group">
+                <label className="input-label">并发创建数</label>
+                <input type="number" min="1" max="10" className="input-ios" value={concurrency} onChange={e => setConcurrency(Math.max(1, Math.min(parseInt(e.target.value) || 1, 10)))} />
+              </div>
+              <div className="text-sm text-slate-500 pb-2">
+                {selectedConfig ? '点击后将在后台生成，进度会显示在素材库页面' : '请选择已保存的配置'}
+              </div>
+            </div>
+          </div>
+          <button className="btn-ios-primary" onClick={startGenerate} disabled={!canStart || starting}>
+            {starting && <Loader2 className="w-4 h-4 animate-spin" />}
+            开始后台铺货
+          </button>
+        </div>
+      </div>
+      <ConfirmModal
+        isOpen={Boolean(deleteTarget)}
+        title="确认删除"
+        message={deleteTarget ? `确认删除配置「${deleteTarget.name}」？` : ''}
+        confirmText="删除"
+        cancelText="取消"
+        type="danger"
+        loading={deleting}
+        onConfirm={confirmDeleteConfig}
+        onCancel={() => {
+          if (deleting) return
+          setDeleteTarget(null)
+        }}
+      />
+    </div>
+  )
+}
+
+export default AiListingModal

--- a/frontend/src/pages/product-publish/MaterialFormModal.tsx
+++ b/frontend/src/pages/product-publish/MaterialFormModal.tsx
@@ -24,6 +24,7 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [saving, setSaving] = useState(false)
   const [uploading, setUploading] = useState(false)
+  const [previewImage, setPreviewImage] = useState<string | null>(null)
   const [form, setForm] = useState<MaterialCreateParams>({
     title: initial?.title ?? '',
     description: initial?.description ?? '',
@@ -68,6 +69,7 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
     if (!form.title.trim()) { addToast({ type: 'warning', message: '请填写商品标题' }); return }
     if (!form.description.trim()) { addToast({ type: 'warning', message: '请填写商品描述' }); return }
     if (!form.price || form.price <= 0) { addToast({ type: 'warning', message: '请填写有效价格' }); return }
+    if (!form.images || form.images.length === 0) { addToast({ type: 'warning', message: '请至少上传一张商品图片' }); return }
     setSaving(true)
     try {
       if (initial) {
@@ -147,7 +149,7 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
                     value={form.postage || ''} onChange={e => setForm(f => ({ ...f, postage: parseFloat(e.target.value) || 0 }))} />
                 </div>
               )}
-              <div className="input-group">
+              <div className="sm:col-span-2 input-group">
                 <label className="input-label">宝贝所在地</label>
                 <input className="input-ios" placeholder="如：北京市朝阳区；仅做素材记录，发布时统一走随机地址"
                   value={form.address} onChange={e => setForm(f => ({ ...f, address: e.target.value }))} />
@@ -167,11 +169,13 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
               </div>
             </div>
             <div className="input-group">
-              <label className="input-label">商品图片（最多9张）</label>
+              <label className="input-label">商品图片（最多9张） <span className="text-red-500">*</span></label>
               <div className="flex flex-wrap gap-2 mt-1.5">
                 {(form.images || []).map((url, i) => (
                   <div key={i} className="relative w-20 h-20 rounded-lg overflow-hidden border border-slate-200 dark:border-slate-600 group">
-                    <img src={url} alt="" className="w-full h-full object-cover" />
+                    <button type="button" className="w-full h-full cursor-zoom-in" onClick={() => setPreviewImage(url)}>
+                      <img src={url} alt="" className="w-full h-full object-cover" />
+                    </button>
                     {i === 0 && (
                       <span className="absolute bottom-0 left-0 right-0 bg-blue-500/80 text-white text-[10px] text-center py-0.5">封面</span>
                     )}
@@ -201,6 +205,22 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
           </button>
         </div>
       </div>
+
+      {previewImage && (
+        <div className="modal-overlay" style={{ zIndex: 70 }}>
+          <div className="modal-content max-w-4xl">
+            <div className="modal-header">
+              <h2 className="modal-title">图片预览</h2>
+              <button className="modal-close" onClick={() => setPreviewImage(null)}>
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div className="modal-body flex items-center justify-center">
+              <img src={previewImage} alt="预览图片" className="max-w-full max-h-[70vh] object-contain rounded-lg" />
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/product-publish/MaterialFormModal.tsx
+++ b/frontend/src/pages/product-publish/MaterialFormModal.tsx
@@ -13,6 +13,11 @@ import {
 const CONDITIONS = ['全新', '99新', '95新', '9成新', '8成新', '7成新以下']
 const CATEGORIES = ['数码家电', '服饰鞋包', '家居日用', '图书音像', '美妆个护', '母婴用品', '运动户外', '食品生鲜', '虚拟商品', '其他']
 
+function normalizeMoney(value: number | null | undefined): number | undefined {
+  if (value === null || value === undefined || Number.isNaN(value)) return undefined
+  return Math.round(value * 100) / 100
+}
+
 interface Props {
   initial: ProductMaterial | null
   onClose: () => void
@@ -68,16 +73,25 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
   const handleSave = async () => {
     if (!form.title.trim()) { addToast({ type: 'warning', message: '请填写商品标题' }); return }
     if (!form.description.trim()) { addToast({ type: 'warning', message: '请填写商品描述' }); return }
-    if (!form.price || form.price <= 0) { addToast({ type: 'warning', message: '请填写有效价格' }); return }
+    const normalizedPrice = normalizeMoney(form.price)
+    const normalizedOriginalPrice = normalizeMoney(form.original_price)
+    if (!normalizedPrice || normalizedPrice < 0.01) { addToast({ type: 'warning', message: '售价最小为0.01' }); return }
+    if (normalizedOriginalPrice !== undefined && normalizedOriginalPrice < 0.01) { addToast({ type: 'warning', message: '原价最小为0.01' }); return }
     if (!form.images || form.images.length === 0) { addToast({ type: 'warning', message: '请至少上传一张商品图片' }); return }
+    const payload = {
+      ...form,
+      price: normalizedPrice,
+      original_price: normalizedOriginalPrice,
+      postage: normalizeMoney(form.postage) ?? 0,
+    }
     setSaving(true)
     try {
       if (initial) {
-        const res = await updateMaterial(initial.id, form)
+        const res = await updateMaterial(initial.id, payload)
         if (!res.success) { addToast({ type: 'error', message: res.message || '更新失败' }); return }
         addToast({ type: 'success', message: '素材更新成功' })
       } else {
-        const res = await createMaterial(form)
+        const res = await createMaterial(payload)
         if (!res.success) { addToast({ type: 'error', message: res.message || '创建失败' }); return }
         addToast({ type: 'success', message: '素材创建成功' })
       }
@@ -106,12 +120,12 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
               </div>
               <div className="input-group">
                 <label className="input-label">售价（元）<span className="text-red-500">*</span></label>
-                <input type="number" className="input-ios" placeholder="0.00" min="0" step="0.01"
+                <input type="number" className="input-ios" placeholder="0.01" min="0.01" step="0.01"
                   value={form.price || ''} onChange={e => setForm(f => ({ ...f, price: parseFloat(e.target.value) || 0 }))} />
               </div>
               <div className="input-group">
                 <label className="input-label">原价（划线价，选填）</label>
-                <input type="number" className="input-ios" placeholder="0.00" min="0" step="0.01"
+                <input type="number" className="input-ios" placeholder="0.01" min="0.01" step="0.01"
                   value={form.original_price || ''} onChange={e => setForm(f => ({ ...f, original_price: parseFloat(e.target.value) || undefined }))} />
               </div>
               <div className="input-group">

--- a/frontend/src/pages/product-publish/MaterialFormModal.tsx
+++ b/frontend/src/pages/product-publish/MaterialFormModal.tsx
@@ -24,6 +24,13 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [saving, setSaving] = useState(false)
   const [uploading, setUploading] = useState(false)
+  const rawInitialDeliveryMethod = initial?.delivery_method as string | undefined
+  const initialDeliveryMethod: ProductDeliveryMethod =
+    rawInitialDeliveryMethod === 'distance_billing' || rawInitialDeliveryMethod === 'fixed_fee' || rawInitialDeliveryMethod === 'no_shipping'
+      ? rawInitialDeliveryMethod
+      : rawInitialDeliveryMethod === 'virtual'
+        ? 'no_shipping'
+        : 'free_shipping'
   const [form, setForm] = useState<MaterialCreateParams>({
     title: initial?.title ?? '',
     description: initial?.description ?? '',
@@ -31,7 +38,8 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
     original_price: initial?.original_price ?? undefined,
     category: initial?.category ?? '',
     images: initial?.images ?? [],
-    delivery_method: initial?.delivery_method ?? 'express',
+    delivery_method: initialDeliveryMethod,
+    support_pickup: initial?.support_pickup ?? false,
     postage: initial?.postage ?? 0,
     address: initial?.address ?? '',
     brand: initial?.brand ?? '',
@@ -68,7 +76,7 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
     setForm(f => ({
       ...f,
       delivery_method: deliveryMethod,
-      postage: deliveryMethod === 'express' ? f.postage : 0,
+      postage: deliveryMethod === 'fixed_fee' ? f.postage : 0,
     }))
   }
 
@@ -80,7 +88,7 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
     try {
       const payload = {
         ...form,
-        postage: form.delivery_method === 'express' ? form.postage : 0,
+        postage: form.delivery_method === 'fixed_fee' ? form.postage : 0,
       }
       if (initial) {
         const res = await updateMaterial(initial.id, payload)
@@ -144,19 +152,31 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
                 <input className="input-ios" placeholder="请输入品牌"
                   value={form.brand} onChange={e => setForm(f => ({ ...f, brand: e.target.value }))} />
               </div>
-              <div className="input-group">
+              <div className="input-group sm:col-span-2">
                 <label className="input-label">发货方式</label>
-                <select className="input-ios" value={form.delivery_method}
-                  onChange={e => updateDeliveryMethod(e.target.value as ProductDeliveryMethod)}>
-                  <option value="express">快递发货</option>
-                  <option value="pickup">自提</option>
-                  <option value="virtual">无需邮寄</option>
-                </select>
+                <div className="flex items-center gap-3 flex-wrap">
+                  <select className="input-ios w-full sm:w-[320px]" value={form.delivery_method}
+                    onChange={e => updateDeliveryMethod(e.target.value as ProductDeliveryMethod)}>
+                    <option value="free_shipping">包邮</option>
+                    <option value="distance_billing">按距离计费</option>
+                    <option value="fixed_fee">一口价</option>
+                    <option value="no_shipping">无需邮寄</option>
+                  </select>
+                  <label className="switch-ios flex-shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(form.support_pickup)}
+                      onChange={e => setForm(f => ({ ...f, support_pickup: e.target.checked }))}
+                    />
+                    <span className="switch-slider"></span>
+                  </label>
+                  <span className="text-sm text-slate-600 dark:text-slate-300 flex-shrink-0">支持自提</span>
+                </div>
               </div>
-              {form.delivery_method === 'express' && (
+              {form.delivery_method === 'fixed_fee' && (
                 <div className="input-group">
-                  <label className="input-label">邮费（元，0=包邮）</label>
-                  <input type="number" className="input-ios" placeholder="0" min="0" step="0.01"
+                  <label className="input-label">运费（元）</label>
+                  <input type="number" className="input-ios w-full sm:w-[320px]" placeholder="0" min="0" step="0.01"
                     value={form.postage || ''} onChange={e => setForm(f => ({ ...f, postage: parseFloat(e.target.value) || 0 }))} />
                 </div>
               )}

--- a/frontend/src/pages/product-publish/MaterialFormModal.tsx
+++ b/frontend/src/pages/product-publish/MaterialFormModal.tsx
@@ -7,7 +7,7 @@ import { X, Loader2, Upload, Trash2 } from 'lucide-react'
 import { useUIStore } from '@/store/uiStore'
 import {
   createMaterial, updateMaterial, uploadProductImages,
-  type ProductMaterial, type MaterialCreateParams,
+  type ProductDeliveryMethod, type ProductMaterial, type MaterialCreateParams,
 } from '@/api/productPublish'
 
 const CONDITIONS = ['全新', '99新', '95新', '9成新', '8成新', '7成新以下']
@@ -64,18 +64,30 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
     setForm(f => ({ ...f, images: (f.images || []).filter((_, i) => i !== idx) }))
   }
 
+  const updateDeliveryMethod = (deliveryMethod: ProductDeliveryMethod) => {
+    setForm(f => ({
+      ...f,
+      delivery_method: deliveryMethod,
+      postage: deliveryMethod === 'express' ? f.postage : 0,
+    }))
+  }
+
   const handleSave = async () => {
     if (!form.title.trim()) { addToast({ type: 'warning', message: '请填写商品标题' }); return }
     if (!form.description.trim()) { addToast({ type: 'warning', message: '请填写商品描述' }); return }
     if (!form.price || form.price <= 0) { addToast({ type: 'warning', message: '请填写有效价格' }); return }
     setSaving(true)
     try {
+      const payload = {
+        ...form,
+        postage: form.delivery_method === 'express' ? form.postage : 0,
+      }
       if (initial) {
-        const res = await updateMaterial(initial.id, form)
+        const res = await updateMaterial(initial.id, payload)
         if (!res.success) { addToast({ type: 'error', message: res.message || '更新失败' }); return }
         addToast({ type: 'success', message: '素材更新成功' })
       } else {
-        const res = await createMaterial(form)
+        const res = await createMaterial(payload)
         if (!res.success) { addToast({ type: 'error', message: res.message || '创建失败' }); return }
         addToast({ type: 'success', message: '素材创建成功' })
       }
@@ -135,9 +147,10 @@ export function MaterialFormModal({ initial, onClose, onSaved }: Props) {
               <div className="input-group">
                 <label className="input-label">发货方式</label>
                 <select className="input-ios" value={form.delivery_method}
-                  onChange={e => setForm(f => ({ ...f, delivery_method: e.target.value as 'express' | 'pickup' }))}>
+                  onChange={e => updateDeliveryMethod(e.target.value as ProductDeliveryMethod)}>
                   <option value="express">快递发货</option>
                   <option value="pickup">自提</option>
+                  <option value="virtual">无需邮寄</option>
                 </select>
               </div>
               {form.delivery_method === 'express' && (

--- a/frontend/src/pages/product-publish/ProductMaterials.tsx
+++ b/frontend/src/pages/product-publish/ProductMaterials.tsx
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * 商品素材库页面
  *
  * 功能：
@@ -8,19 +8,28 @@
  * 4. 勾选批量删除
  * 5. 素材用于单品发布和批量发布
  */
-import { useState, useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
-import { Plus, Pencil, Trash2, RefreshCw, Image, ChevronLeft, ChevronRight, Search, X } from 'lucide-react'
+import { Plus, Pencil, Trash2, RefreshCw, Image, ChevronLeft, ChevronRight, Search, X, Bot } from 'lucide-react'
 import { useUIStore } from '@/store/uiStore'
 import { useAuthStore } from '@/store/authStore'
-import { getMaterials, deleteMaterial, batchDeleteMaterials, type ProductMaterial } from '@/api/productPublish'
+import {
+  getMaterials,
+  deleteMaterial,
+  batchDeleteMaterials,
+  getAiListingTaskStatus,
+  getAiListingTasks,
+  type AiListingTaskStatus,
+  type ProductMaterial,
+} from '@/api/productPublish'
 import { PageLoading } from '@/components/common/Loading'
 import { ConfirmModal } from '@/components/common/ConfirmModal'
 import { MaterialFormModal } from './MaterialFormModal'
+import { AiListingModal } from './AiListingModal'
 
 const CATEGORIES = ['数码家电', '服饰鞋包', '家居日用', '图书音像', '美妆个护', '母婴用品', '运动户外', '食品生鲜', '虚拟商品', '其他']
 const CONDITIONS = ['全新', '99新', '95新', '9成新', '8成新', '7成新以下']
-
+const AI_LISTING_TASK_STORAGE_KEY = 'product_publish_ai_listing_task_ids'
 export function ProductMaterials() {
   const { addToast } = useUIStore()
   const { user } = useAuthStore()
@@ -33,23 +42,26 @@ export function ProductMaterials() {
   const [pageSize, setPageSize] = useState(20)
   const [totalPages, setTotalPages] = useState(0)
   const [showModal, setShowModal] = useState(false)
+  const [showAiListingModal, setShowAiListingModal] = useState(false)
   const [editTarget, setEditTarget] = useState<ProductMaterial | null>(null)
   const [deleteConfirm, setDeleteConfirm] = useState<{ open: boolean; item: ProductMaterial | null }>({ open: false, item: null })
   const [deleting, setDeleting] = useState(false)
+  const [aiListingTasks, setAiListingTasks] = useState<AiListingTaskStatus[]>([])
+  const [taskSyncLoaded, setTaskSyncLoaded] = useState(false)
+  const aiListingTasksRef = useRef<AiListingTaskStatus[]>([])
+  const materialRefreshTickRef = useRef(0)
 
-  // 筛选状态
   const [filterTitle, setFilterTitle] = useState('')
   const [filterCategory, setFilterCategory] = useState('')
   const [filterCondition, setFilterCondition] = useState('')
 
-  // 批量选择状态
   const [selectedIds, setSelectedIds] = useState<number[]>([])
   const [batchDeleteConfirm, setBatchDeleteConfirm] = useState(false)
   const [batchDeleting, setBatchDeleting] = useState(false)
+  const runningTaskCount = aiListingTasks.filter(item => !item.finished).length
 
-  /** 加载素材列表 */
-  const load = async (p = page, size = pageSize) => {
-    setTableLoading(true)
+  const load = async (p = page, size = pageSize, options?: { silent?: boolean }) => {
+    if (!options?.silent) setTableLoading(true)
     try {
       const filters: { title?: string; category?: string; condition?: string } = {}
       if (filterTitle.trim()) filters.title = filterTitle.trim()
@@ -60,37 +72,136 @@ export function ProductMaterials() {
         setMaterials(res.data.list)
         setTotal(res.data.total)
         setTotalPages(res.data.total_pages)
-        // 清除不在当前页的选中项
         const currentIds = new Set(res.data.list.map(m => m.id))
         setSelectedIds(prev => prev.filter(id => currentIds.has(id)))
       } else {
         addToast({ type: 'error', message: res.message || '加载失败' })
       }
     } catch {
-      addToast({ type: 'error', message: '网络错误，请重试' })
+      if (!options?.silent) {
+        addToast({ type: 'error', message: '网络错误，请重试' })
+      }
     } finally {
       setLoading(false)
-      setTableLoading(false)
+      if (!options?.silent) setTableLoading(false)
     }
   }
 
   useEffect(() => { load(page, pageSize) }, [page, pageSize])
 
-  /** 执行筛选 */
+  useEffect(() => {
+    aiListingTasksRef.current = aiListingTasks
+  }, [aiListingTasks])
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(AI_LISTING_TASK_STORAGE_KEY)
+      const taskIds = raw ? JSON.parse(raw) : []
+      if (!Array.isArray(taskIds) || taskIds.length === 0) return
+      setAiListingTasks(taskIds.map((taskId: string) => ({
+        task_id: String(taskId),
+        config_id: 0,
+        config_name: '',
+        total: 0,
+        current: 0,
+        success: 0,
+        failed: 0,
+        status: 'pending',
+        message: '等待同步任务状态',
+        progress_percent: 0,
+        active_stage: 'pending',
+        stage_label: '等待开始',
+        stage_detail: '',
+        step_counts: {
+          text: { done: 0, total: 0 },
+          image_polish: { done: 0, total: 0 },
+          image_generate: { done: 0, total: 0 },
+          material_create: { done: 0, total: 0 },
+        },
+        created_material_ids: [],
+        errors: [],
+        finished: false,
+      })))
+    } catch {
+      localStorage.removeItem(AI_LISTING_TASK_STORAGE_KEY)
+    }
+  }, [])
+
+  useEffect(() => {
+    let stopped = false
+    const currentTasks = aiListingTasksRef.current
+    const hasRunningTasks = currentTasks.some(item => !item.finished)
+    if (taskSyncLoaded && !hasRunningTasks) return
+
+    const syncTasks = async () => {
+      try {
+        const previousTasks = aiListingTasksRef.current
+        const previousRunning = previousTasks.some(item => !item.finished)
+        const listRes = await getAiListingTasks()
+        if (!listRes.success || !listRes.data || stopped) return
+
+        const remoteTasks = listRes.data
+        const remoteTaskMap = new Map(remoteTasks.map(item => [item.task_id, item]))
+        const rememberedTaskIds = previousTasks.map(item => item.task_id)
+        const mergedTaskIds = rememberedTaskIds.length > 0
+          ? rememberedTaskIds
+          : remoteTasks.filter(item => !item.finished).map(item => item.task_id)
+        const detailedTasks = await Promise.all(mergedTaskIds.map(async taskId => {
+          const remoteTask = remoteTaskMap.get(taskId)
+          if (remoteTask) return remoteTask
+          const res = await getAiListingTaskStatus(taskId)
+          return res.success && res.data ? res.data : null
+        }))
+        if (stopped) return
+
+        const nextTasks = detailedTasks.filter((item): item is AiListingTaskStatus => Boolean(item))
+        setTaskSyncLoaded(true)
+        aiListingTasksRef.current = nextTasks
+        setAiListingTasks(nextTasks)
+        const nextTaskIds = nextTasks.map(item => item.task_id)
+        if (nextTaskIds.length > 0) {
+          localStorage.setItem(AI_LISTING_TASK_STORAGE_KEY, JSON.stringify(nextTaskIds))
+        } else {
+          localStorage.removeItem(AI_LISTING_TASK_STORAGE_KEY)
+        }
+
+        const nextRunning = nextTasks.some(item => !item.finished)
+        if (nextRunning) {
+          materialRefreshTickRef.current += 1
+          if (materialRefreshTickRef.current % 2 === 0) {
+            void load(page, pageSize, { silent: true })
+          }
+        } else {
+          materialRefreshTickRef.current = 0
+        }
+        if (previousRunning && !nextRunning) {
+          void load(page, pageSize, { silent: true })
+        }
+      } catch {
+        // 保留当前任务状态，下一轮继续轮询
+      }
+    }
+
+    syncTasks()
+    const timer = window.setInterval(syncTasks, 1500)
+    return () => {
+      stopped = true
+      window.clearInterval(timer)
+    }
+  }, [page, pageSize, filterTitle, filterCategory, filterCondition, taskSyncLoaded, aiListingTasks.length, runningTaskCount])
+
   const handleFilter = () => {
     setPage(1)
     setSelectedIds([])
     load(1, pageSize)
   }
 
-  /** 重置筛选 */
   const handleResetFilter = () => {
     setFilterTitle('')
     setFilterCategory('')
     setFilterCondition('')
     setPage(1)
     setSelectedIds([])
-    // 直接用空筛选加载
     setTableLoading(true)
     getMaterials(1, pageSize).then(res => {
       if (res.success) {
@@ -107,7 +218,6 @@ export function ProductMaterials() {
     })
   }
 
-  /** 确认删除单条 */
   const handleConfirmDelete = async () => {
     if (!deleteConfirm.item) return
     setDeleting(true)
@@ -128,7 +238,6 @@ export function ProductMaterials() {
     }
   }
 
-  /** 批量删除 */
   const handleBatchDelete = async () => {
     if (selectedIds.length === 0) return
     setBatchDeleting(true)
@@ -149,7 +258,6 @@ export function ProductMaterials() {
     }
   }
 
-  /** 全选/取消全选当前页 */
   const handleSelectAll = () => {
     if (materials.length === 0) return
     const currentPageIds = materials.map(m => m.id)
@@ -161,22 +269,76 @@ export function ProductMaterials() {
     }
   }
 
-  /** 切换单条选中 */
   const toggleSelect = (id: number) => {
     setSelectedIds(prev =>
       prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id]
     )
   }
 
-  const allCurrentSelected = materials.length > 0 && materials.every(m => selectedIds.includes(m.id))
+  const closeAiListingTask = (taskId: string) => {
+    setAiListingTasks(prev => {
+      const nextTasks = prev.filter(item => item.task_id !== taskId)
+      const nextTaskIds = nextTasks.map(item => item.task_id)
+      if (nextTaskIds.length > 0) {
+        localStorage.setItem(AI_LISTING_TASK_STORAGE_KEY, JSON.stringify(nextTaskIds))
+      } else {
+        localStorage.removeItem(AI_LISTING_TASK_STORAGE_KEY)
+      }
+      return nextTasks
+    })
+  }
 
+  const handleAiListingTaskStarted = (taskId: string, total: number, configId: number, configName: string) => {
+    setAiListingTasks(prev => {
+      const nextTasks = [
+        {
+          task_id: taskId,
+          config_id: configId,
+          config_name: configName,
+          total,
+          current: 0,
+          success: 0,
+          failed: 0,
+          status: 'pending' as const,
+          message: '任务已提交，正在后台生成',
+          progress_percent: 0,
+          active_stage: 'pending',
+          stage_label: '任务已提交',
+          stage_detail: '等待后台开始处理',
+          step_counts: {
+            text: { done: 0, total },
+            image_polish: { done: 0, total },
+            image_generate: { done: 0, total },
+            material_create: { done: 0, total },
+          },
+          created_material_ids: [],
+          errors: [],
+          finished: false,
+        },
+        ...prev.filter(item => item.task_id !== taskId),
+      ]
+      localStorage.setItem(AI_LISTING_TASK_STORAGE_KEY, JSON.stringify(nextTasks.map(item => item.task_id)))
+      return nextTasks
+    })
+  }
+
+  const runningAiListingTasks = aiListingTasks.filter(item => !item.finished)
+  const aiListingTaskLimitReached = runningTaskCount >= 5
+  const allCurrentSelected = materials.length > 0 && materials.every(m => selectedIds.includes(m.id))
   const handlePageSizeChange = (size: number) => { setPageSize(size); setPage(1) }
+
+  const handleOpenAiListingModal = () => {
+    if (aiListingTaskLimitReached) {
+      addToast({ type: 'warning', message: '最多只能同时执行5个AI铺货任务，请等待生成完成后再继续铺货' })
+      return
+    }
+    setShowAiListingModal(true)
+  }
 
   if (loading) return <PageLoading />
 
   return (
     <div className="space-y-3 sm:space-y-4">
-      {/* 标题栏 */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h1 className="page-title">商品素材库</h1>
@@ -191,13 +353,78 @@ export function ProductMaterials() {
           <button className="btn-ios-secondary" onClick={() => load(page, pageSize)} disabled={tableLoading}>
             <RefreshCw className={`w-4 h-4 ${tableLoading ? 'animate-spin' : ''}`} />刷新
           </button>
+          <button
+            className="btn-ios-primary"
+            style={{
+              backgroundColor: 'transparent',
+              borderColor: 'transparent',
+              backgroundImage:
+                'linear-gradient(135deg, rgb(var(--theme-gradient-from)) 0%, rgb(var(--theme-gradient-via)) 55%, rgb(var(--theme-gradient-to)) 100%)',
+            }}
+            disabled={aiListingTaskLimitReached}
+            onClick={handleOpenAiListingModal}
+          >
+            <Bot className="w-4 h-4" />AI铺货
+          </button>
           <button className="btn-ios-primary" onClick={() => { setEditTarget(null); setShowModal(true) }}>
             <Plus className="w-4 h-4" />新建素材
           </button>
         </div>
       </div>
 
-      {/* 筛选栏 */}
+      {aiListingTasks.length > 0 && (
+        <div className="vben-card">
+          <div className="vben-card-body py-3 px-4">
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 min-w-[180px]">
+                <Bot className="w-4 h-4 text-blue-500" />
+                <span className="font-medium text-slate-700 dark:text-slate-200">AI铺货后台任务</span>
+                <span className="text-xs text-slate-400">运行中 {runningAiListingTasks.length}/5</span>
+              </div>
+              {aiListingTasks.map(task => {
+                const progress = Math.max(0, Math.min(100, Number(task.progress_percent || 0)))
+                return (
+                  <div key={task.task_id} className="flex items-start gap-3 rounded-lg border border-slate-200 dark:border-slate-700 px-3 py-2.5">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="text-sm font-medium text-slate-700 dark:text-slate-200 truncate">{task.config_name || `配置 ID ${task.config_id}`}</div>
+                          <div className="mt-1 flex items-center gap-2 min-w-0 text-xs text-slate-400">
+                            <span className="flex-shrink-0">任务 {task.task_id.slice(0, 8)}</span>
+                            {!task.finished && <span className="inline-flex w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse flex-shrink-0" />}
+                            <span className="truncate">{task.stage_label || task.message}</span>
+                          </div>
+                        </div>
+                        <span className="text-xs text-slate-400 flex-shrink-0">{progress.toFixed(0)}%</span>
+                      </div>
+                      <div className="mt-2 h-2 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden">
+                        <div
+                          className="h-full rounded-full transition-[width] duration-1000 ease-out bg-gradient-to-r from-sky-500 via-blue-500 to-violet-500"
+                          style={{ width: `${progress}%` }}
+                        />
+                      </div>
+                      <div className="mt-2 text-xs text-slate-500 truncate">
+                        {task.current}/{task.total}，成功 {task.success}，失败 {task.failed}，{task.stage_detail || task.message}
+                      </div>
+                      {task.errors.length > 0 && (
+                        <div className="mt-1 text-xs text-red-500 truncate">
+                          {task.errors[task.errors.length - 1]}
+                        </div>
+                      )}
+                    </div>
+                    {task.finished && (
+                      <button className="btn-ios-secondary btn-sm" onClick={() => closeAiListingTask(task.task_id)}>
+                        关闭
+                      </button>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="vben-card">
         <div className="vben-card-body py-3 px-4">
           <div className="flex flex-wrap items-center gap-3">
@@ -210,19 +437,11 @@ export function ProductMaterials() {
                 onKeyDown={e => e.key === 'Enter' && handleFilter()}
               />
             </div>
-            <select
-              className="input-ios w-32"
-              value={filterCategory}
-              onChange={e => { setFilterCategory(e.target.value); }}
-            >
+            <select className="input-ios w-32" value={filterCategory} onChange={e => { setFilterCategory(e.target.value) }}>
               <option value="">全部分类</option>
               {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
             </select>
-            <select
-              className="input-ios w-28"
-              value={filterCondition}
-              onChange={e => { setFilterCondition(e.target.value); }}
-            >
+            <select className="input-ios w-28" value={filterCondition} onChange={e => { setFilterCondition(e.target.value) }}>
               <option value="">全部成色</option>
               {CONDITIONS.map(c => <option key={c} value={c}>{c}</option>)}
             </select>
@@ -238,7 +457,6 @@ export function ProductMaterials() {
         </div>
       </div>
 
-      {/* 表格卡片 */}
       <motion.div
         initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}
         className="vben-card flex flex-col"
@@ -314,12 +532,10 @@ export function ProductMaterials() {
                   </td>
                   <td>
                     <div className="table-actions">
-                      <button className="table-action-btn" title="编辑"
-                        onClick={() => { setEditTarget(m); setShowModal(true) }}>
+                      <button className="table-action-btn" title="编辑" onClick={() => { setEditTarget(m); setShowModal(true) }}>
                         <Pencil className="w-4 h-4 text-blue-500" />
                       </button>
-                      <button className="table-action-btn" title="删除"
-                        onClick={() => setDeleteConfirm({ open: true, item: m })}>
+                      <button className="table-action-btn" title="删除" onClick={() => setDeleteConfirm({ open: true, item: m })}>
                         <Trash2 className="w-4 h-4 text-red-500" />
                       </button>
                     </div>
@@ -330,13 +546,15 @@ export function ProductMaterials() {
           </table>
         </div>
 
-        {/* 分页 */}
         {total > 0 && (
           <div className="flex-shrink-0 flex flex-col sm:flex-row items-center justify-between px-4 py-3 border-t border-slate-200 dark:border-slate-700 gap-3">
             <div className="flex items-center gap-2 text-sm text-slate-500">
               <span>每页</span>
-              <select value={pageSize} onChange={e => handlePageSizeChange(Number(e.target.value))}
-                className="px-2 py-1 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+              <select
+                value={pageSize}
+                onChange={e => handlePageSizeChange(Number(e.target.value))}
+                className="px-2 py-1 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
                 <option value={10}>10 条</option>
                 <option value={20}>20 条</option>
                 <option value={50}>50 条</option>
@@ -346,12 +564,18 @@ export function ProductMaterials() {
             </div>
             <div className="flex items-center gap-2">
               <span className="text-sm text-slate-500">第 {page} / {totalPages} 页</span>
-              <button onClick={() => setPage(p => p - 1)} disabled={page <= 1 || tableLoading}
-                className="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+              <button
+                onClick={() => setPage(p => p - 1)}
+                disabled={page <= 1 || tableLoading}
+                className="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
                 <ChevronLeft className="w-4 h-4" />
               </button>
-              <button onClick={() => setPage(p => p + 1)} disabled={page >= totalPages || tableLoading}
-                className="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+              <button
+                onClick={() => setPage(p => p + 1)}
+                disabled={page >= totalPages || tableLoading}
+                className="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
                 <ChevronRight className="w-4 h-4" />
               </button>
             </div>
@@ -359,7 +583,6 @@ export function ProductMaterials() {
         )}
       </motion.div>
 
-      {/* 新建/编辑弹窗 */}
       {showModal && (
         <MaterialFormModal
           initial={editTarget}
@@ -368,7 +591,13 @@ export function ProductMaterials() {
         />
       )}
 
-      {/* 删除确认弹窗 */}
+      {showAiListingModal && (
+        <AiListingModal
+          onClose={() => setShowAiListingModal(false)}
+          onTaskStarted={handleAiListingTaskStarted}
+        />
+      )}
+
       <ConfirmModal
         isOpen={deleteConfirm.open}
         title="确认删除"
@@ -380,7 +609,6 @@ export function ProductMaterials() {
         onCancel={() => setDeleteConfirm({ open: false, item: null })}
       />
 
-      {/* 批量删除确认弹窗 */}
       <ConfirmModal
         isOpen={batchDeleteConfirm}
         title="确认批量删除"

--- a/frontend/src/pages/product-publish/ProductPublish.tsx
+++ b/frontend/src/pages/product-publish/ProductPublish.tsx
@@ -12,12 +12,29 @@ import React, { useState, useEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { Send, FolderOpen, Loader2, CheckCircle, XCircle, ExternalLink, Upload, Trash2, X } from 'lucide-react'
 import { useUIStore } from '@/store/uiStore'
-import { publishSingle, getMaterials, uploadProductImages, type ProductMaterial } from '@/api/productPublish'
+import {
+  publishSingle,
+  getPublishLog,
+  getPublishLogs,
+  getMaterials,
+  uploadProductImages,
+  type PublishLog,
+  type ProductMaterial,
+} from '@/api/productPublish'
 import { getAccountDetails } from '@/api/accounts'
 import { PageLoading } from '@/components/common/Loading'
 
 const CATEGORIES = ['数码家电', '服饰鞋包', '家居日用', '图书音像', '美妆个护', '母婴用品', '运动户外', '食品生鲜', '虚拟商品', '其他']
 const CONDITIONS = ['全新', '99新', '95新', '9成新', '8成新', '7成新以下']
+const SINGLE_PUBLISH_TRACKER_KEY = 'product_publish_single_active'
+const SINGLE_PUBLISH_POLL_INTERVAL = 2000
+
+interface SinglePublishTracker {
+  account_id: string
+  title: string
+  started_at: string
+  log_id?: number
+}
 
 interface PublishForm {
   account_id: string
@@ -85,6 +102,7 @@ function MaterialPickerModal({ onSelect, onClose }: { onSelect: (m: ProductMater
 export function ProductPublish() {
   const { addToast } = useUIStore()
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [accounts, setAccounts] = useState<any[]>([])
   const [loadingAccounts, setLoadingAccounts] = useState(true)
   const [submitting, setSubmitting] = useState(false)
@@ -111,6 +129,115 @@ export function ProductPublish() {
       .then(list => { setAccounts(list); if (list.length > 0) setForm(f => ({ ...f, account_id: list[0].id })) })
       .catch(() => {})
       .finally(() => setLoadingAccounts(false))
+  }, [])
+
+  const clearSinglePublishPolling = () => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+  }
+
+  const saveSinglePublishTracker = (tracker: SinglePublishTracker) => {
+    sessionStorage.setItem(SINGLE_PUBLISH_TRACKER_KEY, JSON.stringify(tracker))
+  }
+
+  const getSinglePublishTracker = (): SinglePublishTracker | null => {
+    try {
+      const raw = sessionStorage.getItem(SINGLE_PUBLISH_TRACKER_KEY)
+      return raw ? JSON.parse(raw) as SinglePublishTracker : null
+    } catch {
+      sessionStorage.removeItem(SINGLE_PUBLISH_TRACKER_KEY)
+      return null
+    }
+  }
+
+  const clearSinglePublishTracker = () => {
+    sessionStorage.removeItem(SINGLE_PUBLISH_TRACKER_KEY)
+  }
+
+  const buildResultFromLog = (log: PublishLog) => ({
+    success: log.status === 'success',
+    message: log.status === 'success'
+      ? '商品发布成功'
+      : log.error_message || '商品发布失败',
+    item_url: log.item_url || undefined,
+    sync_status: undefined,
+    sync_message: undefined,
+    sync_total_count: 0,
+    sync_saved_count: 0,
+  })
+
+  const findTrackedPublishLog = async (tracker: SinglePublishTracker): Promise<PublishLog | null> => {
+    if (tracker.log_id) {
+      const res = await getPublishLog(tracker.log_id)
+      return res.success && res.data ? res.data : null
+    }
+
+    const res = await getPublishLogs(1, 20, tracker.account_id)
+    if (!res.success) return null
+    const startedAt = new Date(tracker.started_at).getTime()
+    const matched = res.data.list.find(log =>
+      !log.batch_id &&
+      log.account_id === tracker.account_id &&
+      log.title === tracker.title &&
+      new Date(log.created_at).getTime() >= startedAt - 60 * 1000
+    )
+    if (!matched) return null
+
+    const nextTracker = { ...tracker, log_id: matched.id }
+    saveSinglePublishTracker(nextTracker)
+    return matched
+  }
+
+  const syncSinglePublishStatus = async () => {
+    const tracker = getSinglePublishTracker()
+    if (!tracker) {
+      clearSinglePublishPolling()
+      return
+    }
+
+    try {
+      const log = await findTrackedPublishLog(tracker)
+      if (!log) {
+        if (Date.now() - new Date(tracker.started_at).getTime() > 10 * 60 * 1000) {
+          clearSinglePublishTracker()
+          clearSinglePublishPolling()
+          setSubmitting(false)
+        } else {
+          setSubmitting(true)
+        }
+        return
+      }
+
+      if (log.status === 'publishing' || log.status === 'pending') {
+        setSubmitting(true)
+        return
+      }
+
+      setSubmitting(false)
+      setResult(buildResultFromLog(log))
+      clearSinglePublishTracker()
+      clearSinglePublishPolling()
+    } catch {
+      setSubmitting(true)
+    }
+  }
+
+  const startSinglePublishPolling = () => {
+    clearSinglePublishPolling()
+    void syncSinglePublishStatus()
+    pollingRef.current = setInterval(() => {
+      void syncSinglePublishStatus()
+    }, SINGLE_PUBLISH_POLL_INTERVAL)
+  }
+
+  useEffect(() => {
+    if (getSinglePublishTracker()) {
+      setSubmitting(true)
+      startSinglePublishPolling()
+    }
+    return () => clearSinglePublishPolling()
   }, [])
 
   /** 处理图片上传 */
@@ -165,8 +292,15 @@ export function ProductPublish() {
     if (!form.description.trim()) { addToast({ type: 'warning', message: '请填写商品描述' }); return }
     if (!form.price || parseFloat(form.price) <= 0) { addToast({ type: 'warning', message: '请填写有效价格' }); return }
     if (imagePaths.length === 0) { addToast({ type: 'warning', message: '请至少上传一张商品图片' }); return }
+    const tracker: SinglePublishTracker = {
+      account_id: form.account_id,
+      title: form.title.trim(),
+      started_at: new Date().toISOString(),
+    }
+    saveSinglePublishTracker(tracker)
     setSubmitting(true)
     setResult(null)
+    startSinglePublishPolling()
     try {
       const res = await publishSingle({
         account_id: form.account_id, title: form.title, description: form.description,
@@ -193,11 +327,16 @@ export function ProductPublish() {
         })
       }
       else addToast({ type: 'error', message })
+      clearSinglePublishTracker()
+      clearSinglePublishPolling()
     } catch {
-      addToast({ type: 'error', message: '发布请求失败，请重试' })
-      setResult({ success: false, message: '网络错误，请重试' })
+      addToast({ type: 'warning', message: '发布请求连接中断，正在继续同步发布状态' })
+      setResult(null)
+      setSubmitting(true)
     } finally {
-      setSubmitting(false)
+      if (!getSinglePublishTracker()) {
+        setSubmitting(false)
+      }
     }
   }
 
@@ -368,7 +507,7 @@ export function ProductPublish() {
                   : <><Send className="w-4 h-4" />立即发布</>}
               </button>
               {submitting && (
-                <p className="text-xs text-slate-400 text-center">Playwright 发布中，请勿关闭页面</p>
+                <p className="text-xs text-slate-400 text-center">Playwright 发布中，可切换页面，返回后会继续同步状态</p>
               )}
             </div>
           </div>

--- a/frontend/src/pages/product-publish/ProductPublish.tsx
+++ b/frontend/src/pages/product-publish/ProductPublish.tsx
@@ -34,6 +34,7 @@ interface PublishForm {
   category: string
   address: string
   delivery_method: ProductDeliveryMethod
+  support_pickup: boolean
   postage: string
   brand: string
   condition: string
@@ -109,7 +110,7 @@ export function ProductPublish() {
   const [imagePreviews, setImagePreviews] = useState<string[]>([])
   const [form, setForm] = useState<PublishForm>({
     account_id: '', title: '', description: '', price: '', original_price: '',
-    category: '', address: '', delivery_method: 'express', postage: '0', brand: '', condition: '全新',
+    category: '', address: '', delivery_method: 'free_shipping', support_pickup: false, postage: '0', brand: '', condition: '全新',
   })
 
   useEffect(() => {
@@ -150,11 +151,19 @@ export function ProductPublish() {
 
   /** 从素材库导入 */
   const applyMaterial = (m: ProductMaterial) => {
+    const rawDeliveryMethod = m.delivery_method as string | undefined
+    const deliveryMethod: ProductDeliveryMethod =
+      rawDeliveryMethod === 'distance_billing' || rawDeliveryMethod === 'fixed_fee' || rawDeliveryMethod === 'no_shipping'
+        ? rawDeliveryMethod
+        : rawDeliveryMethod === 'virtual'
+          ? 'no_shipping'
+          : 'free_shipping'
     setForm(f => ({
       ...f, title: m.title, description: m.description, price: String(m.price),
       original_price: m.original_price ? String(m.original_price) : '',
       category: m.category || '', address: m.address || '',
-      delivery_method: m.delivery_method || 'express',
+      delivery_method: deliveryMethod,
+      support_pickup: m.support_pickup ?? false,
       postage: String(m.postage ?? 0), brand: m.brand || '', condition: m.condition || '全新',
     }))
     const urls = m.images || []
@@ -168,7 +177,7 @@ export function ProductPublish() {
     setForm(f => ({
       ...f,
       delivery_method: deliveryMethod,
-      postage: deliveryMethod === 'express' ? f.postage : '0',
+      postage: deliveryMethod === 'fixed_fee' ? f.postage : '0',
     }))
   }
 
@@ -188,7 +197,8 @@ export function ProductPublish() {
         original_price: form.original_price ? parseFloat(form.original_price) : undefined,
         category: form.category || undefined, images: imagePaths, address: form.address || undefined,
         delivery_method: form.delivery_method,
-        postage: form.delivery_method === 'express' ? parseFloat(form.postage) || 0 : 0,
+        support_pickup: form.support_pickup,
+        postage: form.delivery_method === 'fixed_fee' ? parseFloat(form.postage) || 0 : 0,
         brand: form.brand || undefined, condition: form.condition,
       })
       const message = res.message || (res.success ? '商品发布成功' : '发布失败')
@@ -310,21 +320,33 @@ export function ProductPublish() {
                 ))}
               </div>
             </div>
-            {/* 发货 + 邮费 */}
+            {/* 发货方式 */}
             <div className="grid grid-cols-2 gap-4">
-              <div className="input-group">
+              <div className="input-group col-span-2">
                 <label className="input-label">发货方式</label>
-                <select className="input-ios" value={form.delivery_method}
-                  onChange={e => updateDeliveryMethod(e.target.value as ProductDeliveryMethod)}>
-                  <option value="express">快递发货</option>
-                  <option value="pickup">自提</option>
-                  <option value="virtual">无需邮寄</option>
-                </select>
+                <div className="flex items-center gap-3 flex-wrap">
+                  <select className="input-ios w-full sm:w-[320px]" value={form.delivery_method}
+                    onChange={e => updateDeliveryMethod(e.target.value as ProductDeliveryMethod)}>
+                    <option value="free_shipping">包邮</option>
+                    <option value="distance_billing">按距离计费</option>
+                    <option value="fixed_fee">一口价</option>
+                    <option value="no_shipping">无需邮寄</option>
+                  </select>
+                  <label className="switch-ios flex-shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={form.support_pickup}
+                      onChange={e => setForm(f => ({ ...f, support_pickup: e.target.checked }))}
+                    />
+                    <span className="switch-slider"></span>
+                  </label>
+                  <span className="text-sm text-slate-600 dark:text-slate-300 flex-shrink-0">支持自提</span>
+                </div>
               </div>
-              {form.delivery_method === 'express' && (
+              {form.delivery_method === 'fixed_fee' && (
                 <div className="input-group">
-                  <label className="input-label">邮费（元，0=包邮）</label>
-                  <input type="number" className="input-ios" placeholder="0" min="0" step="0.01"
+                  <label className="input-label">运费（元）</label>
+                  <input type="number" className="input-ios w-full sm:w-[320px]" placeholder="0" min="0" step="0.01"
                     value={form.postage} onChange={e => setForm(f => ({ ...f, postage: e.target.value }))} />
                 </div>
               )}

--- a/frontend/src/pages/product-publish/ProductPublish.tsx
+++ b/frontend/src/pages/product-publish/ProductPublish.tsx
@@ -12,7 +12,13 @@ import React, { useState, useEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { Send, FolderOpen, Loader2, CheckCircle, XCircle, ExternalLink, Upload, Trash2, X } from 'lucide-react'
 import { useUIStore } from '@/store/uiStore'
-import { publishSingle, getMaterials, uploadProductImages, type ProductMaterial } from '@/api/productPublish'
+import {
+  publishSingle,
+  getMaterials,
+  uploadProductImages,
+  type ProductDeliveryMethod,
+  type ProductMaterial,
+} from '@/api/productPublish'
 import { getAccountDetails } from '@/api/accounts'
 import { PageLoading } from '@/components/common/Loading'
 
@@ -27,7 +33,7 @@ interface PublishForm {
   original_price: string
   category: string
   address: string
-  delivery_method: 'express' | 'pickup'
+  delivery_method: ProductDeliveryMethod
   postage: string
   brand: string
   condition: string
@@ -148,7 +154,7 @@ export function ProductPublish() {
       ...f, title: m.title, description: m.description, price: String(m.price),
       original_price: m.original_price ? String(m.original_price) : '',
       category: m.category || '', address: m.address || '',
-      delivery_method: (m.delivery_method as 'express' | 'pickup') || 'express',
+      delivery_method: m.delivery_method || 'express',
       postage: String(m.postage ?? 0), brand: m.brand || '', condition: m.condition || '全新',
     }))
     const urls = m.images || []
@@ -156,6 +162,14 @@ export function ProductPublish() {
     setImagePreviews(urls)
     setShowPicker(false)
     addToast({ type: 'success', message: '已从素材库导入' })
+  }
+
+  const updateDeliveryMethod = (deliveryMethod: ProductDeliveryMethod) => {
+    setForm(f => ({
+      ...f,
+      delivery_method: deliveryMethod,
+      postage: deliveryMethod === 'express' ? f.postage : '0',
+    }))
   }
 
   /** 发布商品 */
@@ -173,7 +187,8 @@ export function ProductPublish() {
         price: parseFloat(form.price),
         original_price: form.original_price ? parseFloat(form.original_price) : undefined,
         category: form.category || undefined, images: imagePaths, address: form.address || undefined,
-        delivery_method: form.delivery_method, postage: parseFloat(form.postage) || 0,
+        delivery_method: form.delivery_method,
+        postage: form.delivery_method === 'express' ? parseFloat(form.postage) || 0 : 0,
         brand: form.brand || undefined, condition: form.condition,
       })
       const message = res.message || (res.success ? '商品发布成功' : '发布失败')
@@ -300,16 +315,19 @@ export function ProductPublish() {
               <div className="input-group">
                 <label className="input-label">发货方式</label>
                 <select className="input-ios" value={form.delivery_method}
-                  onChange={e => setForm(f => ({ ...f, delivery_method: e.target.value as 'express' | 'pickup' }))}>
+                  onChange={e => updateDeliveryMethod(e.target.value as ProductDeliveryMethod)}>
                   <option value="express">快递发货</option>
                   <option value="pickup">自提</option>
+                  <option value="virtual">无需邮寄</option>
                 </select>
               </div>
-              <div className="input-group">
-                <label className="input-label">邮费（元，0=包邮）</label>
-                <input type="number" className="input-ios" placeholder="0" min="0" step="0.01"
-                  value={form.postage} onChange={e => setForm(f => ({ ...f, postage: e.target.value }))} />
-              </div>
+              {form.delivery_method === 'express' && (
+                <div className="input-group">
+                  <label className="input-label">邮费（元，0=包邮）</label>
+                  <input type="number" className="input-ios" placeholder="0" min="0" step="0.01"
+                    value={form.postage} onChange={e => setForm(f => ({ ...f, postage: e.target.value }))} />
+                </div>
+              )}
             </div>
             {/* 所在地 */}
             <div className="input-group">

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -379,6 +379,7 @@
     @apply fixed inset-0 bg-black/50 dark:bg-black/70 z-50
            flex items-center justify-center p-4
            animate-fade-in;
+    margin-top: 0 !important;
   }
 
   .modal-content {


### PR DESCRIPTION
## 修改内容

- 新增素材库 AI 铺货配置管理，支持多套配置的新增、编辑、删除和搜索
- 支持 OpenAI 格式的文案生成、图片提示词润色和图片生成接口
- 支持固定价格、价格区间、随机选图、AI 多图生成和多图关联
- 增加后台多任务生成、并发控制、失败重试、实时进度和素材列表刷新
- 支持素材图片放大预览，并恢复切换页面后的单品发布状态
- 添加无需邮寄的发货方式 #238 ，发货相关设置对齐闲鱼网页端，支持自提改为单独的开关

## 检查

- `npx tsc --noEmit`
- `python -m py_compile backend-web/app/api/routes/product_publish.py backend-web/app/services/ai_listing_service.py backend-web/app/services/ai_listing_task_status_service.py backend-web/app/services/publish_execution_service.py common/models/ai_listing_config.py common/services/ai_provider_service.py`
- `git diff --check upstream/main...HEAD`
