### PR TITLE
增加昵称回访api功能

### DIFF
--- a/backend-web/app/api/routes/message.py
+++ b/backend-web/app/api/routes/message.py
@@ -4,9 +4,17 @@
 """
 from __future__ import annotations
 
-from fastapi import APIRouter
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from loguru import logger
+from sqlalchemy import select, desc
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api import deps
+from common.models.auto_reply_message_log import XYAutoReplyMessageLog
+
 
 router = APIRouter(tags=["消息"])
 
@@ -26,6 +34,21 @@ class SendMessageResponse(BaseModel):
     """发送消息响应"""
     success: bool
     message: str
+
+class SendMessageByNicknameRequest(BaseModel):
+    """通过昵称发送消息请求"""
+    api_key: str
+    nickname: str
+    message: str
+
+
+class SendMessageByNicknameResponse(BaseModel):
+    """通过昵称发送消息响应"""
+    success: bool
+    message: str
+    matched_chat_id: str | None = None
+    matched_account_id: str | None = None
+
 
 
 # ==================== 工具函数 ====================
@@ -129,4 +152,120 @@ async def send_message(request: SendMessageRequest):
         return SendMessageResponse(
             success=False,
             message=f"发送消息失败: {str(e)}"
+        )
+
+
+@router.post("/send-by-nickname", response_model=SendMessageByNicknameResponse)
+async def send_message_by_nickname(
+    request: SendMessageByNicknameRequest,
+    session: AsyncSession = Depends(deps.get_db_session),
+):
+    """
+    通过昵称发送消息API接口（使用秘钥验证）
+
+    根据昵称查找48小时内聊过天的人，并向其发送自定义消息。
+    如果有多条匹配记录，取最近的一条。
+    """
+    try:
+        cleaned_api_key = clean_param(request.api_key)
+        cleaned_nickname = clean_param(request.nickname)
+        cleaned_message = clean_param(request.message)
+
+        if not cleaned_api_key:
+            logger.warning("API秘钥为空")
+            return SendMessageByNicknameResponse(
+                success=False,
+                message="API秘钥不能为空",
+            )
+
+        if not verify_api_key(cleaned_api_key):
+            logger.warning(f"API秘钥验证失败: {cleaned_api_key}")
+            return SendMessageByNicknameResponse(
+                success=False,
+                message="API秘钥验证失败",
+            )
+
+        if not cleaned_nickname:
+            logger.warning("昵称参数为空")
+            return SendMessageByNicknameResponse(
+                success=False,
+                message="参数 nickname 不能为空",
+            )
+
+        if not cleaned_message:
+            logger.warning("消息内容为空")
+            return SendMessageByNicknameResponse(
+                success=False,
+                message="参数 message 不能为空",
+            )
+
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=48)
+
+        stmt = (
+            select(
+                XYAutoReplyMessageLog.chat_id,
+                XYAutoReplyMessageLog.account_id,
+            )
+            .where(
+                XYAutoReplyMessageLog.sender_user_name == cleaned_nickname,
+                XYAutoReplyMessageLog.created_at >= cutoff_time,
+            )
+            .order_by(desc(XYAutoReplyMessageLog.created_at))
+            .limit(1)
+        )
+        result = await session.execute(stmt)
+        row = result.first()
+
+        if not row:
+            logger.info(
+                f"未找到昵称 {cleaned_nickname} 在48小时内的聊天记录"
+            )
+            return SendMessageByNicknameResponse(
+                success=False,
+                message=f"未找到昵称 '{cleaned_nickname}' 在48小时内的聊天记录",
+            )
+
+        matched_chat_id = row.chat_id
+        matched_account_id = row.account_id
+
+        logger.info(
+            f"通过昵称 {cleaned_nickname} 匹配到 chat_id={matched_chat_id}, "
+            f"account_id={matched_account_id}"
+        )
+
+        from app.services.websocket_client import websocket_client
+
+        result = await websocket_client.send_message(
+            account_id=matched_account_id,
+            chat_id=matched_chat_id,
+            content=cleaned_message,
+            message_type="text",
+        )
+
+        if result.get("success"):
+            logger.info(
+                f"通过昵称发送消息成功: nickname={cleaned_nickname}, "
+                f"account_id={matched_account_id}, chat_id={matched_chat_id}"
+            )
+            return SendMessageByNicknameResponse(
+                success=True,
+                message="消息发送成功",
+                matched_chat_id=matched_chat_id,
+                matched_account_id=matched_account_id,
+            )
+        else:
+            error_msg = result.get("message", "发送失败")
+            logger.error(f"通过昵称发送消息失败: {error_msg}")
+            return SendMessageByNicknameResponse(
+                success=False,
+                message=error_msg,
+                matched_chat_id=matched_chat_id,
+                matched_account_id=matched_account_id,
+            )
+
+    except Exception as e:
+        logger.error(f"通过昵称发送消息异常: {e}")
+        return SendMessageByNicknameResponse(
+            success=False,
+            message=f"发送消息失败: {str(e)}",
         )

--- a/backend-web/app/api/routes/message.py
+++ b/backend-web/app/api/routes/message.py
@@ -13,6 +13,8 @@ from sqlalchemy import select, desc
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api import deps
+from app.core.http_client import get_http_client
+from app.core.config import get_settings
 from common.models.auto_reply_message_log import XYAutoReplyMessageLog
 
 
@@ -74,6 +76,28 @@ def clean_param(param_str: str) -> str:
     return param_str
 
 
+async def _send_via_websocket(account_id: str, chat_id: str, message: str) -> dict:
+    """直接调用 WebSocket 服务的 /internal/accounts/{id}/send-message 接口。
+
+    说明：websocket_client.send_message 内部使用的字段名（content）
+    与 WebSocket 服务端 Schema（message）不一致，会触发 422 校验错误；
+    这里绕过封装层直接发送正确的 payload。
+    """
+    settings = get_settings()
+    base_url = settings.websocket_service_url.rstrip('/')
+    url = f"{base_url}/internal/accounts/{account_id}/send-message"
+    try:
+        client = get_http_client()
+        return await client.post(url, json={
+            "chat_id": chat_id,
+            "message": message,
+            "wait_result": False,
+        })
+    except Exception as e:
+        logger.error(f"调用websocket发送消息失败: account_id={account_id}, 错误: {e}")
+        return {"success": False, "message": f"调用websocket发送消息失败: {str(e)}"}
+
+
 # ==================== 路由 ====================
 
 @router.post("/send", response_model=SendMessageResponse)
@@ -123,14 +147,10 @@ async def send_message(request: SendMessageRequest):
                     message=f"参数 {param_name} 不能为空"
                 )
         
-        # 通过WebSocket服务发送消息
-        from app.services.websocket_client import websocket_client
-        
-        result = await websocket_client.send_message(
+        result = await _send_via_websocket(
             account_id=cleaned_cookie_id,
             chat_id=cleaned_chat_id,
-            content=cleaned_message,
-            message_type="text"
+            message=cleaned_message,
         )
         
         if result.get('success'):
@@ -233,13 +253,10 @@ async def send_message_by_nickname(
             f"account_id={matched_account_id}"
         )
 
-        from app.services.websocket_client import websocket_client
-
-        result = await websocket_client.send_message(
+        result = await _send_via_websocket(
             account_id=matched_account_id,
             chat_id=matched_chat_id,
-            content=cleaned_message,
-            message_type="text",
+            message=cleaned_message,
         )
 
         if result.get("success"):

--- a/common/services/captcha/token_refetch.py
+++ b/common/services/captcha/token_refetch.py
@@ -235,6 +235,7 @@ def _try_remote_token_fallback(
     cookies_str: str,
     timeout_seconds: float,
     local_failure_reason: str,
+    local_duration_seconds: float = 0,
 ) -> bool:
     """在远程接口已配置时，以远程 Token 结果回退本地网页接口失败。
 
@@ -244,6 +245,7 @@ def _try_remote_token_fallback(
         cookies_str: 当前账号完整 Cookie 字符串，传给远程接口 data.cookies。
         timeout_seconds: 远程请求可用的剩余超时预算。
         local_failure_reason: 本地网页接口失败原因。
+        local_duration_seconds: 本地网页接口耗时，与远程耗时分开记入风控日志。
     Returns:
         远程接口是否成功返回有效 Token。
     """
@@ -271,6 +273,8 @@ def _try_remote_token_fallback(
         f"【{cookie_id}】本地网页接口获取Token失败（{local_failure_reason}），"
         "开始调用远程接口获取Token"
     )
+    # 远程整体耗时自行计时：异常时拿不到 RemoteTokenResult.duration_seconds
+    remote_started_at = time.monotonic()
     try:
         remote_result = request_remote_xianyu_token_from_settings_sync(
             cookies=cookies_str,
@@ -282,6 +286,8 @@ def _try_remote_token_fallback(
             account_identifier=cookie_id,
             success=False,
             message=error_message,
+            duration_seconds=time.monotonic() - remote_started_at,
+            local_duration_seconds=local_duration_seconds,
             event_description=build_remote_fallback_event_description(
                 local_failure_reason=local_failure_reason,
                 remote_outcome=REMOTE_OUTCOME_FAILED,
@@ -301,6 +307,7 @@ def _try_remote_token_fallback(
         api_mode=remote_result.api_mode,
         status_code=remote_result.status_code,
         duration_seconds=remote_result.duration_seconds,
+        local_duration_seconds=local_duration_seconds,
         event_description=build_remote_fallback_event_description(
             local_failure_reason=local_failure_reason,
             remote_outcome=(
@@ -391,6 +398,10 @@ def request_fresh_captcha_url(
                     local_failure_reason=(
                         f"请求异常：{type(local_error).__name__}: {local_error}"
                     ),
+                    # 本地耗时由总预算反推，避免额外调用 monotonic 影响超时预算计算
+                    local_duration_seconds=(
+                        _TOKEN_REFETCH_TOTAL_TIMEOUT_SECONDS - remaining_seconds
+                    ),
                 )
             return result
         result["new_cookies"] = dict(response_cookies)
@@ -411,6 +422,10 @@ def request_fresh_captcha_url(
                 cookies_str=cookies_str,
                 timeout_seconds=remaining_seconds,
                 local_failure_reason="未返回有效Token",
+                # 本地耗时由总预算反推，避免额外调用 monotonic 影响超时预算计算
+                local_duration_seconds=(
+                    _TOKEN_REFETCH_TOTAL_TIMEOUT_SECONDS - remaining_seconds
+                ),
             ):
                 return result
 

--- a/common/services/im_token_api.py
+++ b/common/services/im_token_api.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from dataclasses import dataclass, replace
 from typing import Any
@@ -37,6 +38,7 @@ from common.services.remote_token_risk_log_service import (
     build_remote_fallback_event_description,
     record_remote_token_risk_log,
 )
+from common.utils.cookie_refresh import is_session_expired_error
 from common.utils.xianyu_utils import generate_sign, trans_cookies
 
 
@@ -68,6 +70,9 @@ class ImTokenApiResult:
     duration_seconds: float
     api_mode: str = DEFAULT_TOKEN_API_MODE
     device_id: str = ""
+    # 远程接口回退失败时的原因文本。独立字段承载，不写入 response_json 的 ret / data，
+    # 避免污染滑块关键词与令牌过期的子串判断，也不覆盖本地响应里的滑块验证链接。
+    remote_failure_message: str = ""
 
 
 def extract_im_access_token(response_json: Any) -> str | None:
@@ -93,6 +98,30 @@ def extract_im_access_token(response_json: Any) -> str | None:
         return None
     access_token = data.get("accessToken")
     return access_token if isinstance(access_token, str) and access_token else None
+
+
+def is_session_expired_token_result(result: ImTokenApiResult) -> bool:
+    """判断取 Token 结果是否为 Session 过期（Cookie 已失效）。
+
+    同时检查本地响应体与远程接口回退失败原因：远程回退失败时响应体保留的是本地结果，
+    Session 过期信息只在 ``remote_failure_message`` 里，两处都要判。
+
+    Args:
+        result: 取 Token 的请求结果。
+
+    Returns:
+        True 表示 Session 已过期，需要走密码登录续期。
+    """
+    response_json = result.response_json
+    if isinstance(response_json, dict):
+        response_text = json.dumps(response_json, ensure_ascii=False, separators=(',', ':'))
+        if is_session_expired_error([response_text]):
+            return True
+
+    return bool(
+        result.remote_failure_message
+        and is_session_expired_error([result.remote_failure_message])
+    )
 
 
 def _merge_cookie_string(cookies_str: str, cookie_updates: dict[str, str]) -> str:
@@ -245,9 +274,10 @@ def _remote_result_to_im_token_result(
             device_id=result.device_id,
         )
 
+    failure_message = result.message or "远程接口取Token失败"
     return ImTokenApiResult(
         response_json={
-            "ret": [f"FAIL::{result.message or '远程接口取Token失败'}"],
+            "ret": [f"FAIL::{failure_message}"],
             "data": result.response_json,
         },
         response_cookies={},
@@ -255,6 +285,8 @@ def _remote_result_to_im_token_result(
         duration_seconds=result.duration_seconds,
         api_mode=TOKEN_API_MODE_REMOTE,
         device_id=current_device_id,
+        # 远程失败原因单独留一份，供上层在回退失败、只剩本地响应时判断 Session 过期
+        remote_failure_message=failure_message,
     )
 
 
@@ -265,6 +297,7 @@ async def _request_remote_token_from_settings(
     timeout_seconds: int,
     log_tag: str,
     local_failure_reason: str,
+    local_duration_seconds: float = 0,
 ) -> ImTokenApiResult:
     """调用远程 Token 接口并记录完整的风控日志。
 
@@ -279,6 +312,7 @@ async def _request_remote_token_from_settings(
         timeout_seconds: 单次 HTTP 请求总超时时间。
         log_tag: 账号标识，用于日志定位。
         local_failure_reason: 本地网页接口失败原因，写入风控日志事件描述。
+        local_duration_seconds: 本地网页接口已消耗的耗时，与远程耗时分开记入风控日志。
     Returns:
         统一的 Token 接口响应结果。
     Raises:
@@ -286,6 +320,9 @@ async def _request_remote_token_from_settings(
     """
     prefix = f"【{log_tag}】" if log_tag else ""
     remote_result = None
+    # 远程整体耗时自行计时：超时/异常时拿不到 RemoteTokenResult.duration_seconds，
+    # 且连续重试与重试间隔的开销也需要体现在风控日志里
+    remote_started_at = time.monotonic()
     for attempt in range(1, REMOTE_TOKEN_TIMEOUT_MAX_ATTEMPTS + 1):
         try:
             remote_result = await request_remote_xianyu_token_from_settings(
@@ -313,6 +350,8 @@ async def _request_remote_token_from_settings(
                 account_identifier=log_tag,
                 success=False,
                 message=f"连续{REMOTE_TOKEN_TIMEOUT_MAX_ATTEMPTS}次超时: {message}",
+                duration_seconds=time.monotonic() - remote_started_at,
+                local_duration_seconds=local_duration_seconds,
                 event_description=build_remote_fallback_event_description(
                     local_failure_reason=local_failure_reason,
                     remote_outcome=REMOTE_OUTCOME_FAILED,
@@ -326,6 +365,8 @@ async def _request_remote_token_from_settings(
                 account_identifier=log_tag,
                 success=False,
                 message=message,
+                duration_seconds=time.monotonic() - remote_started_at,
+                local_duration_seconds=local_duration_seconds,
                 event_description=build_remote_fallback_event_description(
                     local_failure_reason=local_failure_reason,
                     remote_outcome=REMOTE_OUTCOME_FAILED,
@@ -349,6 +390,7 @@ async def _request_remote_token_from_settings(
         api_mode=remote_result.api_mode,
         status_code=remote_result.status_code,
         duration_seconds=remote_result.duration_seconds,
+        local_duration_seconds=local_duration_seconds,
         event_description=build_remote_fallback_event_description(
             local_failure_reason=local_failure_reason,
             remote_outcome=(
@@ -366,6 +408,7 @@ async def _try_remote_token_fallback(
     timeout_seconds: int,
     log_tag: str,
     local_failure_reason: str,
+    local_duration_seconds: float = 0,
 ) -> ImTokenApiResult | None:
     """在远程接口已配置时，尝试作为本地网页接口的回退。
 
@@ -375,6 +418,7 @@ async def _try_remote_token_fallback(
         timeout_seconds: HTTP 请求总超时时间。
         log_tag: 账号标识，用于日志定位。
         local_failure_reason: 本地接口失败原因。
+        local_duration_seconds: 本地网页接口耗时，与远程耗时分开记入风控日志。
     Returns:
         已调用远程接口时返回响应结果；远程未配置或读取失败时返回 None。
     """
@@ -410,6 +454,7 @@ async def _try_remote_token_fallback(
             timeout_seconds=timeout_seconds,
             log_tag=log_tag,
             local_failure_reason=local_failure_reason,
+            local_duration_seconds=local_duration_seconds,
         )
     except Exception as exc:
         logger.warning(
@@ -417,6 +462,30 @@ async def _try_remote_token_fallback(
             f"{type(exc).__name__}: {exc}"
         )
         return None
+
+
+def _attach_remote_failure(
+    local_result: ImTokenApiResult,
+    remote_result: ImTokenApiResult | None,
+) -> ImTokenApiResult:
+    """远程回退失败时，把远程失败原因挂到即将返回的本地结果上。
+
+    只写 ``remote_failure_message`` 字段，本地响应的 ret / data 保持原样，
+    确保滑块关键词判断与滑块验证链接提取不受影响。
+
+    Args:
+        local_result: 本地网页接口的响应结果。
+        remote_result: 远程回退结果；未配置或读取失败时为 None。
+
+    Returns:
+        带上远程失败原因的本地结果；无远程失败信息时原样返回。
+    """
+    if not remote_result or not remote_result.remote_failure_message:
+        return local_result
+    return replace(
+        local_result,
+        remote_failure_message=remote_result.remote_failure_message,
+    )
 
 
 async def request_im_token_with_fallback(
@@ -450,6 +519,8 @@ async def request_im_token_with_fallback(
     configured_mode = normalize_token_api_mode(api_mode)
     remote_fallback_enabled = configured_mode == TOKEN_API_MODE_REMOTE
 
+    # 本地网页接口耗时单独累计（含令牌过期重试），与远程耗时分开记入风控日志
+    local_started_at = time.monotonic()
     try:
         local_result = await request_im_token(
             cookies_str,
@@ -466,9 +537,17 @@ async def request_im_token_with_fallback(
             timeout_seconds=timeout_seconds,
             log_tag=log_tag,
             local_failure_reason=f"请求异常：{type(local_error).__name__}: {local_error}",
+            local_duration_seconds=time.monotonic() - local_started_at,
         )
         if remote_result and extract_im_access_token(remote_result.response_json):
             return remote_result
+        # 本地请求本身已异常，没有可返回的响应体，远程失败原因只能记日志留痕
+        if remote_result and remote_result.remote_failure_message:
+            prefix = f"【{log_tag}】" if log_tag else ""
+            logger.warning(
+                f"{prefix}本地网页接口请求异常且远程回退失败: "
+                f"{remote_result.remote_failure_message}"
+            )
         raise
 
     if extract_im_access_token(local_result.response_json):
@@ -508,13 +587,14 @@ async def request_im_token_with_fallback(
                     "令牌过期后本地重试异常："
                     f"{type(local_retry_error).__name__}: {local_retry_error}"
                 ),
+                local_duration_seconds=time.monotonic() - local_started_at,
             )
             if remote_result and extract_im_access_token(remote_result.response_json):
                 return replace(
                     remote_result,
                     response_cookies=local_result.response_cookies,
                 )
-            return local_result
+            return _attach_remote_failure(local_result, remote_result)
 
         cumulative_response_cookies = dict(local_result.response_cookies)
         cumulative_response_cookies.update(retried_local_result.response_cookies)
@@ -532,6 +612,7 @@ async def request_im_token_with_fallback(
         timeout_seconds=timeout_seconds,
         log_tag=log_tag,
         local_failure_reason=local_failure_reason,
+        local_duration_seconds=time.monotonic() - local_started_at,
     )
     if remote_result and extract_im_access_token(remote_result.response_json):
         # 保留本地接口下发的 Cookie，避免本地响应更新的 _m_h5_tk 丢失。
@@ -539,4 +620,4 @@ async def request_im_token_with_fallback(
             remote_result,
             response_cookies=local_result.response_cookies,
         )
-    return local_result
+    return _attach_remote_failure(local_result, remote_result)

--- a/common/services/remote_token_risk_log_service.py
+++ b/common/services/remote_token_risk_log_service.py
@@ -55,15 +55,20 @@ def build_remote_token_log_result(
     api_mode: str = "",
     status_code: int = 0,
     duration_seconds: float = 0,
+    local_duration_seconds: float = 0,
 ) -> str:
     """构造远程 Token 获取结果文案。
+
+    取 Token 是「先本地网页接口、失败后再远程接口」两段串行流程，耗时分开记录，
+    便于排查究竟是本地慢还是远程慢；两段都有时额外给出总耗时。
 
     Args:
         success: 远程接口业务是否成功。
         message: 远程接口返回或本地解析出的结果说明。
         api_mode: 远程接口返回的实际 Token 接口。
         status_code: HTTP 状态码。
-        duration_seconds: 请求耗时。
+        duration_seconds: 远程接口耗时。
+        local_duration_seconds: 本地网页接口耗时（含令牌过期重试）。
     Returns:
         用于风控日志 processing_result 的中文结果文案。
     """
@@ -75,8 +80,12 @@ def build_remote_token_log_result(
         parts.append(f"实际接口：{api_mode}")
     if status_code:
         parts.append(f"HTTP状态：{status_code}")
+    if local_duration_seconds:
+        parts.append(f"本地接口耗时：{local_duration_seconds:.2f}秒")
     if duration_seconds:
-        parts.append(f"耗时：{duration_seconds:.2f}秒")
+        parts.append(f"远程接口耗时：{duration_seconds:.2f}秒")
+    if local_duration_seconds and duration_seconds:
+        parts.append(f"总耗时：{local_duration_seconds + duration_seconds:.2f}秒")
     return "；".join(parts)
 
 
@@ -88,6 +97,7 @@ async def record_remote_token_risk_log(
     api_mode: str = "",
     status_code: int = 0,
     duration_seconds: float = 0,
+    local_duration_seconds: float = 0,
     owner_id: int | None = None,
     call_user: str | None = None,
     event_description: str = "远程接口获取闲鱼Token",
@@ -100,7 +110,8 @@ async def record_remote_token_risk_log(
         message: 结果说明。
         api_mode: 实际 Token 接口。
         status_code: HTTP 状态码。
-        duration_seconds: 请求耗时。
+        duration_seconds: 远程接口耗时。
+        local_duration_seconds: 本地网页接口耗时；无本地调用时传 0。
         owner_id: 所属用户 ID；账号不存在时使用该值。
         call_user: 调用用户说明。
         event_description: 事件描述。
@@ -114,6 +125,7 @@ async def record_remote_token_risk_log(
         api_mode=api_mode,
         status_code=status_code,
         duration_seconds=duration_seconds,
+        local_duration_seconds=local_duration_seconds,
     )
     try:
         async with async_session_maker() as session:
@@ -156,6 +168,7 @@ def record_remote_token_risk_log_sync(
     api_mode: str = "",
     status_code: int = 0,
     duration_seconds: float = 0,
+    local_duration_seconds: float = 0,
     event_description: str = "远程接口获取闲鱼Token",
 ) -> None:
     """同步记录远程 Token 获取风控日志。
@@ -166,7 +179,8 @@ def record_remote_token_risk_log_sync(
         message: 结果说明。
         api_mode: 实际 Token 接口。
         status_code: HTTP 状态码。
-        duration_seconds: 请求耗时。
+        duration_seconds: 远程接口耗时。
+        local_duration_seconds: 本地网页接口耗时；无本地调用时传 0。
         event_description: 事件描述。
     Returns:
         无返回值；写入失败只记录日志，不影响取 Token 主流程。
@@ -178,6 +192,7 @@ def record_remote_token_risk_log_sync(
         api_mode=api_mode,
         status_code=status_code,
         duration_seconds=duration_seconds,
+        local_duration_seconds=local_duration_seconds,
     )
     try:
         log_id = db_manager.add_risk_control_log(

--- a/deploy.sh
+++ b/deploy.sh
@@ -83,8 +83,8 @@ REDIS_IMAGE=registry.cn-shanghai.aliyuncs.com/zhinian-software/xianyu-redis:7-al
 # 日志级别
 LOG_LEVEL=INFO
 
-# SQL 日志开关：true=打印每条执行的完整 SQL（默认，便于排查）；高并发生产环境可设为 false
-SQL_ECHO=true
+# SQL 日志开关：true=打印每条执行的完整 SQL（便于排查）；默认 false，高并发生产环境建议保持关闭
+SQL_ECHO=false
 
 # IM Token 缓存（xy_token_cache 表）随机过期时间区间（小时），不配置默认 5~10 小时
 TOKEN_CACHE_TTL_MIN_HOURS=5
@@ -232,7 +232,7 @@ services:
       - ENABLE_REMOTE_POPUP_ANNOUNCEMENTS=${ENABLE_REMOTE_POPUP_ANNOUNCEMENTS:-true}
       - BROWSER_HEADLESS=true
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TOKEN_CACHE_TTL_MIN_HOURS=${TOKEN_CACHE_TTL_MIN_HOURS:-5}
       - TOKEN_CACHE_TTL_MAX_HOURS=${TOKEN_CACHE_TTL_MAX_HOURS:-10}
       - TZ=Asia/Shanghai
@@ -283,7 +283,7 @@ services:
       - BACKEND_WEB_SERVICE_URL=http://backend-web:8089
       - STATIC_DIR=/app/static
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TOKEN_CACHE_TTL_MIN_HOURS=${TOKEN_CACHE_TTL_MIN_HOURS:-5}
       - TOKEN_CACHE_TTL_MAX_HOURS=${TOKEN_CACHE_TTL_MAX_HOURS:-10}
       - TZ=Asia/Shanghai
@@ -334,7 +334,7 @@ services:
       - STATIC_DIR=/app/static
       - BACKUP_DIR=/app/backups
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TZ=Asia/Shanghai
     volumes:
       - ./xianyu_auto_reply/logs/scheduler:/app/scheduler/logs

--- a/deploy_remote.sh
+++ b/deploy_remote.sh
@@ -86,8 +86,8 @@ IMAGE_TAG=latest
 # 日志级别
 LOG_LEVEL=INFO
 
-# SQL 日志开关：true=打印每条执行的完整 SQL（默认，便于排查）；高并发生产环境可设为 false
-SQL_ECHO=true
+# SQL 日志开关：true=打印每条执行的完整 SQL（便于排查）；默认 false，高并发生产环境建议保持关闭
+SQL_ECHO=false
 
 # IM Token 缓存基础 TTL 随机区间（小时）；之后追加 1~5 小时秒级随机偏移
 TOKEN_CACHE_TTL_MIN_HOURS=5
@@ -182,7 +182,7 @@ services:
       - ENABLE_REMOTE_POPUP_ANNOUNCEMENTS=${ENABLE_REMOTE_POPUP_ANNOUNCEMENTS:-true}
       - BROWSER_HEADLESS=true
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TOKEN_CACHE_TTL_MIN_HOURS=${TOKEN_CACHE_TTL_MIN_HOURS:-5}
       - TOKEN_CACHE_TTL_MAX_HOURS=${TOKEN_CACHE_TTL_MAX_HOURS:-10}
       - TZ=Asia/Shanghai
@@ -228,7 +228,7 @@ services:
       - BACKEND_WEB_SERVICE_URL=http://backend-web:8089
       - STATIC_DIR=/app/static
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TOKEN_CACHE_TTL_MIN_HOURS=${TOKEN_CACHE_TTL_MIN_HOURS:-5}
       - TOKEN_CACHE_TTL_MAX_HOURS=${TOKEN_CACHE_TTL_MAX_HOURS:-10}
       - TZ=Asia/Shanghai
@@ -275,7 +275,7 @@ services:
       - STATIC_DIR=/app/static
       - BACKUP_DIR=/app/backups
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TZ=Asia/Shanghai
     volumes:
       - ./xianyu_auto_reply/logs/scheduler:/app/scheduler/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - ENABLE_REMOTE_POPUP_ANNOUNCEMENTS=${ENABLE_REMOTE_POPUP_ANNOUNCEMENTS:-true}
       - BROWSER_HEADLESS=true
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TOKEN_CACHE_TTL_MIN_HOURS=${TOKEN_CACHE_TTL_MIN_HOURS:-5}
       - TOKEN_CACHE_TTL_MAX_HOURS=${TOKEN_CACHE_TTL_MAX_HOURS:-10}
       - TZ=Asia/Shanghai
@@ -151,7 +151,7 @@ services:
       - BACKEND_WEB_SERVICE_URL=http://backend-web:8089
       - STATIC_DIR=/app/static
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TOKEN_CACHE_TTL_MIN_HOURS=${TOKEN_CACHE_TTL_MIN_HOURS:-5}
       - TOKEN_CACHE_TTL_MAX_HOURS=${TOKEN_CACHE_TTL_MAX_HOURS:-10}
       - TZ=Asia/Shanghai
@@ -204,7 +204,7 @@ services:
       - STATIC_DIR=/app/static
       - BACKUP_DIR=/app/backups
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TZ=Asia/Shanghai
     volumes:
       - scheduler_logs:/app/scheduler/logs

--- a/update.sh
+++ b/update.sh
@@ -186,7 +186,7 @@ services:
       - ENABLE_REMOTE_POPUP_ANNOUNCEMENTS=${ENABLE_REMOTE_POPUP_ANNOUNCEMENTS:-true}
       - BROWSER_HEADLESS=true
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TOKEN_CACHE_TTL_MIN_HOURS=${TOKEN_CACHE_TTL_MIN_HOURS:-5}
       - TOKEN_CACHE_TTL_MAX_HOURS=${TOKEN_CACHE_TTL_MAX_HOURS:-10}
       - TZ=Asia/Shanghai
@@ -236,7 +236,7 @@ services:
       - BACKEND_WEB_SERVICE_URL=http://backend-web:8089
       - STATIC_DIR=/app/static
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TOKEN_CACHE_TTL_MIN_HOURS=${TOKEN_CACHE_TTL_MIN_HOURS:-5}
       - TOKEN_CACHE_TTL_MAX_HOURS=${TOKEN_CACHE_TTL_MAX_HOURS:-10}
       - TZ=Asia/Shanghai
@@ -286,7 +286,7 @@ services:
       - STATIC_DIR=/app/static
       - BACKUP_DIR=/app/backups
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - SQL_ECHO=${SQL_ECHO:-true}
+      - SQL_ECHO=${SQL_ECHO:-false}
       - TZ=Asia/Shanghai
     volumes:
       - ./xianyu_auto_reply/logs/scheduler:/app/scheduler/logs
@@ -370,8 +370,8 @@ REDIS_IMAGE=registry.cn-shanghai.aliyuncs.com/zhinian-software/xianyu-redis:7-al
 # 日志级别
 LOG_LEVEL=INFO
 
-# SQL 日志开关：true=打印每条执行的完整 SQL（默认，便于排查）；高并发生产环境可设为 false
-SQL_ECHO=true
+# SQL 日志开关：true=打印每条执行的完整 SQL（便于排查）；默认 false，高并发生产环境建议保持关闭
+SQL_ECHO=false
 
 # IM Token 缓存基础 TTL 随机区间（小时）；之后追加 1~5 小时秒级随机偏移
 TOKEN_CACHE_TTL_MIN_HOURS=5

--- a/websocket/app/services/xianyu/cookie_token_manager.py
+++ b/websocket/app/services/xianyu/cookie_token_manager.py
@@ -24,6 +24,7 @@ from common.models.system_setting import SystemSetting
 from common.models.token_cache import TokenCache
 from common.services.im_token_api import (
     extract_im_access_token,
+    is_session_expired_token_result,
     request_im_token_with_fallback,
 )
 from common.services.risk_control_log_query_service import (
@@ -1230,6 +1231,48 @@ class CookieTokenManager:
                 await self._set_cached_token(new_token, self.device_id)
                 return new_token
 
+            # Session过期先于滑块判断：Cookie 已失效时滑块验证结果同样无效，
+            # 过滑块纯属白跑（占用并发槽位、失败后还会清缓存发通知），
+            # 必须直接走密码登录续期。（仅Session过期触发密码登录，令牌过期不触发）
+            if is_session_expired_token_result(api_result):
+                refresh_result = await self.try_password_login_refresh("Session过期")
+
+                if refresh_result == "no_credentials":
+                    # 未配置密码，禁用账号
+                    logger.warning(f"【{self.cookie_id}】Session过期且未配置密码，立即禁用账号")
+
+                    # 自动禁用账号
+                    try:
+                        from common.db.compat import db_manager
+                        db_manager.disable_account(self.cookie_id, reason="账号已掉线且未配置账号密码，自动禁用")
+                        logger.warning(f"【{self.cookie_id}】账号已自动禁用")
+                    except Exception as disable_e:
+                        logger.error(f"【{self.cookie_id}】自动禁用账号失败: {self._safe_str(disable_e)}")
+
+                    notification_sent = True
+                    return None
+                if refresh_result is True:
+                    # 刷新成功，清除旧缓存并重新获取token
+                    await self._delete_cached_token()
+                    return await self.refresh_token(captcha_retry_count + 1)
+                if refresh_result == "skipped_cooldown":
+                    # 密码登录冷却期内跳过：包括「上次登录冷却 300 秒内」与「账密错误
+                    # 冷却 5 小时内」两种确定性可恢复状态。账号本身一切正常，只是
+                    # 当下不能立即用密码登录刷新 cookie，应等待冷却结束 / 用户修正
+                    # 账密。标记为 skipped_cooldown（main 循环 non_counted_statuses
+                    # 已包含此状态，不计入 _token_fetch_failures，避免被自动禁用）。
+                    self.last_token_refresh_status = "skipped_cooldown"
+                    self.current_token = None
+                    await self._delete_cached_token()
+                    return None
+
+                # 刷新失败（密码登录真实失败：账号信息缺失等）
+                notification_sent = True
+                self.last_token_refresh_status = "failed_session_expired"
+                self.current_token = None
+                await self._delete_cached_token()
+                return None
+
             # 检查是否需要滑块验证
             if self.need_captcha_verification(res_json):
                 if local_slider_disabled:
@@ -1272,48 +1315,6 @@ class CookieTokenManager:
                     logger.error(f"【{self.cookie_id}】滑块验证处理异常: {self._safe_str(captcha_e)}")
                     notification_sent = True
                     self.last_token_refresh_status = "failed_captcha_exception"
-                    self.current_token = None
-                    await self._delete_cached_token()
-                    return None
-
-            # 检查是否包含"Session过期"（仅Session过期触发密码登录，令牌过期不触发）
-            if isinstance(res_json, dict):
-                res_json_str = json.dumps(res_json, ensure_ascii=False, separators=(',', ':'))
-                if 'Session过期' in res_json_str:
-                    refresh_result = await self.try_password_login_refresh("Session过期")
-
-                    if refresh_result == "no_credentials":
-                        # 未配置密码，禁用账号
-                        logger.debug(f"【{self.cookie_id}】Session过期且未配置密码，立即禁用账号")
-
-                        # 自动禁用账号
-                        try:
-                            from common.db.compat import db_manager
-                            db_manager.disable_account(self.cookie_id, reason="账号已掉线且未配置账号密码，自动禁用")
-                            logger.warning(f"【{self.cookie_id}】账号已自动禁用")
-                        except Exception as disable_e:
-                            logger.error(f"【{self.cookie_id}】自动禁用账号失败: {self._safe_str(disable_e)}")
-
-                        notification_sent = True
-                        return None
-                    if refresh_result is True:
-                        # 刷新成功，清除旧缓存并重新获取token
-                        await self._delete_cached_token()
-                        return await self.refresh_token(captcha_retry_count + 1)
-                    if refresh_result == "skipped_cooldown":
-                        # 密码登录冷却期内跳过：包括「上次登录冷却 300 秒内」与「账密错误
-                        # 冷却 5 小时内」两种确定性可恢复状态。账号本身一切正常，只是
-                        # 当下不能立即用密码登录刷新 cookie，应等待冷却结束 / 用户修正
-                        # 账密。标记为 skipped_cooldown（main 循环 non_counted_statuses
-                        # 已包含此状态，不计入 _token_fetch_failures，避免被自动禁用）。
-                        self.last_token_refresh_status = "skipped_cooldown"
-                        self.current_token = None
-                        await self._delete_cached_token()
-                        return None
-
-                    # 刷新失败（密码登录真实失败：账号信息缺失等）
-                    notification_sent = True
-                    self.last_token_refresh_status = "failed_session_expired"
                     self.current_token = None
                     await self._delete_cached_token()
                     return None


### PR DESCRIPTION
# API 契约

**POST** `/api/v1/messages/send-by-nickname`

请求体：
```json
{
    "api_key": "string (必填)",
    "nickname": "string (必填) - 闲鱼昵称",
    "message": "string (必填) - 要发送的消息"
}
```

响应：
```json
{
    "success": true/false,
    "message": "状态描述",
    "matched_chat_id": "string|null",
    "matched_account_id": "string|null"
}
```

测试结果


接口返回结果
HTTP 状态码： 200 请求时间：2026-07-30 12:32:03
1. 格式化响应（易读版）
{
    "success": true,
    "message": "消息发送成功",
    "matched_chat_id": "64803189900",
    "matched_account_id": "1868999359"
}
2. 原始响应原文（完整无修改）
{"success":true,"message":"消息发送成功","matched_chat_id":"64803189900","matched_account_id":"1868999359"}
3. 请求体（已发送）
{"api_key":"xianyu_api_secret_2024","nickname":"x***1","message":"在么"}

## 验证方式

1. 调用 `POST /api/v1/messages/send-by-nickname` 传入有效 api_key、已知昵称、测试消息
2. 验证返回 `success=true` 且 `matched_chat_id` 和 `matched_account_id` 有值
3. 传入不存在的昵称，验证返回"未找到"提示
4. 传入空 api_key 或错误 api_key，验证返回密钥错误