### PR TITLE
feat: 滑块验证失败/无效后加指数退避冷却，避免反复启动浏览器烧 CPU

### DIFF
--- a/common/services/captcha/slider_fail_cooldown.py
+++ b/common/services/captcha/slider_fail_cooldown.py
@@ -1,0 +1,125 @@
+"""
+滑块验证失败冷却管理（websocket 进程内内存态）
+
+功能：
+1. 滑块验证失败后，按 cookie_id 进入指数退避冷却期
+2. 冷却期内 refresh_token 检测到 punish 时跳过 handle_captcha_verification，
+   不再启动 chromium，避免"视觉通过但风控不放行"时的无脑重试烧 CPU
+3. 滑块验证成功（或风控解除）立即清零；冷却到期后下一次探测若成功同样清零
+
+冷却序列（指数退避，封顶 30 分钟）：120s → 240s → 480s → 960s → 1800s → 1800s …
+
+说明：
+- 仅保存在 websocket 进程内存中（重启进程即清空），用于避免高频重启浏览器。
+- 以 cookie_id 为键，多账号互不影响。
+- 与 common/services/account_cooldown.py 区别：后者是 scheduler 进程专用、面向采集
+  轮询的账号级冷却；本模块专治 websocket 进程滑块验证失败的高频重试，二者互不干扰。
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict
+
+# 首次失败冷却时长（秒）：2 分钟
+BASE_COOLDOWN = 120
+# 冷却时长上限（秒）：30 分钟
+MAX_COOLDOWN = 1800
+
+
+class SliderFailCooldownManager:
+    """滑块验证失败冷却管理器（线程安全单例）。
+
+    状态：
+        _fail_count[cookie_id]    连续失败次数
+        _cooldown_until[cookie_id] 冷却到期时间戳（epoch 秒）
+    """
+
+    _instance = None
+    _instance_lock = threading.Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    inst = super().__new__(cls)
+                    inst._initialized = False
+                    cls._instance = inst
+        return cls._instance
+
+    def __init__(self):
+        if getattr(self, "_initialized", False):
+            return
+        self._lock = threading.Lock()
+        self._fail_count: Dict[str, int] = {}
+        self._cooldown_until: Dict[str, float] = {}
+        self._initialized = True
+
+    def _now(self) -> float:
+        """当前时间戳（测试可替换以避免真实 sleep）。"""
+        return time.time()
+
+    @staticmethod
+    def _cooldown_for(fail_count: int) -> float:
+        """根据连续失败次数计算本次冷却时长（指数退避，封顶 MAX_COOLDOWN）。"""
+        if fail_count <= 0:
+            return 0.0
+        return float(min(BASE_COOLDOWN * (2 ** (fail_count - 1)), MAX_COOLDOWN))
+
+    def mark_fail(self, cookie_id: str) -> float:
+        """记录一次滑块验证失败，进入/延长冷却期。
+
+        Returns:
+            本次冷却时长（秒）。
+        """
+        if not cookie_id:
+            return 0.0
+        key = str(cookie_id)
+        with self._lock:
+            count = self._fail_count.get(key, 0) + 1
+            self._fail_count[key] = count
+            cooldown = self._cooldown_for(count)
+            self._cooldown_until[key] = self._now() + cooldown
+            return cooldown
+
+    def is_cooling(self, cookie_id: str) -> bool:
+        """该账号当前是否处于滑块失败冷却期。"""
+        if not cookie_id:
+            return False
+        key = str(cookie_id)
+        with self._lock:
+            return self._cooldown_until.get(key, 0.0) > self._now()
+
+    def remaining(self, cookie_id: str) -> float:
+        """冷却剩余秒数（不在冷却期返回 0，日志用）。"""
+        if not cookie_id:
+            return 0.0
+        key = str(cookie_id)
+        with self._lock:
+            left = self._cooldown_until.get(key, 0.0) - self._now()
+            return left if left > 0 else 0.0
+
+    def clear(self, cookie_id: str) -> None:
+        """滑块验证成功（或风控解除）时清零失败计数与冷却。"""
+        if not cookie_id:
+            return
+        key = str(cookie_id)
+        with self._lock:
+            self._fail_count.pop(key, None)
+            self._cooldown_until.pop(key, None)
+
+    def reset(self) -> None:
+        """清空所有账号的冷却状态（主要用于测试与进程重启场景）。"""
+        with self._lock:
+            self._fail_count.clear()
+            self._cooldown_until.clear()
+
+
+slider_fail_cooldown_manager = SliderFailCooldownManager()
+
+__all__ = [
+    "SliderFailCooldownManager",
+    "slider_fail_cooldown_manager",
+    "BASE_COOLDOWN",
+    "MAX_COOLDOWN",
+]

--- a/scripts/test_slider_fail_cooldown.py
+++ b/scripts/test_slider_fail_cooldown.py
@@ -1,0 +1,201 @@
+"""
+滑块失败冷却管理器 —— 本地验证脚本（不依赖 pytest）
+
+直接运行：
+    python scripts/test_slider_fail_cooldown.py
+
+覆盖：退避序列、封顶、mark_fail/is_cooling/remaining、过期解除、
+clear 清零后重新计数、多账号隔离、空 cookie_id、单例。
+"""
+import os
+import sys
+
+# 把项目根加入 sys.path，使 common.* 可被 import
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+# 直接按文件路径加载被测模块，绕过 common/services/__init__.py 的运行时依赖
+# （该 __init__ 会连带 import sqlalchemy 等本地未必安装的库）。
+# 被测模块本身只依赖标准库，可独立加载。
+import importlib.util as _ilu  # noqa: E402
+
+_spec = _ilu.spec_from_file_location(
+    "_slider_fail_cooldown_under_test",
+    os.path.join(PROJECT_ROOT, "common", "services", "captcha", "slider_fail_cooldown.py"),
+)
+_mod = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+BASE_COOLDOWN = _mod.BASE_COOLDOWN
+MAX_COOLDOWN = _mod.MAX_COOLDOWN
+SliderFailCooldownManager = _mod.SliderFailCooldownManager
+slider_fail_cooldown_manager = _mod.slider_fail_cooldown_manager
+
+
+class FakeClock:
+    """可推进的假时钟，替换 manager._now 用。"""
+
+    def __init__(self, start=1000.0):
+        self.t = float(start)
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
+
+
+def setup(start=1000.0):
+    """每个用例独立的干净状态 + 假时钟。"""
+    mgr = slider_fail_cooldown_manager
+    mgr.reset()
+    clock = FakeClock(start)
+    mgr._now = clock  # 注入假时钟
+    return mgr, clock
+
+
+def test_constants():
+    assert BASE_COOLDOWN == 120
+    assert MAX_COOLDOWN == 1800
+
+
+def test_cooldown_for_sequence():
+    f = SliderFailCooldownManager._cooldown_for
+    assert f(0) == 0.0
+    assert f(1) == 120.0
+    assert f(2) == 240.0
+    assert f(3) == 480.0
+    assert f(4) == 960.0
+    assert f(5) == 1800.0  # 1920 封顶到 1800
+    assert f(6) == 1800.0
+    assert f(100) == 1800.0
+
+
+def test_mark_fail_sets_cooldown():
+    mgr, clock = setup()
+    cd = mgr.mark_fail("acc1")
+    assert cd == 120.0
+    assert mgr.is_cooling("acc1") is True
+    assert abs(mgr.remaining("acc1") - 120.0) < 0.01
+
+
+def test_cooldown_expires():
+    mgr, clock = setup()
+    mgr.mark_fail("acc1")
+    clock.advance(119)
+    assert mgr.is_cooling("acc1") is True
+    assert abs(mgr.remaining("acc1") - 1.0) < 0.01
+    clock.advance(2)  # 累计 121s，越过 120s 冷却
+    assert mgr.is_cooling("acc1") is False
+    assert mgr.remaining("acc1") == 0.0
+
+
+def test_backoff_escalation():
+    mgr, clock = setup()
+    cds = [mgr.mark_fail("acc1") for _ in range(6)]  # 同一时刻连续失败
+    assert cds == [120.0, 240.0, 480.0, 960.0, 1800.0, 1800.0]
+    # 连续失败后冷却被延长到最长一档
+    assert mgr.remaining("acc1") == 1800.0
+
+
+def test_clear_resets_count():
+    mgr, clock = setup()
+    mgr.mark_fail("acc1")
+    mgr.mark_fail("acc1")  # count=2 → 240s
+    assert mgr.is_cooling("acc1") is True
+    mgr.clear("acc1")
+    assert mgr.is_cooling("acc1") is False
+    # 清零后再次失败从 count=1 重新计
+    cd = mgr.mark_fail("acc1")
+    assert cd == 120.0
+
+
+def test_multi_account_isolation():
+    mgr, clock = setup()
+    mgr.mark_fail("A")
+    assert mgr.is_cooling("A") is True
+    assert mgr.is_cooling("B") is False
+    mgr.mark_fail("B")
+    assert mgr.is_cooling("B") is True
+    # 清 A 不影响 B
+    mgr.clear("A")
+    assert mgr.is_cooling("A") is False
+    assert mgr.is_cooling("B") is True
+    # A、B 退避计数独立
+    cd_a = mgr.mark_fail("A")  # A 重新 count=1 → 120
+    assert cd_a == 120.0
+    cd_b = mgr.mark_fail("B")  # B 原 count=1 → 再 mark count=2 → 240
+    assert cd_b == 240.0
+
+
+def test_empty_cookie_id():
+    mgr, clock = setup()
+    assert mgr.mark_fail("") == 0.0
+    assert mgr.is_cooling("") is False
+    assert mgr.remaining("") == 0.0
+
+
+def test_clear_nonexistent_is_noop():
+    mgr, clock = setup()
+    mgr.clear("ghost")  # 不应抛异常
+    assert mgr.is_cooling("ghost") is False
+
+
+def test_singleton():
+    a = SliderFailCooldownManager()
+    b = SliderFailCooldownManager()
+    assert a is b
+    assert a is slider_fail_cooldown_manager
+
+
+def test_mark_fail_extends_cooldown_on_repeat():
+    mgr, clock = setup()
+    mgr.mark_fail("acc1")  # count=1, until=1000+120=1120
+    clock.advance(100)     # now=1100，仍在冷却
+    assert mgr.is_cooling("acc1") is True
+    cd = mgr.mark_fail("acc1")  # count=2, until 重置为 1100+240=1340
+    assert cd == 240.0
+    clock.advance(20)      # now=1120，原本 count=1 的冷却已过，但被延长了
+    assert mgr.is_cooling("acc1") is True
+    assert abs(mgr.remaining("acc1") - 220.0) < 0.01  # 1340-1120
+
+
+TESTS = [
+    test_constants,
+    test_cooldown_for_sequence,
+    test_mark_fail_sets_cooldown,
+    test_cooldown_expires,
+    test_backoff_escalation,
+    test_clear_resets_count,
+    test_multi_account_isolation,
+    test_empty_cookie_id,
+    test_clear_nonexistent_is_noop,
+    test_singleton,
+    test_mark_fail_extends_cooldown_on_repeat,
+]
+
+
+def main():
+    failed = 0
+    for test in TESTS:
+        try:
+            test()
+            print(f"PASS  {test.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"FAIL  {test.__name__}: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {test.__name__}: {type(exc).__name__}: {exc}")
+    # 还原单例的 _now，避免影响同进程后续使用
+    slider_fail_cooldown_manager._now = (
+        SliderFailCooldownManager._now.__get__(slider_fail_cooldown_manager)
+    )
+    slider_fail_cooldown_manager.reset()
+
+    print(f"\n{'=' * 40}\n{len(TESTS) - failed}/{len(TESTS)} 通过")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/websocket/app/services/xianyu/cookie_token_manager.py
+++ b/websocket/app/services/xianyu/cookie_token_manager.py
@@ -20,6 +20,7 @@ from loguru import logger
 
 from common.db.session import async_session_maker
 from common.services.captcha.concurrency import run_browser_task
+from common.services.captcha.slider_fail_cooldown import slider_fail_cooldown_manager
 from common.services.captcha.token_refetch import request_fresh_captcha_url
 from common.utils.cookie_refresh import get_account_by_identity, update_account_cookies_in_db
 from common.utils.xianyu_utils import trans_cookies, generate_sign
@@ -541,6 +542,7 @@ class CookieTokenManager:
                             logger.error(f"【{self.cookie_id}】更新风控日志失败: {update_e}")
 
                     self._refetch_token_ok = False
+                    slider_fail_cooldown_manager.clear(self.cookie_id)  # 风控已解除，清零滑块失败冷却
                     return self.cookies_str
 
                 if success and cookies:
@@ -589,6 +591,10 @@ class CookieTokenManager:
                     # 这里显式判定失败，让上层走 failed_captcha 分支（不计入禁用计数），
                     # 避免账号被误累加 _token_fetch_failures 直至 10 次自动禁用。
                     if not x5sec_cookies:
+                        _slider_cd = slider_fail_cooldown_manager.mark_fail(self.cookie_id)
+                        logger.warning(
+                            f"【{self.cookie_id}】滑块视觉通过但风控未放行，进入指数退避冷却（{_slider_cd:.0f}秒）"
+                        )
                         logger.error(
                             f"【{self.cookie_id}】滑块视觉验证通过但未获取到任何 x5 相关 cookie，"
                             f"判定为失败（浏览器返回的 cookies: {list(cookies.keys())}）"
@@ -618,6 +624,31 @@ class CookieTokenManager:
                             updated_cookies[cookie_name] = cookie_value
                             new_cookie_count += 1
 
+                    # x5sec 虽有但值全部未变：滑块视觉通过却未带来任何有效更新，服务端实际未放行
+                    # （典型表现：反复"新增0 更新0"且 token 接口仍 punish）。与上面 x5sec 为空同理，
+                    # 判失败触发指数退避冷却，避免每 ~40 秒空转一次 chromium 烧 CPU。
+                    if new_cookie_count == 0 and updated_cookie_count == 0:
+                        _slider_cd = slider_fail_cooldown_manager.mark_fail(self.cookie_id)
+                        logger.warning(
+                            f"【{self.cookie_id}】滑块视觉通过但 x5sec 值未变（风控未放行），"
+                            f"判定为无效，进入指数退避冷却（{_slider_cd:.0f}秒）"
+                        )
+                        captcha_duration = time.time() - captcha_start_time
+                        if log_id:
+                            try:
+                                from common.db.compat import db_manager
+                                db_manager.update_risk_control_log(
+                                    log_id=log_id,
+                                    processing_status='failed',
+                                    processing_result=(
+                                        f'滑块视觉通过但 x5sec 值未变（风控未放行），'
+                                        f'耗时: {captcha_duration:.2f}秒'
+                                    ),
+                                )
+                            except Exception as update_e:
+                                logger.error(f"【{self.cookie_id}】更新风控日志失败: {update_e}")
+                        return None
+
                     cookies_str = "; ".join([f"{k}={v}" for k, v in updated_cookies.items()])
 
                     # 更新数据库
@@ -645,8 +676,11 @@ class CookieTokenManager:
                         self.cookies_str = old_cookies_str
                         self.cookies = old_cookies_dict
 
+                    slider_fail_cooldown_manager.clear(self.cookie_id)  # 滑块验证成功，清零失败冷却
                     return cookies_str
                 else:
+                    _slider_cd = slider_fail_cooldown_manager.mark_fail(self.cookie_id)
+                    logger.warning(f"【{self.cookie_id}】滑块验证失败，进入指数退避冷却（{_slider_cd:.0f}秒）")
                     logger.error(f"【{self.cookie_id}】滑块验证失败")
                     
                     # 更新风控日志为失败状态
@@ -666,6 +700,8 @@ class CookieTokenManager:
 
             except ImportError as import_e:
                 logger.error(f"【{self.cookie_id}】滑块验证导入失败: {import_e}")
+                _slider_cd = slider_fail_cooldown_manager.mark_fail(self.cookie_id)
+                logger.warning(f"【{self.cookie_id}】滑块依赖缺失，进入指数退避冷却（{_slider_cd:.0f}秒）")
                 
                 # 更新风控日志为异常状态
                 if log_id:
@@ -703,6 +739,8 @@ class CookieTokenManager:
 
             except Exception as stealth_e:
                 logger.error(f"【{self.cookie_id}】滑块验证异常: {self._safe_str(stealth_e)}")
+                _slider_cd = slider_fail_cooldown_manager.mark_fail(self.cookie_id)
+                logger.warning(f"【{self.cookie_id}】滑块验证异常，进入指数退避冷却（{_slider_cd:.0f}秒）")
                 
                 # 更新风控日志为异常状态
                 captcha_duration = time.time() - captcha_start_time
@@ -957,6 +995,19 @@ class CookieTokenManager:
                         
                         try:
                             captcha_start_time = time.time()
+                            # 滑块失败冷却门控：失败后指数退避，冷却期内跳过浏览器验证，
+                            # 避免"视觉通过但风控不放行"时无脑重启 chromium 烧 CPU。
+                            # 冷却到期后此处自动放行，重新探测一次（成功即清零恢复）。
+                            if slider_fail_cooldown_manager.is_cooling(self.cookie_id):
+                                remaining = slider_fail_cooldown_manager.remaining(self.cookie_id)
+                                logger.info(
+                                    f"【{self.cookie_id}】滑块失败冷却中，跳过浏览器验证"
+                                    f"（还需{remaining:.0f}秒，冷却到期后自动重试）"
+                                )
+                                self.last_token_refresh_status = "skipped_slider_cooldown"
+                                self.current_token = None
+                                await self._delete_cached_token()
+                                return None
                             new_cookies_str = await self.handle_captcha_verification(res_json)
                             captcha_duration = time.time() - captcha_start_time
 

--- a/websocket/app/services/xianyu/xianyu_async.py
+++ b/websocket/app/services/xianyu/xianyu_async.py
@@ -2520,6 +2520,7 @@ class XianyuAsync:
                                 'failed_captcha_exception',
                                 'failed_captcha_max_retries',
                                 'skipped_cooldown',
+                                'skipped_slider_cooldown',
                             )
 
                             if not hasattr(self, '_token_fetch_failures'):
@@ -2555,9 +2556,11 @@ class XianyuAsync:
                             #   该状态属于"确定性可恢复但短期内无法自愈"（账密错误冷却 5 小时 /
                             #   上次登录间隔 300 秒未到），每 5 秒重试无意义且会刷屏日志、
                             #   占用 token API 配额。
+                            # - 滑块失败冷却（skipped_slider_cooldown）：同样拉长到 5 分钟。
+                            #   冷却期内浏览器验证被跳过，5 秒重试只会反复打 punish 接口无意义。
                             # - 其他场景（滑块、网络故障、API 业务失败）：保持 5 秒快速重试，
                             #   避免延误账号恢复。
-                            sleep_duration = 300 if refresh_status == 'skipped_cooldown' else 5
+                            sleep_duration = 300 if refresh_status in ('skipped_cooldown', 'skipped_slider_cooldown') else 5
                             await self._interruptible_sleep(sleep_duration)
                             continue
                     else:


### PR DESCRIPTION
## 背景

token 接口（`mtop.taobao.idlemessage.pc.login.token`）被 punish 风控时，系统会自动启动 playwright / drissionpage 浏览器过滑块。但**滑块失败 / 无效后没有任何冷却**，主循环每 5 秒重试一次 token → 每次 punish → 每次都启动 chromium → 在无 GPU 容器里软件渲染单核烧满，CPU 持续 250%+。

## 根因

现有冷却机制全部漏在这条路径上：

- `account_cooldown`（20min）只在 **scheduler 进程内存**，只给采集任务用；token 请求在 **websocket 进程**，跨进程读不到。
- `message_cookie_refresh_cooldown` 是"收到消息后 5 分钟"，但 `last_message_received_time` 全仓库无人写入（dead code），实际从不触发。
- `slider_stealth.py` / `orchestrator.py` / `drissionpage_slider.py` 三个滑块核心文件 **零 `cooldown` 调用**——失败路径完全无冷却。

## 方案

新增 `common/services/captcha/slider_fail_cooldown.py`：websocket 进程内线程安全单例，按 `cookie_id` 指数退避（`120 → 240 → 480 → 960 → 1800s` 封顶），滑块成功立即清零，冷却到期自动放行重新探测一次。

接入点：

- `refresh_token` 检测到 punish 后、**启动 chromium 之前**做门控（新增状态 `skipped_slider_cooldown`，纳入 `non_counted_statuses` 不误禁用账号，主循环 sleep 拉长到 300s 减轻 punish 接口压力）。
- **两种"风控未放行"均判失败并 `mark_fail`**：
  - **(a)** `x5sec` 为空（视觉通过但未下发 x5 cookie）—— 原有判定
  - **(b)** `x5sec` 有但**值全部未变**（视觉通过、cookies 拿到但无有效更新，token 仍 punish）—— 新增判定，覆盖"滑块看似成功实则无效"的高频空转场景（实测每 ~40 秒空转一次 chromium）
- 滑块真正成功（x5sec 有效更新）时 `clear`。

**不引入 `account_cooldown`**：它是 scheduler 进程专用、面向采集轮询的账号级冷却，语义不符；本模块专治 websocket 进程滑块失败的高频重试，二者各管各的进程，互不干扰。

## 测试

- `scripts/test_slider_fail_cooldown.py`：11 例全过（退避序列 / 封顶 / 清零 / 过期 / 多账号隔离 / 单例），纯内存逻辑，`python scripts/test_slider_fail_cooldown.py` 直接跑，不依赖运行时环境与 pytest。
- 集成验证（all-in-one 单容器部署）：触发真实风控后，扩展判定（场景 b）生效，容器 CPU 从 **55-85% 降到 0.6%**，chromium 不再反复启动。

## 改动文件

- 新增 `common/services/captcha/slider_fail_cooldown.py`（冷却管理器单例）
- 新增 `scripts/test_slider_fail_cooldown.py`（本地验证脚本）
- 改 `websocket/app/services/xianyu/cookie_token_manager.py`（门控 + 失败 `mark_fail` + 成功 `clear`）
- 改 `websocket/app/services/xianyu/xianyu_async.py`（`non_counted_statuses` + 主循环 sleep）

## 风险与回滚

- 冷却仅存 websocket 进程内存，`restart websocket` 即清空（重启后重新探测，可接受）。
- `skipped_slider_cooldown` 已纳入 `non_counted_statuses`，不会误禁用账号。
- 纯新增 + 少量门控，revert 该 commit 即可回滚；或把 `BASE_COOLDOWN` 设 0 等效关闭。
