### PR TITLE
feat/fix: 自动化消息桥接、补发货与 AI 输出黑名单优化

### DIFF
--- a/backend-web/app/api/routes/chat_new.py
+++ b/backend-web/app/api/routes/chat_new.py
@@ -398,6 +398,43 @@ class SendMessageRequest(BaseModel):
     text: str
 
 
+@router.post("/internal/send-message/{account_id}")
+async def internal_send_message(
+    account_id: str,
+    req: SendMessageRequest,
+):
+    """通过 chat-new 的主 IM 连接发送自动化消息。"""
+    try:
+        if not req.text.strip():
+            return ApiResponse(success=False, message="消息内容不能为空")
+
+        manager = get_im_session_manager()
+        client = manager.clients.get(account_id)
+        if not client or not client.is_connected:
+            client = await manager.get_or_connect(account_id)
+
+        send_result = await client.send_text_message(
+            cid=req.cid,
+            to_user_id=req.toUserId,
+            text=req.text,
+        )
+        logger.info(
+            f"【{account_id}】自动化消息经 chat-new 发送成功: "
+            f"cid={req.cid}, to={req.toUserId}, text={req.text[:50]}"
+        )
+        return ApiResponse(
+            success=True,
+            message="发送成功",
+            data={"messageId": send_result.get("messageId", "")},
+        )
+    except Exception as e:
+        logger.warning(
+            f"【{account_id}】自动化消息经 chat-new 发送失败: "
+            f"cid={req.cid}, to={req.toUserId}, error={e}"
+        )
+        return ApiResponse(success=False, message=f"发送失败：{e}")
+
+
 class RecallMessageRequest(BaseModel):
     messageId: str
     messageTime: int

--- a/backend-web/app/api/routes/message_filters.py
+++ b/backend-web/app/api/routes/message_filters.py
@@ -23,14 +23,14 @@ from common.utils.auth_scope import resolve_owner_scope
 from app.services.account_service import AccountService
 
 router = APIRouter(tags=["message-filters"])
-VALID_FILTER_TYPES = {"skip_reply", "skip_notify"}
+VALID_FILTER_TYPES = {"skip_reply", "skip_notify", "skip_ai_reply_output"}
 
 
 class MessageFilterCreate(BaseModel):
     """创建消息过滤规则请求"""
     account_id: str
     keyword: str
-    filter_types: List[str]  # 支持多选: ['skip_reply', 'skip_notify']
+    filter_types: List[str]  # 支持多选: ['skip_reply', 'skip_notify', 'skip_ai_reply_output']
 
 
 class MessageFilterBatchCreate(BaseModel):
@@ -340,7 +340,7 @@ async def update_message_filter(
         params["keyword"] = filter_data.keyword.strip()
     
     if filter_data.filter_type is not None:
-        if filter_data.filter_type not in ["skip_reply", "skip_notify"]:
+        if filter_data.filter_type not in VALID_FILTER_TYPES:
             raise HTTPException(status_code=400, detail="无效的过滤类型")
         updates.append("filter_type = :filter_type")
         params["filter_type"] = filter_data.filter_type

--- a/backend-web/app/services/chat_new/automation_bridge.py
+++ b/backend-web/app/services/chat_new/automation_bridge.py
@@ -1,0 +1,26 @@
+"""Bridge chat-new push messages into the automation websocket service."""
+from __future__ import annotations
+
+from loguru import logger
+
+from app.core.config import get_settings
+from app.core.http_client import get_http_client
+
+
+async def forward_message_to_automation(account_id: str, message_data: dict) -> None:
+    """Forward one decrypted IM push message to the automation service."""
+    if not account_id or not isinstance(message_data, dict):
+        return
+
+    try:
+        settings = get_settings()
+        url = (
+            f"{settings.websocket_service_url.rstrip('/')}"
+            f"/internal/accounts/{account_id}/ingest-message"
+        )
+        await get_http_client().post(
+            url,
+            json={"message_data": message_data, "source": "chat_new"},
+        )
+    except Exception as exc:
+        logger.warning(f"【{account_id}】转发在线聊天推送到自动化服务失败: {exc}")

--- a/backend-web/app/services/chat_new/im_client.py
+++ b/backend-web/app/services/chat_new/im_client.py
@@ -212,12 +212,14 @@ class GoofishImClient:
 
     @property
     def is_connected(self) -> bool:
-        """是否已连接并注册（含底层 ws 真实状态双重检查，避免标志位与实际连接不同步）"""
+        """是否已连接并注册（含底层连接真实状态检查，避免标志位与实际连接不同步）"""
         return (
             self._connected
             and self._registered
             and self._ws is not None
             and not self._ws.closed
+            and self._session is not None
+            and not self._session.closed
         )
 
     # ==================== 业务接口 ====================
@@ -898,6 +900,8 @@ class GoofishImClient:
     async def _send_raw(self, msg: dict):
         """直接发送消息（不等待响应）"""
         if not self._ws or self._ws.closed:
+            self._connected = False
+            self._registered = False
             raise Exception("WebSocket未连接")
         await self._ws.send_json(msg)
 
@@ -916,6 +920,8 @@ class GoofishImClient:
             响应消息字典
         """
         if not self._ws or self._ws.closed:
+            self._connected = False
+            self._registered = False
             raise Exception("WebSocket未连接")
 
         loop = asyncio.get_event_loop()
@@ -1056,6 +1062,16 @@ class GoofishImClient:
                 decrypted = self._push_parser.decrypt_push_data(sync_data["data"])
                 if decrypted is None:
                     continue
+                try:
+                    from .automation_bridge import forward_message_to_automation
+
+                    asyncio.create_task(
+                        forward_message_to_automation(self.account_id, decrypted)
+                    )
+                except Exception as bridge_e:
+                    logger.warning(
+                        f"[{self.account_id}] forward push to automation failed: {bridge_e}"
+                    )
                 parsed = self._push_parser.parse(decrypted)
                 if parsed is None:
                     continue
@@ -1084,6 +1100,8 @@ class GoofishImClient:
                     logger.warning(
                         f"【{self.account_id}】心跳发送失败: {e}"
                     )
+                    self._connected = False
+                    self._registered = False
                     break
         except asyncio.CancelledError:
             pass

--- a/backend-web/app/services/system_setting_service.py
+++ b/backend-web/app/services/system_setting_service.py
@@ -53,6 +53,8 @@ DEFAULT_SYSTEM_SETTINGS: dict[str, tuple[str, str | None]] = {
     "theme.font_family": ("system", "系统主题字体预设"),
     "log.retention_days": ("7", "日志保留天数（所有模块生效，修改后实时刷新各服务日志策略）"),
     "account.face_verify_timeout_disable": ("true", "人脸验证超时是否自动禁用账号"),
+    "delivery.manual_redelivery_cooldown_seconds": ("0", "卖家手动补发成功后的冷却秒数"),
+    "delivery.manual_redelivery_lock_seconds": ("0", "卖家手动补发成功后的延迟锁秒数"),
     # 代理设置：用于配置网络请求的代理 API URL 和启用开关
     # api_url 默认空字符串表示未配置；enabled 默认 false 表示不启用
     "proxy.api_url": ("", "代理 API 的 URL（可能较长，用于配置外部代理服务）"),
@@ -112,6 +114,8 @@ NO_ESCAPE_KEYS = {
     # 用户到期/续期设置：均为数字字符串，无需 XSS 转义
     "user.renew_month_price",
     "user.register_default_days",
+    "delivery.manual_redelivery_cooldown_seconds",
+    "delivery.manual_redelivery_lock_seconds",
     # 代理设置：URL 含 :、/、?、&、= 等字符不能被 XSS 转义；布尔字符串"true"/"false"也无需转义
     "proxy.api_url",
     "proxy.enabled",

--- a/frontend/src/pages/autoReplyLogs/AutoReplyLogs.tsx
+++ b/frontend/src/pages/autoReplyLogs/AutoReplyLogs.tsx
@@ -44,6 +44,7 @@ const DECISION_REASON_LABELS: Record<string, string> = {
   item_not_belong: '商品不属于当前账号',
   duplicate_message: '重复消息',
   skip_reply_filter: '命中过滤规则',
+  ai_output_filter: 'AI回复命中黑名单',
   reply_sent: '已发送回复',
   send_failed: '发送失败',
   no_rule_matched: '未匹配回复规则',

--- a/frontend/src/pages/cards/CardFormModal.tsx
+++ b/frontend/src/pages/cards/CardFormModal.tsx
@@ -37,6 +37,7 @@ const postParams = [
   { name: 'spec_value', desc: '规格值' },
   { name: 'cookie_id', desc: 'cookies账号id' },
   { name: 'buyer_id', desc: '买家id' },
+  { name: 'buyer_name', desc: '买家昵称' },
 ]
 
 // 卡券表单数据类型

--- a/frontend/src/pages/messageFilters/MessageFilterFormModal.tsx
+++ b/frontend/src/pages/messageFilters/MessageFilterFormModal.tsx
@@ -259,6 +259,7 @@ export function MessageFilterFormModal({
                 <ul className="list-disc list-inside mt-1 space-y-1">
                   <li><strong>跳过自动回复</strong>：匹配到关键词时，不触发自动回复（关键词回复、默认回复、AI回复都不会触发）</li>
                   <li><strong>跳过消息通知</strong>：匹配到关键词时，不发送消息通知到配置的通知渠道</li>
+                  <li><strong>AI回复黑名单</strong>：AI生成的回复包含关键词时，直接拦截不发送给买家</li>
                 </ul>
               </div>
             </div>

--- a/frontend/src/pages/messageFilters/MessageFilterRulesTable.tsx
+++ b/frontend/src/pages/messageFilters/MessageFilterRulesTable.tsx
@@ -40,6 +40,12 @@ export function MessageFilterRulesTable({
   onPageChange,
   onPageSizeChange,
 }: MessageFilterRulesTableProps) {
+  const getFilterTypeClassName = (filterType: string) => {
+    if (filterType === 'skip_reply') return 'badge-primary'
+    if (filterType === 'skip_notify') return 'badge-warning'
+    return 'badge-danger'
+  }
+
   return (
     <div
       className="vben-card flex flex-col"
@@ -120,7 +126,7 @@ export function MessageFilterRulesTable({
                     </code>
                   </td>
                   <td>
-                    <span className={filter.filter_type === 'skip_reply' ? 'badge-primary' : 'badge-warning'}>
+                    <span className={getFilterTypeClassName(filter.filter_type)}>
                       {getFilterTypeLabel(filter.filter_type)}
                     </span>
                   </td>

--- a/frontend/src/pages/messageFilters/MessageFilters.tsx
+++ b/frontend/src/pages/messageFilters/MessageFilters.tsx
@@ -27,6 +27,7 @@ import type { MessageFilter, Account, MessageFilterType } from '@/types'
 const FILTER_TYPE_OPTIONS: Array<{ value: MessageFilterType; label: string }> = [
   { value: 'skip_reply', label: '跳过自动回复' },
   { value: 'skip_notify', label: '跳过消息通知' },
+  { value: 'skip_ai_reply_output', label: 'AI回复黑名单' },
 ]
 
 export function MessageFilters() {
@@ -286,7 +287,7 @@ export function MessageFilters() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="page-title">消息过滤</h1>
-          <p className="page-description">管理消息过滤规则，支持跳过自动回复和消息通知</p>
+          <p className="page-description">管理消息过滤规则，支持跳过自动回复、消息通知和AI回复黑名单</p>
         </div>
         <div className="flex flex-wrap gap-3">
           <button type="button" onClick={openAddModal} className="btn-ios-primary">

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -696,6 +696,44 @@ export function Settings() {
                   current ? { ...current, 'captcha.slider_mode': mode } : current
                 ))}
               />
+              <div className="flex items-center justify-between py-3 border-t border-slate-100 dark:border-slate-700">
+                <div>
+                  <p className="font-medium text-slate-900 dark:text-slate-100">手动补发冷却时间</p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">卖家发送“订单号+补发”后的冷却秒数，0 表示可立即再次补发</p>
+                </div>
+                <input
+                  type="number"
+                  min={0}
+                  max={3600}
+                  value={settings?.['delivery.manual_redelivery_cooldown_seconds'] || '0'}
+                  onChange={(e) => {
+                    const val = e.target.value
+                    if (val === '' || /^\d+$/.test(val)) {
+                      setSettings(s => s ? { ...s, 'delivery.manual_redelivery_cooldown_seconds': val } : null)
+                    }
+                  }}
+                  className="input-ios w-24 text-center"
+                />
+              </div>
+              <div className="flex items-center justify-between py-3 border-t border-slate-100 dark:border-slate-700">
+                <div>
+                  <p className="font-medium text-slate-900 dark:text-slate-100">手动补发延迟锁</p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">补发完成后继续锁定订单的秒数，0 表示发送完成即释放</p>
+                </div>
+                <input
+                  type="number"
+                  min={0}
+                  max={3600}
+                  value={settings?.['delivery.manual_redelivery_lock_seconds'] || '0'}
+                  onChange={(e) => {
+                    const val = e.target.value
+                    if (val === '' || /^\d+$/.test(val)) {
+                      setSettings(s => s ? { ...s, 'delivery.manual_redelivery_lock_seconds': val } : null)
+                    }
+                  }}
+                  className="input-ios w-24 text-center"
+                />
+              </div>
             </div>
           </div>
           {/* SMTP邮件配置 */}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -283,6 +283,8 @@ export interface SystemSettings {
   // 账号密码登录方式
   'password_login.mode'?: PasswordLoginMode
   'captcha.slider_mode'?: SliderMode
+  'delivery.manual_redelivery_cooldown_seconds'?: string
+  'delivery.manual_redelivery_lock_seconds'?: string
   // 代理设置
   'proxy.api_url'?: string
   'proxy.enabled'?: boolean
@@ -311,7 +313,7 @@ export interface DashboardStats {
 }
 
 // 消息过滤规则类型
-export type MessageFilterType = 'skip_reply' | 'skip_notify'
+export type MessageFilterType = 'skip_reply' | 'skip_notify' | 'skip_ai_reply_output'
 
 export interface MessageFilter {
   id: number

--- a/scheduler/app/services/scheduler/redelivery_task.py
+++ b/scheduler/app/services/scheduler/redelivery_task.py
@@ -476,13 +476,14 @@ class RedeliveryTask:
             if need_api_fetch:
                 logger.info(f"[定时补发货] 订单 {order_no} {', '.join(fetch_reasons)}，尝试从API重新获取...")
                 try:
-                    from common.services.order_service import OrderStatusChecker
+                    from common.services.order_service import OrderDetailService, OrderStatusChecker
                     from decimal import Decimal
                     checker = OrderStatusChecker(cookie_string, account_id=order.account_id if hasattr(order, 'account_id') else None)
                     raw_detail = await checker._fetch_raw_order_detail(order_no)
                     if raw_detail:
                         # 使用完整的解析方法提取金额和规格
-                        parsed = checker._parse_order_detail_response(order_no, raw_detail)
+                        detail_parser = OrderDetailService(order.account_id, checker.cookies_str)
+                        parsed = detail_parser._parse_order_detail_response(order_no, raw_detail)
                         if parsed:
                             updated_fields = []
                             # 更新金额
@@ -533,8 +534,9 @@ class RedeliveryTask:
                 return False, "订单缺少商品ID", cookie_string
             if not order.buyer_id:
                 return False, "订单缺少买家ID", cookie_string
-            # 订单缺少会话ID时，先调用 WebSocket 服务自动创建会话并回写，再继续发货
-            if not order.chat_id:
+            # 订单缺少会话ID或持有失败占位ID时，先尝试复用历史真实会话，
+            # 必要时再调用 WebSocket 服务创建会话并回写。
+            if not order.chat_id or order.chat_id.startswith("FAILED_"):
                 chat_ok, chat_error = await self._ensure_chat_id(session, order)
                 if not chat_ok:
                     return False, chat_error or "订单缺少会话ID", cookie_string
@@ -718,6 +720,44 @@ class RedeliveryTask:
             (是否成功, 错误信息)
         """
         try:
+            # 同一账号、买家、商品的会话通常会复用。订单列表接口有时不返回 chat_id，
+            # 而主动创建会话又可能被闲鱼以 code=400 拒绝；此时优先复用历史订单中的
+            # 真实会话ID，比创建新会话更可靠。
+            history_stmt = (
+                select(XYOrder.chat_id)
+                .where(
+                    XYOrder.order_no != order.order_no,
+                    XYOrder.account_id == order.account_id,
+                    XYOrder.buyer_id == order.buyer_id,
+                    XYOrder.item_id == order.item_id,
+                    XYOrder.chat_id.is_not(None),
+                    ~XYOrder.chat_id.like("FAILED_%"),
+                )
+                .order_by(XYOrder.updated_at.desc())
+                .limit(1)
+            )
+            history_chat_id = (await session.execute(history_stmt)).scalar_one_or_none()
+            if history_chat_id:
+                from common.services.order_service import OrderService
+
+                order_svc = OrderService(session)
+                updated = await order_svc.update_order_chat_id(
+                    order.order_no, history_chat_id
+                )
+                if updated:
+                    old_chat_id = order.chat_id
+                    order.chat_id = history_chat_id
+                    logger.info(
+                        f"[定时补发货] 订单 {order.order_no} 复用历史真实会话ID: "
+                        f"{old_chat_id or '空'} -> {history_chat_id}"
+                    )
+                    return True, None
+
+            # FAILED_* 表示此前已经尝试创建但被平台拒绝。没有历史会话可复用时
+            # 保持失败状态，避免每轮定时任务都请求一次创建会话。
+            if order.chat_id and order.chat_id.startswith("FAILED_"):
+                return False, "会话创建失败（占位ID），且未找到可复用的历史会话"
+
             settings = get_settings()
             http_client = get_http_client()
             

--- a/websocket/app/api/routes/internal.py
+++ b/websocket/app/api/routes/internal.py
@@ -9,6 +9,7 @@ WebSocket服务内部API路由
 from __future__ import annotations
 
 import asyncio
+import json
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -36,6 +37,34 @@ class SendMessageRequest(BaseModel):
     # 是否等待服务端发送结果（识别 CSI_FORBID 等安全拦截）。默认 False 保持既有调用方零影响。
     wait_result: bool = False
     wait_timeout: float = 10.0
+
+
+class IngestMessageRequest(BaseModel):
+    """Decrypted IM push message from backend chat-new."""
+    message_data: dict
+    source: str | None = None
+
+
+class _IngestWebSocketProxy:
+    """Drop local ACK frames while forwarding real outgoing IM frames."""
+
+    def __init__(self, real_ws):
+        self.real_ws = real_ws
+
+    async def send(self, data):
+        try:
+            payload = json.loads(data) if isinstance(data, str) else data
+        except Exception:
+            payload = None
+
+        if (
+            isinstance(payload, dict)
+            and payload.get("code") == 200
+            and "lwp" not in payload
+        ):
+            return
+
+        await self.real_ws.send(data)
 
 
 class DeliverOrderRequest(BaseModel):
@@ -688,6 +717,55 @@ async def send_message(account_id: str, request: SendMessageRequest):
         }
 
 
+@router.post("/accounts/{account_id}/ingest-message")
+async def ingest_message(account_id: str, request: IngestMessageRequest):
+    """Ingest a decrypted IM push and reuse automation handlers."""
+    try:
+        from app.services.xianyu.cookie_manager import get_manager
+        from loguru import logger
+
+        manager = get_manager()
+        instance = manager.instances.get(account_id)
+        if not instance:
+            return {
+                "success": False,
+                "code": 404,
+                "message": f"account {account_id} is not running",
+                "data": None,
+            }
+
+        real_ws = getattr(instance, "ws", None)
+        if not real_ws:
+            return {
+                "success": False,
+                "code": 400,
+                "message": f"account {account_id} websocket is not connected",
+                "data": None,
+            }
+
+        proxy_ws = _IngestWebSocketProxy(real_ws)
+        instance._create_tracked_task(
+            instance._handle_message_with_semaphore(request.message_data, proxy_ws)
+        )
+
+        logger.info(
+            f"[{account_id}] ingested external IM push: source={request.source or 'unknown'}"
+        )
+        return {
+            "success": True,
+            "code": 200,
+            "message": "message ingested",
+            "data": {"account_id": account_id, "source": request.source},
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "code": 500,
+            "message": f"ingest message failed: {str(e)}",
+            "data": None,
+        }
+
+
 @router.post("/orders/confirm-no-logistics")
 async def confirm_no_logistics(request: ConfirmNoLogisticsRequest):
     """无物流发货：在闲鱼确认发货但不发送任何卡券内容"""
@@ -1308,10 +1386,10 @@ async def deliver_order(request: DeliverOrderRequest):
         raw_contents: list[str] = []
         final_contents: list[str] = []
         failed_indices: list[int] = []
+        send_results: list[dict] = []
         early_break_reason: str | None = None  # 库存不足 / api 失败导致提前结束的原因
         # 收集每条文本消息的发送结果（含 send_future / mid），循环结束后统一等待闲鱼服务端回执，
         # 识别异步风控拦截（CSI_FORBID 等）。图片消息无回执 future，不参与拦截判定。
-        send_results: list = []
 
         for i in range(quantity):
             # ---- 1. 获取本张卡密的原始内容 ----
@@ -1376,19 +1454,29 @@ async def deliver_order(request: DeliverOrderRequest):
 
             # ---- 2. 立刻发送本张内容（成功/失败都记录到 final_contents） ----
             send_ok = False
+            send_result_count_before = len(send_results)
             try:
                 if card.type == 'image':
                     logger.info(
                         f"【内部API】发送图片消息 第 {idx}/{quantity}: {content}"
                         if quantity > 1 else f"【内部API】发送图片消息: {content}"
                     )
-                    await xianyu_live.send_image_msg(
+                    image_result = await xianyu_live.send_image_msg(
                         ws,
                         request.chat_id,
                         request.buyer_id,
                         content,
                         request.card_id
                     )
+                    if isinstance(image_result, dict):
+                        send_results.append(image_result)
+                    if not isinstance(image_result, dict) or not image_result.get("success"):
+                        image_error = (
+                            image_result.get("error_message")
+                            if isinstance(image_result, dict)
+                            else None
+                        ) or "图片发送失败"
+                        raise RuntimeError(image_error)
                     final_contents.append(f"[图片]{content}")
                     send_ok = True
                 else:
@@ -1401,13 +1489,22 @@ async def deliver_order(request: DeliverOrderRequest):
                         f"【内部API】发送文本消息 第 {idx}/{quantity}: {rendered[:50]}..."
                         if quantity > 1 else f"【内部API】发送文本消息: {rendered[:50]}..."
                     )
-                    await xianyu_live.auto_delivery_handler._send_text_with_separator(
+                    text_send_results: list[dict] = []
+                    text_ok = await xianyu_live.auto_delivery_handler._send_text_with_separator(
                         ws,
                         request.chat_id,
                         request.buyer_id,
                         rendered,
-                        send_results=send_results
+                        send_results=text_send_results,
                     )
+                    send_results.extend(text_send_results)
+                    if not text_ok:
+                        text_errors = [
+                            str(result.get("error_message") or "发送失败")
+                            for result in text_send_results
+                            if isinstance(result, dict) and not result.get("success")
+                        ]
+                        raise RuntimeError("；".join(text_errors[:3]) or "文本发送失败")
                     final_contents.append(rendered)
                     send_ok = True
             except Exception as send_err:
@@ -1415,6 +1512,14 @@ async def deliver_order(request: DeliverOrderRequest):
                 # 都能在订单 delivery_content 中追溯，避免数据丢失。商家可从这里手动复制转发。
                 failed_indices.append(idx)
                 logger.error(f"【内部API】第 {idx}/{quantity} 张卡券发送异常: {send_err}")
+                if len(send_results) == send_result_count_before:
+                    send_results.append({
+                        "success": False,
+                        "mode": "image" if card.type == "image" else "text",
+                        "image_url": content if card.type == "image" else None,
+                        "content": content if card.type != "image" else None,
+                        "error_message": str(send_err),
+                    })
                 if card.type == 'image':
                     final_contents.append(f"[图片-发送失败-请手动转发]{content}")
                 else:

--- a/websocket/app/services/xianyu/auto_delivery_handler.py
+++ b/websocket/app/services/xianyu/auto_delivery_handler.py
@@ -15,6 +15,7 @@ import os
 import time
 import hashlib
 import aiohttp
+from decimal import Decimal, InvalidOperation
 from loguru import logger
 
 from app.services.xianyu.delivery_utils import (
@@ -414,16 +415,22 @@ class AutoDeliveryHandler:
                 errors = [r.get("error_message", "发送失败") for r in send_results if not r.get("success")]
                 error_message = "；".join(errors[:3]) if errors else "部分消息发送失败"
 
-            # 发送状态：发送层（WebSocket 发送）失败直接判定 failed；
-            # 全部发出成功则先置 unknown，由后台任务等服务端响应后回写 success/failed
-            send_status = "failed" if any_send_failed else "unknown"
-            send_fail_reason = error_message if any_send_failed else None
             # 收集本次发出文本消息的 (future, mid)，供异步检测是否被安全拦截
             pending_send_waiters = [
                 (r.get("send_future"), r.get("mid"))
                 for r in send_results
                 if r.get("send_future") is not None
             ]
+            # 发送状态：
+            # - 发送层失败：failed
+            # - 旧 WebSocket 路径有 send_future：先 unknown，后台等服务端响应后回写
+            # - chat-new 路径已在 send_msg 内拿到 message_id 确认，且没有旧 send_future：直接 success
+            send_status = (
+                "failed"
+                if any_send_failed
+                else ("unknown" if pending_send_waiters else "success")
+            )
+            send_fail_reason = error_message if any_send_failed else None
 
             log_payload = {
                 "sender_user_id": sender_user_id,
@@ -591,8 +598,17 @@ class AutoDeliveryHandler:
     def is_lock_held(self, lock_key: str) -> bool:
         return self.parent.is_lock_held(lock_key)
     
-    async def _delayed_lock_release(self, lock_key: str, delay_minutes: int = 10):
-        return await self.parent._delayed_lock_release(lock_key, delay_minutes)
+    async def _delayed_lock_release(
+        self,
+        lock_key: str,
+        delay_minutes: float = 10,
+        delay_seconds: float | None = None,
+    ):
+        return await self.parent._delayed_lock_release(
+            lock_key,
+            delay_minutes=delay_minutes,
+            delay_seconds=delay_seconds,
+        )
     
     async def fetch_order_detail_info(self, order_id: str, item_id: str = None, buyer_id: str = None):
         """获取订单详情信息，并同步更新到数据库
@@ -921,16 +937,42 @@ class AutoDeliveryHandler:
         self.last_delivery_time[order_id] = current_time
         logger.info(f"【{self.cookie_id}】订单 {order_id} 已标记为发货（冷却期已设置）")
 
+    @staticmethod
+    def _get_non_negative_system_int(key: str, default: int) -> int:
+        try:
+            from common.db.compat import db_manager
+
+            raw_value = db_manager.get_system_setting(key, str(default))
+            return max(int(str(raw_value).strip()), 0)
+        except (TypeError, ValueError):
+            return default
+        except Exception as exc:
+            logger.warning(f"读取系统设置 {key} 失败，使用默认值 {default}: {exc}")
+            return default
+
+    def _manual_redelivery_cooldown_seconds(self) -> int:
+        return self._get_non_negative_system_int(
+            "delivery.manual_redelivery_cooldown_seconds", 0
+        )
+
+    def _manual_redelivery_lock_seconds(self) -> int:
+        return self._get_non_negative_system_int(
+            "delivery.manual_redelivery_lock_seconds", 0
+        )
+
 
     # ==================== 统一发货处理 ====================
 
     async def _handle_auto_delivery(self, websocket, message: dict, send_user_name: str, send_user_id: str,
                                    item_id: str, chat_id: str, msg_time: str, override_order_id: str = None,
-                                   pre_check_result: dict | None = None):
+                                   pre_check_result: dict | None = None,
+                                   allow_shipped_redelivery: bool = False):
         """统一处理自动发货逻辑
 
         Args:
             override_order_id: 如果指定，直接使用此订单ID，跳过从raw_message提取
+            allow_shipped_redelivery: 是否允许已发货订单继续发送卡券内容。
+                仅用于卖家手动输入重发货关键字的补发场景；普通自动发货仍跳过已发货订单。
             pre_check_result: 可选的预先 pre_delivery_check_and_close 结果。
                 调用方（如 _handle_card_message / 重发货关键字）若需要在调用免拼接口
                 之前先做禁止发货检查，可以预先调用 pre_delivery_check_and_close 拿到
@@ -945,8 +987,21 @@ class AutoDeliveryHandler:
                     from common.db.compat import db_manager
                     item_info = db_manager.get_item_info(self.cookie_id, item_id)
                     if not item_info:
-                        logger.warning(f'[{msg_time}] 【{self.cookie_id}】❌ 商品 {item_id} 不属于当前账号，跳过自动发货')
-                        return
+                        order_account_ok = False
+                        order_item_ok = False
+                        if allow_shipped_redelivery and override_order_id:
+                            existing_order = db_manager.get_order_by_id(override_order_id)
+                            if existing_order:
+                                order_account_ok = str(existing_order.get('account_id') or '') == str(self.cookie_id)
+                                order_item_ok = str(existing_order.get('item_id') or '') == str(item_id)
+                        if order_account_ok and order_item_ok:
+                            logger.warning(
+                                f'[{msg_time}] [{self.cookie_id}] item {item_id} missing catalog cache, '
+                                f'allowed by redelivery order ownership'
+                            )
+                        else:
+                            logger.warning(f'[{msg_time}] 【{self.cookie_id}】❌ 商品 {item_id} 不属于当前账号，跳过自动发货')
+                            return
                     logger.warning(f'[{msg_time}] 【{self.cookie_id}】✅ 商品 {item_id} 归属验证通过')
                 except Exception as e:
                     logger.error(f'[{msg_time}] 【{self.cookie_id}】检查商品归属失败: {self._safe_str(e)}，跳过自动发货')
@@ -1019,14 +1074,34 @@ class AutoDeliveryHandler:
 
             # 使用订单ID作为锁的键
             lock_key = order_id
+            manual_lock_seconds = (
+                self._manual_redelivery_lock_seconds()
+                if allow_shipped_redelivery
+                else None
+            )
+            manual_cooldown_seconds = (
+                self._manual_redelivery_cooldown_seconds()
+                if allow_shipped_redelivery
+                else None
+            )
 
             # 第一重检查：延迟锁状态（在获取锁之前检查，避免不必要的等待）
-            if self.is_lock_held(lock_key):
+            if self.is_lock_held(lock_key) and not (
+                allow_shipped_redelivery and manual_lock_seconds == 0
+            ):
                 logger.info(f'[{msg_time}] 【{self.cookie_id}】🔒【提前检查】订单 {lock_key} 延迟锁仍在持有状态，跳过发货')
                 return
 
             # 第二重检查：基于时间的冷却机制
-            if not self.can_auto_delivery(order_id):
+            if allow_shipped_redelivery:
+                last_delivery = self.last_delivery_time.get(order_id, 0)
+                if time.time() - last_delivery < manual_cooldown_seconds:
+                    logger.info(
+                        f'[{msg_time}] 【{self.cookie_id}】订单 {order_id} '
+                        f'手动补发冷却中（{manual_cooldown_seconds}秒），跳过'
+                    )
+                    return
+            elif not self.can_auto_delivery(order_id):
                 logger.info(f'[{msg_time}] 【{self.cookie_id}】订单 {order_id} 在冷却期内，跳过发货')
                 return
 
@@ -1057,18 +1132,34 @@ class AutoDeliveryHandler:
                         from common.db.compat import db_manager
                         existing_order = db_manager.get_order_by_id(order_id)
                         if existing_order and existing_order.get('status') == 'shipped':
-                            logger.info(f'[{msg_time}] 【{self.cookie_id}】获取锁后检查发现订单 {order_id} 已发货，跳过处理')
-                            return
+                            if allow_shipped_redelivery:
+                                logger.info(
+                                    f'[{msg_time}] 【{self.cookie_id}】订单 {order_id} 已发货，'
+                                    f'但本次为重发货触发，继续补发卡券'
+                                )
+                            else:
+                                logger.info(f'[{msg_time}] 【{self.cookie_id}】获取锁后检查发现订单 {order_id} 已发货，跳过处理')
+                                return
                     except Exception as e:
                         logger.warning(f'[{msg_time}] 【{self.cookie_id}】获取锁后检查订单状态异常: {self._safe_str(e)}')
 
                 # 第三重检查：获取锁后再次检查延迟锁状态（双重检查，防止在等待锁期间状态发生变化）
-                if self.is_lock_held(lock_key):
+                if self.is_lock_held(lock_key) and not (
+                    allow_shipped_redelivery and manual_lock_seconds == 0
+                ):
                     logger.info(f'[{msg_time}] 【{self.cookie_id}】订单 {lock_key} 在获取锁后检查发现延迟锁仍持有，跳过发货')
                     return
 
                 # 第四重检查：获取锁后再次检查冷却状态
-                if not self.can_auto_delivery(order_id):
+                if allow_shipped_redelivery:
+                    last_delivery = self.last_delivery_time.get(order_id, 0)
+                    if time.time() - last_delivery < manual_cooldown_seconds:
+                        logger.info(
+                            f'[{msg_time}] 【{self.cookie_id}】订单 {order_id} '
+                            f'获取锁后仍处于手动补发冷却（{manual_cooldown_seconds}秒），跳过'
+                        )
+                        return
+                elif not self.can_auto_delivery(order_id):
                     logger.info(f'[{msg_time}] 【{self.cookie_id}】订单 {order_id} 在获取锁后检查发现仍在冷却期，跳过发货')
                     return
 
@@ -1147,6 +1238,7 @@ class AutoDeliveryHandler:
                             delivery_content = await self._auto_delivery(
                                 item_id, item_title, order_id, send_user_id, chat_id, send_user_name,
                                 skip_confirm=skip_confirm_for_card_only,
+                                allow_shipped_redelivery=allow_shipped_redelivery,
                             )
                             if delivery_content:
                                 delivery_contents.append(delivery_content)
@@ -1181,7 +1273,7 @@ class AutoDeliveryHandler:
                                 # 第一次调用返回None，可能是订单已发货，检查订单状态
                                 from common.db.compat import db_manager
                                 existing_order = db_manager.get_order_by_id(order_id)
-                                if existing_order and existing_order.get('status') == 'shipped':
+                                if existing_order and existing_order.get('status') == 'shipped' and not allow_shipped_redelivery:
                                     logger.info(f"【{self.cookie_id}】订单 {order_id} 已发货，跳过发送卡券")
                                     order_already_shipped = True
                                     break
@@ -1199,17 +1291,26 @@ class AutoDeliveryHandler:
                         # 标记已发货（防重复）- 基于订单ID
                         self.mark_delivery_sent(order_id)
 
-                        # 标记锁为持有状态，并启动延迟释放任务
+                        hold_seconds = (
+                            manual_lock_seconds
+                            if allow_shipped_redelivery
+                            else 10 * 60
+                        )
+                        # 标记锁为持有状态，并按配置启动延迟释放任务
                         self._lock_hold_info[lock_key] = {
-                            'locked': True,
+                            'locked': hold_seconds > 0,
                             'lock_time': time.time(),
-                            'release_time': None,
+                            'release_time': None if hold_seconds > 0 else time.time(),
                             'task': None
                         }
 
-                        # 启动延迟释放锁的异步任务（10分钟后释放）
-                        delay_task = asyncio.create_task(self._delayed_lock_release(lock_key, delay_minutes=10))
-                        self._lock_hold_info[lock_key]['task'] = delay_task
+                        if hold_seconds > 0:
+                            delay_task = asyncio.create_task(
+                                self._delayed_lock_release(
+                                    lock_key, delay_seconds=hold_seconds
+                                )
+                            )
+                            self._lock_hold_info[lock_key]['task'] = delay_task
 
                         # 发送所有获取到的发货内容，跟踪发送结果
                         any_send_failed = False
@@ -1742,13 +1843,15 @@ class AutoDeliveryHandler:
         cleaned = name.strip().strip('[]【】')
         return cleaned in self._SYSTEM_PLACEHOLDER_NAMES
 
-    async def _auto_delivery(self, item_id: str, item_title: str = None, order_id: str = None, send_user_id: str = None, chat_id: str = None, send_user_name: str = None, skip_confirm: bool = False):
+    async def _auto_delivery(self, item_id: str, item_title: str = None, order_id: str = None, send_user_id: str = None, chat_id: str = None, send_user_name: str = None, skip_confirm: bool = False, allow_shipped_redelivery: bool = False):
         """自动发货功能 - 根据商品ID获取卡券，执行延时，确认发货，发送内容
 
         Args:
             skip_confirm: 跳过确认发货接口（auto_confirm）。用于"禁止发货 + 关闭订单后只发卡券"
                 场景——订单已经被卖家主动关闭，此时不能再调用确认发货接口，但仍需要把卡券内容
                 发送给买家作为"补偿"。该参数为 True 时，"发货成功再发卡券"开关会被忽略。
+            allow_shipped_redelivery: 已发货订单补发模式。为 True 时，即使确认发货接口返回已发货，
+                也继续生成并发送卡券内容。
         """
         try:
             from common.db.compat import db_manager
@@ -1936,32 +2039,35 @@ class AutoDeliveryHandler:
                             # 检查是否是"已发货成功"的响应
                             success_msg = confirm_result.get('message', '')
                             if 'ORDER_ALREADY_DELIVERY' in success_msg or '已发货成功' in success_msg:
-                                logger.info(f"【{self.cookie_id}】订单 {order_id} 已发货过，只更新数据库状态，不再发送卡券")
+                                if allow_shipped_redelivery:
+                                    logger.info(f"【{self.cookie_id}】订单 {order_id} 已发货过，本次为重发货触发，继续发送卡券")
+                                else:
+                                    logger.info(f"【{self.cookie_id}】订单 {order_id} 已发货过，只更新数据库状态，不再发送卡券")
                                 
-                                # 更新订单状态为已发货
-                                try:
-                                    from common.services.order_service import OrderService
-                                    from common.db.session import async_session_maker
-                                    async with async_session_maker() as db_session:
-                                        order_service = OrderService(db_session)
-                                        # 确认发货成功但不发送卡券，记录发货方式为"自动发货"，内容为空
-                                        await order_service.update_order_delivery_info(
-                                            order_no=order_id,
-                                            status="shipped",
-                                            delivery_method="auto",
-                                            delivery_content="订单已确认发货（闲鱼平台已发货）",
-                                            buyer_fish_nick=local_buyer_fish_nick,
-                                        )
-                                    logger.info(f"【{self.cookie_id}】订单 {order_id} 状态已更新为已发货")
-                                except Exception as e:
-                                    logger.error(f"【{self.cookie_id}】更新订单状态失败: {self._safe_str(e)}")
+                                    # 更新订单状态为已发货
+                                    try:
+                                        from common.services.order_service import OrderService
+                                        from common.db.session import async_session_maker
+                                        async with async_session_maker() as db_session:
+                                            order_service = OrderService(db_session)
+                                            # 确认发货成功但不发送卡券，记录发货方式为"自动发货"，内容为空
+                                            await order_service.update_order_delivery_info(
+                                                order_no=order_id,
+                                                status="shipped",
+                                                delivery_method="auto",
+                                                delivery_content="订单已确认发货（闲鱼平台已发货）",
+                                                buyer_fish_nick=local_buyer_fish_nick,
+                                            )
+                                        logger.info(f"【{self.cookie_id}】订单 {order_id} 状态已更新为已发货")
+                                    except Exception as e:
+                                        logger.error(f"【{self.cookie_id}】更新订单状态失败: {self._safe_str(e)}")
                                 
-                                # 标记已发货，防止重复处理
-                                self.mark_delivery_sent(order_id)
+                                    # 标记已发货，防止重复处理
+                                    self.mark_delivery_sent(order_id)
                                 
-                                # 直接返回None，不再发送卡券内容
-                                self._last_delivery_fail_reason = f"订单 {order_id} 已发货过，不再发送卡券"
-                                return None
+                                    # 直接返回None，不再发送卡券内容
+                                    self._last_delivery_fail_reason = f"订单 {order_id} 已发货过，不再发送卡券"
+                                    return None
                             
                             logger.info(f"🎉 自动确认发货成功！订单ID: {order_id}")
                         else:
@@ -2771,9 +2877,42 @@ class AutoDeliveryHandler:
 
             # 从订单信息中提取参数
             if order_info:
+                fresh_order_detail = None
+                try:
+                    fresh_order_detail = await self.fetch_order_detail_info(order_id, item_id, buyer_id)
+                except Exception as e:
+                    logger.warning(f"刷新订单详情用于API参数失败: {self._safe_str(e)}")
+
+                if fresh_order_detail:
+                    detail_amount = fresh_order_detail.get('amount')
+                    detail_quantity = fresh_order_detail.get('quantity')
+                    if detail_amount:
+                        order_info['amount'] = detail_amount
+                    if detail_quantity:
+                        order_info['quantity'] = detail_quantity
+                    logger.info(
+                        f"API参数使用订单详情口径: order_id={order_id}, "
+                        f"amount={order_info.get('amount')}, quantity={order_info.get('quantity')}"
+                    )
+
+                order_total_amount = str(order_info.get('amount', '') or '')
+                order_quantity = str(order_info.get('quantity', '') or '')
+                order_unit_price = ''
+                try:
+                    amount_decimal = Decimal(order_total_amount)
+                    quantity_decimal = Decimal(order_quantity)
+                    if quantity_decimal > 0:
+                        order_unit_price = str(
+                            (amount_decimal / quantity_decimal).quantize(Decimal('0.000001')).normalize()
+                        )
+                except (InvalidOperation, ValueError, TypeError):
+                    order_unit_price = ''
+
                 param_mapping.update({
-                    'order_amount': str(order_info.get('amount', '')),
-                    'order_quantity': str(order_info.get('quantity', '')),
+                    'order_amount': order_total_amount,
+                    'order_total_amount': order_total_amount,
+                    'order_unit_price': order_unit_price,
+                    'order_quantity': order_quantity,
                 })
 
             # 从商品信息中提取参数

--- a/websocket/app/services/xianyu/auto_reply_service.py
+++ b/websocket/app/services/xianyu/auto_reply_service.py
@@ -93,6 +93,13 @@ class AutoReplyService:
         '我已付款，等待你发货',
         '[记得及时发货]',
     ]
+
+    AUTO_SELF_MESSAGES_TO_SKIP = [
+        '已求买家送我闲鱼小红花',
+        '可以送我闲鱼小红花吗',
+        '卖家人不错？送Ta闲鱼小红花',
+        '你人真不错，送你闲鱼小红花',
+    ]
     
     def __init__(self, cookie_id: str, xianyu_instance):
         """
@@ -120,10 +127,80 @@ class AutoReplyService:
         self._processed_messages_max_size = 10000
         self._message_expire_time: Optional[int] = None  # 从数据库加载
         self._message_expire_time_loaded = False
+        # 记录本服务刚发出的自动回复，识别闲鱼随后推回来的“自身消息”。
+        # 否则自动回复会被误判为人工发送，并触发会话暂停。
+        self._pending_auto_sent_messages: Dict[str, List[float]] = {}
+        self._pending_auto_sent_ttl: float = 60.0
+        self._pending_auto_sent_max_size: int = 10000
         self._reply_trace_var: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
             f"auto_reply_trace_{cookie_id}",
             default=None,
         )
+
+    @staticmethod
+    def _normalize_sent_message_text(message: str) -> str:
+        """规范化发送与回流文本，避免换行格式差异导致匹配失败。"""
+        return str(message or "").replace("\r\n", "\n").replace("\r", "\n").strip()
+
+    def _build_auto_sent_message_key(self, chat_id: str, message: str) -> str:
+        normalized_chat_id = str(chat_id or "").strip()
+        normalized_message = self._normalize_sent_message_text(message)
+        return f"{normalized_chat_id}\0{normalized_message}"
+
+    def _cleanup_pending_auto_sent_messages(self, now: Optional[float] = None) -> None:
+        """清理已过期的自动发送登记，避免长期运行时占用内存。"""
+        current_time = now if now is not None else time.time()
+        expire_before = current_time - self._pending_auto_sent_ttl
+
+        for key, timestamps in list(self._pending_auto_sent_messages.items()):
+            valid_timestamps = [timestamp for timestamp in timestamps if timestamp >= expire_before]
+            if valid_timestamps:
+                self._pending_auto_sent_messages[key] = valid_timestamps
+            else:
+                self._pending_auto_sent_messages.pop(key, None)
+
+    def _register_auto_sent_message(self, chat_id: str, message: str) -> None:
+        """在发送前登记自动回复，确保极快回流时也能正确识别。"""
+        key = self._build_auto_sent_message_key(chat_id, message)
+        now = time.time()
+
+        if len(self._pending_auto_sent_messages) >= self._pending_auto_sent_max_size:
+            self._cleanup_pending_auto_sent_messages(now)
+
+        self._pending_auto_sent_messages.setdefault(key, []).append(now)
+
+    def _discard_auto_sent_message(self, chat_id: str, message: str) -> None:
+        """发送失败时撤销一条尚未消费的自动发送登记。"""
+        key = self._build_auto_sent_message_key(chat_id, message)
+        timestamps = self._pending_auto_sent_messages.get(key)
+        if not timestamps:
+            return
+
+        timestamps.pop()
+        if not timestamps:
+            self._pending_auto_sent_messages.pop(key, None)
+
+    def _consume_auto_sent_message(self, chat_id: str, message: str) -> bool:
+        """消费匹配的自动回复回流；未匹配则视为真正的人工自身消息。"""
+        now = time.time()
+        self._cleanup_pending_auto_sent_messages(now)
+
+        key = self._build_auto_sent_message_key(chat_id, message)
+        timestamps = self._pending_auto_sent_messages.get(key)
+        if not timestamps:
+            return False
+
+        timestamps.pop(0)
+        if not timestamps:
+            self._pending_auto_sent_messages.pop(key, None)
+        return True
+
+    def _is_auto_self_message_to_skip(self, message: str) -> bool:
+        """识别平台/系统自动发出的卖家侧消息，避免误判为人工接管。"""
+        normalized_message = self._normalize_sent_message_text(message)
+        if not normalized_message:
+            return False
+        return any(keyword in normalized_message for keyword in self.AUTO_SELF_MESSAGES_TO_SKIP)
     
     async def _get_account(self, session: AsyncSession) -> Optional[XYAccount]:
         """获取账号信息(带缓存)"""
@@ -523,6 +600,19 @@ class AutoReplyService:
                 return True
         
         return False
+
+    def find_matched_filter_keyword(self, message: str, filter_keywords: List[str]) -> Optional[str]:
+        """返回命中的过滤关键词，未命中则返回 None。"""
+        if not filter_keywords or not message:
+            return None
+
+        message_lower = message.lower()
+        for keyword in filter_keywords:
+            normalized_keyword = (keyword or "").strip()
+            if normalized_keyword and normalized_keyword.lower() in message_lower:
+                return normalized_keyword
+
+        return None
     
     def should_skip_notify(self, message: str, filter_keywords: List[str]) -> bool:
         """检查消息是否应该跳过消息通知
@@ -580,6 +670,26 @@ class AutoReplyService:
             myid = getattr(self.xianyu_instance, 'myid', self.cookie_id)
             self._merge_log_context(log_payload, myid=myid)
             if send_user_id == myid:
+                if self._consume_auto_sent_message(chat_id, send_message):
+                    logger.info(
+                        f"【{self.cookie_id}】识别到自动回复回流，不暂停会话: "
+                        f"chat_id={chat_id}, message={send_message[:50]}"
+                    )
+                    log_payload["process_status"] = "skipped"
+                    log_payload["decision_reason"] = "auto_reply_echo"
+                    self._merge_log_context(log_payload, auto_reply_echo=True)
+                    return
+
+                if self._is_auto_self_message_to_skip(send_message):
+                    logger.info(
+                        f"【{self.cookie_id}】识别到系统自动发出的卖家侧消息，不暂停会话: "
+                        f"chat_id={chat_id}, message={send_message[:50]}"
+                    )
+                    log_payload["process_status"] = "skipped"
+                    log_payload["decision_reason"] = "auto_self_message"
+                    self._merge_log_context(log_payload, auto_self_message=True)
+                    return
+
                 # 手动发出消息，暂停该会话的自动回复
                 log_payload["process_status"] = "skipped"
                 log_payload["decision_reason"] = "self_message"
@@ -793,15 +903,17 @@ class AutoReplyService:
                 if not failed_results:
                     log_payload["process_status"] = "success"
                     log_payload["decision_reason"] = "reply_sent"
-                    # 消息已发出 WebSocket，但是否被服务端接收需异步等待响应确认，
-                    # 先置为 unknown，由后台任务在拿到响应后回写 success/failed
-                    log_payload["send_status"] = "unknown"
                     # 收集本次发出消息的 (future, mid)，供异步检测发送结果
-                    log_payload["_pending_send_waiters"] = [
+                    pending_send_waiters = [
                         (result.get("send_future"), result.get("mid"))
                         for result in send_results
                         if result.get("send_future") is not None
                     ]
+                    log_payload["_pending_send_waiters"] = pending_send_waiters
+                    # 旧 WebSocket 路径有 send_future 时先置 unknown 等回写；
+                    # chat-new 路径成功时已拿到 message_id 确认，没有 send_future，直接记 success，
+                    # 避免后续超时任务把实际成功的消息标成 timeout。
+                    log_payload["send_status"] = "unknown" if pending_send_waiters else "success"
                 else:
                     log_payload["process_status"] = "failed"
                     log_payload["decision_reason"] = "send_failed"
@@ -930,12 +1042,15 @@ class AutoReplyService:
             logger.info(f"【{self.cookie_id}】检测到分隔符，拆分为 {len(messages)} 条消息")
              
             for i, msg in enumerate(messages):
+                self._register_auto_sent_message(chat_id, msg)
                 result = await self.xianyu_instance.send_msg(
                     websocket=websocket,
                     chat_id=chat_id,
                     send_user_id=send_user_id,
                     content=msg,
                 )
+                if not result or not result.get("success", False):
+                    self._discard_auto_sent_message(chat_id, msg)
                 send_results.append(result or self._build_empty_send_result("text", msg))
                 logger.info(f"【{self.cookie_id}】发送文本回复 {i+1}/{len(messages)}: {msg[:50]}...")
                  
@@ -944,12 +1059,15 @@ class AutoReplyService:
                     await asyncio.sleep(0.5)
         else:
             # 单条消息直接发送
+            self._register_auto_sent_message(chat_id, text)
             result = await self.xianyu_instance.send_msg(
                 websocket=websocket,
                 chat_id=chat_id,
                 send_user_id=send_user_id,
                 content=text,
             )
+            if not result or not result.get("success", False):
+                self._discard_auto_sent_message(chat_id, text)
             send_results.append(result or self._build_empty_send_result("text", text))
             logger.info(f"【{self.cookie_id}】发送文本回复: {text[:50]}...")
 
@@ -1105,6 +1223,8 @@ class AutoReplyService:
                     session, send_user_name, send_user_id, send_message, item_id, chat_id
                 )
                 if ai_reply:
+                    if ai_reply == "EMPTY_REPLY":
+                        return None
                     return ai_reply
                 
                 default_reply = await self.get_default_reply(
@@ -1872,6 +1992,25 @@ class AutoReplyService:
             )
             
             if reply:
+                blocked_keywords = await self.get_filter_keywords('skip_ai_reply_output')
+                matched_blocked_keyword = self.find_matched_filter_keyword(reply, blocked_keywords)
+                if matched_blocked_keyword:
+                    logger.warning(
+                        f"【{self.cookie_id}】AI回复命中输出黑名单 '{matched_blocked_keyword}'，"
+                        f"跳过发送: {reply[:80]}..."
+                    )
+                    if reply_trace is not None:
+                        reply_trace["process_status"] = "skipped"
+                        reply_trace["decision_reason"] = "ai_output_filter"
+                        reply_trace["reply_strategy"] = "ai"
+                        reply_trace["matched_rule_type"] = "ai_output_filter"
+                        reply_trace["reply_mode"] = "text"
+                        reply_trace["reply_text"] = reply
+                        reply_trace["reply_segments"] = self._build_text_reply_segments(reply)
+                        reply_trace.setdefault("context_snapshot", {})["ai_output_filter_keywords"] = blocked_keywords
+                        reply_trace.setdefault("context_snapshot", {})["ai_output_filter_matched_keyword"] = matched_blocked_keyword
+                    return "EMPTY_REPLY"
+
                 logger.info(f"【{self.cookie_id}】AI回复生成成功: {reply[:50]}...")
                 if reply_trace is not None:
                     reply_trace["reply_strategy"] = "ai"

--- a/websocket/app/services/xianyu/xianyu_async.py
+++ b/websocket/app/services/xianyu/xianyu_async.py
@@ -762,7 +762,36 @@ class XianyuAsync:
                                         if order_info:
                                             order_item_id = order_info.get('item_id', '') or item_id
                                             order_buyer_id = order_info.get('buyer_id', '')
-                                            order_chat_id = order_info.get('chat_id', '') or parsed_message.get('chat_id', '')
+                                            stored_chat_id = order_info.get('chat_id', '') or ''
+                                            current_chat_id = parsed_message.get('chat_id', '') or ''
+                                            order_chat_id = stored_chat_id or current_chat_id
+
+                                            # 会话创建失败时 scheduler 会写入 FAILED_* 占位值。
+                                            # 卖家在真实买家会话里发送“补发+订单号”时，当前消息已经携带
+                                            # 可用的 chat_id，应优先用它修复订单，避免继续向占位会话发送。
+                                            if stored_chat_id.startswith("FAILED_") and current_chat_id:
+                                                order_chat_id = current_chat_id
+                                                try:
+                                                    from common.services.order_service import OrderService
+                                                    from common.db.session import async_session_maker
+
+                                                    async with async_session_maker() as db_session:
+                                                        order_service = OrderService(db_session)
+                                                        await order_service.update_order_chat_id(
+                                                            order_no, current_chat_id
+                                                        )
+                                                    order_info['chat_id'] = current_chat_id
+                                                    logger.info(
+                                                        f"【{self.cookie_id}】重发货触发: "
+                                                        f"订单 {order_no} 已用当前会话修复占位chat_id: "
+                                                        f"{stored_chat_id} -> {current_chat_id}"
+                                                    )
+                                                except Exception as chat_fix_e:
+                                                    logger.warning(
+                                                        f"【{self.cookie_id}】重发货触发: "
+                                                        f"订单 {order_no} 回写真实会话ID失败，"
+                                                        f"本次仍使用当前会话: {chat_fix_e}"
+                                                    )
                                             
                                             if hasattr(self, 'auto_delivery_handler') and self.auto_delivery_handler:
                                                 # 关键防护：在调 pre_check 之前先做 item 归属检查
@@ -774,11 +803,19 @@ class XianyuAsync:
                                                     try:
                                                         item_info = db_manager.get_item_info(self.cookie_id, order_item_id)
                                                         if not item_info:
-                                                            logger.warning(
-                                                                f"【{self.cookie_id}】重发货触发：商品 {order_item_id} 不属于当前账号，"
-                                                                f"跳过 pre_check / freeshipping / 自动发货"
-                                                            )
-                                                            return
+                                                            order_account_ok = str(order_info.get('account_id') or '') == str(self.cookie_id)
+                                                            order_item_ok = str(order_info.get('item_id') or '') == str(order_item_id)
+                                                            if order_account_ok and order_item_ok:
+                                                                logger.warning(
+                                                                    f"[{self.cookie_id}] redelivery item {order_item_id} "
+                                                                    f"missing catalog cache, allowed by order ownership"
+                                                                )
+                                                            else:
+                                                                logger.warning(
+                                                                    f"【{self.cookie_id}】重发货触发：商品 {order_item_id} 不属于当前账号，"
+                                                                    f"跳过 pre_check / freeshipping / 自动发货"
+                                                                )
+                                                                return
                                                     except Exception as e:
                                                         logger.error(
                                                             f"【{self.cookie_id}】重发货触发：检查商品归属失败，跳过: {e}"
@@ -846,6 +883,7 @@ class XianyuAsync:
                                                     msg_time=msg_time,
                                                     override_order_id=order_no,
                                                     pre_check_result=pre_check,
+                                                    allow_shipped_redelivery=True,
                                                 )
                                             else:
                                                 logger.warning(f"【{self.cookie_id}】auto_delivery_handler未初始化，跳过重发货")
@@ -1046,10 +1084,16 @@ class XianyuAsync:
             return False
         return self._lock_hold_info[lock_key].get('locked', False)
     
-    async def _delayed_lock_release(self, lock_key: str, delay_minutes: int = 10):
+    async def _delayed_lock_release(
+        self,
+        lock_key: str,
+        delay_minutes: float = 10,
+        delay_seconds: float | None = None,
+    ):
         """延迟释放锁"""
         try:
-            await asyncio.sleep(delay_minutes * 60)
+            wait_seconds = delay_seconds if delay_seconds is not None else delay_minutes * 60
+            await asyncio.sleep(max(float(wait_seconds), 0))
             if lock_key in self._lock_hold_info:
                 self._lock_hold_info[lock_key]['locked'] = False
                 self._lock_hold_info[lock_key]['release_time'] = time.time()
@@ -1790,81 +1834,55 @@ class XianyuAsync:
             return None
     
     async def send_msg(self, websocket, chat_id: str, send_user_id: str, content: str):
-        """发送文本消息（参照旧框架实现）
+        """发送文本消息。
 
-        消息通过 WebSocket 发出后立即返回成功（不阻塞自动回复）。
-        同时注册 mid 等待队列，返回结果中携带 mid，供上层在写入日志后
-        异步等待服务端响应、回写发送状态（识别 CSI_FORBID 安全拦截等失败）。
+        经 chat-new 主 IM 连接发送并等待 messageId 确认。
+        旧 websocket 连接上的本地 send 仅表示写出成功，平台可能未真正接收。
         """
         try:
-            import base64
-            from common.utils.xianyu_utils import generate_mid, generate_uuid
+            from app.core.config import get_settings
 
-            # 构建消息内容（参照旧框架）
-            msg_content = {
-                "contentType": 1,
-                "text": {"text": content}
+            settings = get_settings()
+            backend_url = settings.backend_web_service_url.rstrip("/")
+            send_url = (
+                f"{backend_url}/api/v1/chat-new/internal/send-message/"
+                f"{self.cookie_id}"
+            )
+            payload = {
+                "cid": str(chat_id),
+                "toUserId": str(send_user_id),
+                "text": content,
             }
-            content_json = json.dumps(msg_content, ensure_ascii=False)
-            content_base64 = base64.b64encode(content_json.encode("utf-8")).decode("utf-8")
+            timeout = aiohttp.ClientTimeout(total=20)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(send_url, json=payload) as response:
+                    response_text = await response.text()
+                    if response.status != 200:
+                        raise RuntimeError(
+                            f"chat-new HTTP {response.status}: {response_text[:300]}"
+                        )
+                    try:
+                        response_data = json.loads(response_text)
+                    except json.JSONDecodeError as exc:
+                        raise RuntimeError(
+                            f"chat-new 返回非 JSON 响应: {response_text[:300]}"
+                        ) from exc
+                    if not response_data.get("success"):
+                        raise RuntimeError(
+                            response_data.get("message") or "chat-new 发送失败"
+                        )
 
-            mid = generate_mid()
-            msg = {
-                "lwp": "/r/MessageSend/sendByReceiverScope",
-                "headers": {"mid": mid},
-                "body": [
-                    {
-                        "uuid": generate_uuid(),
-                        "cid": f"{chat_id}@goofish",
-                        "conversationType": 1,
-                        "content": {
-                            "contentType": 101,
-                            "custom": {"type": 1, "data": content_base64}
-                        },
-                        "redPointPolicy": 0,
-                        "extension": {"extJson": "{}"},
-                        "ctx": {"appVersion": "1.0", "platform": "web"},
-                        "mtags": {},
-                        "msgReadStatusSetting": 1
-                    },
-                    {
-                        "actualReceivers": [
-                            f"{send_user_id}@goofish",
-                            f"{self.myid}@goofish"
-                        ]
-                    }
-                ]
-            }
-            
-            # 打印发送参数用于调试
-            logger.info(f"【{self.cookie_id}】发送文本消息: chat_id={chat_id}, to={send_user_id}, myid={self.myid}")
-            
-            # 打印完整的WebSocket消息用于调试
-            msg_str = json.dumps(msg)
-            logger.info(f"【{self.cookie_id}】WebSocket发送数据长度: {len(msg_str)} 字节")
-
-            # 注册 mid 等待队列（供上层写日志后异步检测发送结果），注册失败不影响发送
-            registered_mid = None
-            send_future = None
-            try:
-                loop = asyncio.get_running_loop()
-                send_future = loop.create_future()
-                self._pending_mid_futures[mid] = send_future
-                registered_mid = mid
-            except Exception as reg_e:
-                logger.warning(f"【{self.cookie_id}】注册发送结果检测失败（不影响发送）: {self._safe_str(reg_e)}")
-
-            await websocket.send(msg_str)
-            logger.info(f"【{self.cookie_id}】发送消息成功: {content[:50]}...")
+            message_id = (response_data.get("data") or {}).get("messageId", "")
+            logger.info(
+                f"【{self.cookie_id}】消息经 chat-new 确认发送成功: "
+                f"chat_id={chat_id}, to={send_user_id}, message_id={message_id}"
+            )
             return {
                 "success": True,
                 "mode": "text",
                 "content": content,
-                "mid": registered_mid,
-                # 直接携带 Future 引用：即使服务端响应在上层 await 之前到达
-                # （_dispatch_mid_response 已 set_result 并从字典移除），
-                # 持有引用仍能拿到结果，避免漏判拦截
-                "send_future": send_future,
+                "message_id": message_id,
+                "confirmed": True,
             }
         except Exception as e:
             logger.error(f"【{self.cookie_id}】发送消息失败: {e}")


### PR DESCRIPTION
## 概述

基于上游 `zhinianboke/xianyu-auto-reply` 最新 `main` 整理并提交一组自动化聊天、补发货与消息过滤相关优化与缺陷修复。

本 PR **不包含** 本地 Windows 运行环境适配、私人域名等个人/临时配置。

## 优化项

1. **chat-new 与自动化服务双向桥接**
   - 在线聊天（chat-new）解密后的 IM 推送可转发到 websocket 自动化服务处理
   - 自动化/自动回复文本消息统一经 chat-new 主 IM 连接发送并等待 `messageId` 确认
   - 完善 IM 连接状态判定（含 session 关闭检测），发送失败时及时重置连接标志

2. **手动补发货能力增强**
   - 支持已发货订单在卖家触发“补发+订单号”时继续发卡券
   - 新增系统设置：手动补发冷却秒数、补发后延迟锁秒数（0 表示立即/即释放）
   - 补发时订单商品目录缓存缺失，可按订单归属放行
   - 卡券 API 参数补充订单总价/单价口径，参数说明补充买家昵称

3. **消息过滤扩展**
   - 新增过滤类型 `skip_ai_reply_output`（AI 回复输出黑名单）
   - 自动回复日志展示 `ai_output_filter` 决策原因
   - 过滤规则前端/后端同步支持新类型

4. **定时补发会话复用**
   - 订单缺少 `chat_id` 或持有 `FAILED_*` 占位时，优先复用同账号/买家/商品历史真实会话
   - 避免反复创建会话被平台拒绝

## 处理的 Bug

1. **自动回复回流被误判为人工接管**
   - 自动发出的消息被闲鱼推回后，原先会当成卖家人工消息并暂停会话
   - 现通过发送前登记 + 回流消费匹配，识别自动回复回声，不再误暂停
   - 同时跳过平台侧卖家自动消息（如小红花相关系统话术）

2. **补发场景会话占位 ID 导致发错/发不出**
   - scheduler 创建会话失败会写入 `FAILED_*` 占位
   - 卖家在真实会话触发补发时，优先使用当前消息中的真实 `chat_id` 并回写订单

3. **内部发货 API 发送结果误判**
   - 图片/文本发送失败时补齐 `send_results` 与失败原因
   - 文本分段发送返回失败时正确抛错，避免“假成功”

4. **chat-new 路径发送状态被误标 timeout**
   - 无 `send_future`（已由 chat-new 确认）时直接记 `success`，避免后台超时任务把成功消息改成 timeout

## 提交列表

1. `feat: 打通 chat-new 与自动化服务双向消息桥接并统一主连接发送`
2. `fix: 修复自动回复回流误判为人工接管并拦截 AI 输出黑名单`
3. `feat: 消息过滤新增 AI 回复输出黑名单类型与日志展示`
4. `fix: 完善手动补发货会话修复、已发货补发及可配置冷却锁`
5. `feat: 卡券 API 参数说明补充买家昵称`

## 测试建议

- [ ] 开启在线聊天后，买家消息可触发自动回复/自动发货
- [ ] 自动回复后会话不会被误暂停；人工真实回复仍会暂停
- [ ] 配置 AI 输出黑名单关键词后，命中内容不发送给买家
- [ ] 对已发货订单发送“补发+订单号”可重新发卡券
- [ ] 手动补发冷却/延迟锁设置生效
- [ ] `FAILED_*` 占位会话订单在真实会话补发后 chat_id 被修复