### PR TITLE
fix(token): 滑块验证成功后不再因重试上限丢弃刷新

### DIFF
--- a/websocket/app/services/xianyu/cookie_token_manager.py
+++ b/websocket/app/services/xianyu/cookie_token_manager.py
@@ -1040,16 +1040,9 @@ class CookieTokenManager:
                 return existing_token
             self.restarted_in_browser_refresh = False
 
-            # 检查滑块验证重试次数
-            if captcha_retry_count >= self.max_captcha_verification_count:
-                logger.error(f"【{self.cookie_id}】滑块验证重试次数已达上限 ({self.max_captcha_verification_count})，停止重试")
-                await self.send_token_refresh_notification(
-                    f"滑块验证重试次数已达上限，请手动处理",
-                    "captcha_max_retries_exceeded"
-                )
-                notification_sent = True
-                self.last_token_refresh_status = "failed_captcha_max_retries"
-                return None
+            # 滑块重试上限的检查已移动到下方"拉取 token 后仍要求滑块"分支（need_captcha_verification）。
+            # 原来放在这里（拉 token 之前）有 bug：滑块刚验证成功、cookie 已更新后递归重试进来，
+            # 会在真正用新 cookie 拉 token 之前就撞上限被中止，把本可成功的那次刷新丢掉。
 
             # 检查消息接收冷却时间
             current_time = time.time()
@@ -1111,6 +1104,18 @@ class CookieTokenManager:
 
             # 检查是否需要滑块验证
             if self.need_captcha_verification(res_json):
+                # 滑块重试上限在此判断：只有"用最新 cookie 拉 token 后仍被要求滑块"才算一次真正的重试失败。
+                # 这样滑块成功后的那次重试能先走到上面的 token 拉取并成功返回，不会被上限提前拦掉。
+                if captcha_retry_count >= self.max_captcha_verification_count:
+                    logger.error(f"【{self.cookie_id}】滑块验证重试次数已达上限 ({self.max_captcha_verification_count})，停止重试")
+                    await self.send_token_refresh_notification(
+                        f"滑块验证重试次数已达上限，请手动处理",
+                        "captcha_max_retries_exceeded"
+                    )
+                    notification_sent = True
+                    self.last_token_refresh_status = "failed_captcha_max_retries"
+                    return None
+
                 logger.warning(f"【{self.cookie_id}】检测到需要滑块验证，开始处理...")
 
                 try:


### PR DESCRIPTION
## 问题

`CookieTokenManager.refresh_token` 里，滑块重试上限的检查放在了「拉取 token 之前」。

当账号处于风控、token 刷新触发滑块验证时，流程是递归的：

1. 拉 token → 返回 `FAIL_SYS_USER_VALIDATE` → 需要滑块
2. `handle_captcha_verification` 滑块**验证成功**、更新 cookie
3. `return await self.refresh_token(captcha_retry_count + 1)` 递归重试，用新 cookie 再拉一次 token

问题在于：当第 3 步递归进来时 `captcha_retry_count` 恰好达到上限，函数在**真正用新 cookie 拉取 token 之前**就命中上限检查 `return None`，把一次**本应成功**的 token 刷新白白丢弃。

生产日志表现（同一秒内）：

```
滑块验证成功，获取到新的cookies
滑块验证成功，准备重新刷新token...
开始刷新token... (滑块验证重试次数: 3)
滑块验证重试次数已达上限 (3)，停止重试   ← 新 cookie 还没用上就被拦掉
```

结果：账号即使滑块通过了也无法恢复，`current_token` 一直拿不到，消息连接持续降级。

## 修复

把上限检查从函数开头移动到「拉取 token 后**仍**被要求滑块验证」的分支里。

语义变为：只有「用最新 cookie 拉 token 仍返回 `FAIL_SYS_USER_VALIDATE`」才算一次真正的重试失败。这样滑块成功后的那次递归重试能先走到 token 拉取逻辑，在成功时正常 `return new_token`；只有确实还需要再次滑块时才计入上限并中止。

- 不改变上限值，也不会无限递归（仍由 `max_captcha_verification_count` 兜底）
- 通知与 `last_token_refresh_status` 状态保持不变，仅位置调整

## 影响

风控滑块通过后账号能正常完成 token 刷新并恢复，不再出现「滑块成功却立刻达到上限停止」导致的假死。

https://claude.ai/code/session_016wLtH1DEnwHuVKdHMnRzUQ