### PR TITLE
fix: 账号删除时级联清理关联数据 & 修复卡券编辑时图片无法删除

### DIFF
--- a/backend-web/app/services/account_service.py
+++ b/backend-web/app/services/account_service.py
@@ -11,13 +11,18 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import func, select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.services.account_limit_service import AccountLimitService
 from common.models.xy_account import XYAccount
+from common.models.xy_catalog_item import XYCatalogItem
+from common.models.xy_keyword_rule import XYKeywordRule
+from common.models.default_reply import DefaultReply, DefaultReplyRecord
+from common.models.card_item_relation import CardItemRelation
 from common.models.user import User
 from common.utils.cookie_refresh import clear_cookie_refresh_snapshot
+from loguru import logger
 
 # UTC时区常量
 UTC = timezone.utc
@@ -434,8 +439,53 @@ class AccountService:
         await self.session.commit()
 
     async def delete_account(self, account: XYAccount) -> None:
+        """删除账号及其关联数据（商品、关键词规则、默认回复等）。
+
+        在同一事务内依次清理子表，再删除账号本身；任一失败整体回滚。
+        """
+        account_pk = account.id
+        account_id_str = account.account_id
+
+        # 1. 收集该账号下所有商品的 item_id，用于清理卡券-商品关联
+        item_result = await self.session.execute(
+            select(XYCatalogItem.item_id).where(XYCatalogItem.account_pk == account_pk)
+        )
+        item_ids = [row[0] for row in item_result.all()]
+
+        # 2. 删除卡券-商品关联（按收集到的 item_id）
+        if item_ids:
+            await self.session.execute(
+                delete(CardItemRelation).where(CardItemRelation.item_id.in_(item_ids))
+            )
+
+        # 3. 删除商品目录
+        await self.session.execute(
+            delete(XYCatalogItem).where(XYCatalogItem.account_pk == account_pk)
+        )
+
+        # 4. 删除关键词规则
+        await self.session.execute(
+            delete(XYKeywordRule).where(XYKeywordRule.account_pk == account_pk)
+        )
+
+        # 5. 删除默认回复配置
+        await self.session.execute(
+            delete(DefaultReply).where(DefaultReply.account_id == account_id_str)
+        )
+
+        # 6. 删除默认回复记录
+        await self.session.execute(
+            delete(DefaultReplyRecord).where(DefaultReplyRecord.account_id == account_id_str)
+        )
+
+        # 7. 最后删除账号本身
         await self.session.delete(account)
+
         await self.session.commit()
+        logger.info(
+            f"Account deleted: pk={account_pk}, account_id={account_id_str}, "
+            f"cleaned {len(item_ids)} catalog items"
+        )
 
     async def get_account_by_unb(self, owner_id: int, unb: str) -> XYAccount | None:
         stmt = select(XYAccount).where(

--- a/backend-web/app/services/card_service.py
+++ b/backend-web/app/services/card_service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select, delete, func, or_, and_, update
@@ -537,7 +538,7 @@ class CardService:
         **kwargs
     ) -> bool:
         """更新卡券
-        
+
         Raises:
             ValueError: 卡券重复时抛出
         """
@@ -546,6 +547,15 @@ class CardService:
         card = result.scalars().first()
         if not card:
             return False
+
+        # 保存旧图片数据快照，用于后续差异检测和文件删除
+        old_image_url = card.image_url
+        old_image_urls: list[str] = []
+        if card.image_urls:
+            try:
+                old_image_urls = json.loads(card.image_urls)
+            except (json.JSONDecodeError, TypeError):
+                pass
 
         # 获取更新后的值（如果没有传入则使用原值）
         new_name = kwargs.get("name", card.name)
@@ -575,8 +585,49 @@ class CardService:
                     value = json.dumps(value)
                 setattr(card, key, value)
 
+        # 检测并删除被移除的图片文件
+        removed: set[str] = set()
+
+        if "image_urls" in kwargs:
+            new_urls: list[str] = []
+            raw = card.image_urls
+            if raw:
+                try:
+                    if isinstance(raw, str):
+                        new_urls = json.loads(raw)
+                    elif isinstance(raw, list):
+                        new_urls = raw
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            removed |= set(old_image_urls) - set(new_urls)
+
+        if "image_url" in kwargs:
+            if old_image_url and old_image_url != card.image_url:
+                removed.add(old_image_url)
+
+        for url in removed:
+            self._delete_card_image_file(url)
+
         await self.session.commit()
         return True
+
+    @staticmethod
+    def _delete_card_image_file(image_url: str) -> None:
+        """删除卡券图片文件（根据 /static/... URL 定位磁盘文件）"""
+        if not image_url:
+            return
+        try:
+            # image_url 格式: "/static/uploads/cards/filename.jpg"
+            relative = image_url.lstrip("/")
+            if relative.startswith("static/"):
+                relative = relative[7:]  # 去掉 "static/" 前缀 -> "uploads/cards/filename.jpg"
+            from app.core.paths import STATIC_ROOT
+            file_path = STATIC_ROOT / relative
+            if file_path.exists():
+                os.remove(str(file_path))
+                logger.info(f"Deleted card image file: {file_path}")
+        except Exception as e:
+            logger.warning(f"Failed to delete card image {image_url}: {e}")
 
     async def delete_card(self, card_id: int, user_id: int) -> bool:
         """删除卡券（同时删除关联表记录）"""

--- a/frontend/src/pages/cards/CardFormModal.tsx
+++ b/frontend/src/pages/cards/CardFormModal.tsx
@@ -304,9 +304,7 @@ export function CardFormModal({ cardId, initialData, onClose, onSaved }: CardFor
         cardData.data_content = formData.dataContent.trim()
       }
 
-      if (formData.imageUrls.length > 0) {
-        cardData.image_urls = formData.imageUrls
-      }
+      cardData.image_urls = formData.imageUrls
 
       if (isEditMode) {
         await updateCard(String(cardId), cardData)


### PR DESCRIPTION
## 修复内容 / Changes

  ### Bug 1：删除账号后关联数据未级联清理 / Account deletion does not cascade-clean related data

  **现象 / Symptom**：删除账号后，其商品（`xy_catalog_items`）、卡券关联（`xy_card_item_relations`）
  、关键词规则（`xy_keyword_rules`）、默认回复（`xy_default_replies`/`xy_default_reply_records`）成
  为孤儿记录。商品管理页"所有账号"视图仍显示已删除账号下的商品。

  Deleting an account left orphan rows in 5 related tables, causing deleted-account products to
  still appear in the "All Accounts" product view.

  **根因 / Root cause**：`AccountService.delete_account()` 仅执行
  `session.delete(account)`，数据库无外键约束，ORM 关系均为 `viewonly=True`。

  `AccountService.delete_account()` only called `session.delete(account)`. No FK constraints exist
  in the DB schema.

  **修复 / Fix**（`backend-web/app/services/account_service.py`）：重写
  `delete_account()`，同一事务内依次清理 5 张关联表，任一失败整体回滚。

  Cascade-delete 5 related tables in a single transaction before removing the account.

  ---

  ### Bug 2：卡券编辑时无法删除图片 / Cannot delete images when editing cards

  **现象 / Symptom**：编辑卡券时点击删除图片只在前端移除，提交后图片文件仍保留在服务器磁盘，且
  `image_urls` 未被清空（清空全部图片时 `imageUrls` 为空数组 `[]`，前端提交逻辑跳过此字段）。

  Removing images in the card edit form only removed them client-side. The files remained on disk
  and the DB `image_urls` field was not cleared because empty arrays were never submitted.

  **修复 / Fix**：
  - 前端 `CardFormModal.tsx`（1 行）：移除条件判断，始终提交 `image_urls`
  - 后端 `card_service.py`：更新前保存旧图片快照 → 更新后计算差异 → 删除被移除的图片文件

  Frontend: always submit `image_urls` (including empty arrays). Backend: snapshot old images before
  update, compute diff, delete removed files from disk.

  ---

  ## 变更文件 / Files Changed

  | 文件 | 变更 |
  |------|------|
  | `backend-web/app/services/account_service.py` | 重写 `delete_account()`，增加级联清理 |
  | `backend-web/app/services/card_service.py` | `update_card()` 增加图片差异检测与磁盘文件删除 |
  | `frontend/src/pages/cards/CardFormModal.tsx` | 移除 `image_urls` 提交的条件判断（1 行） |

  ## 测试 / Testing

  - **Bug 1**：创建账号 → 插入商品/规则/回复 → 删除账号 → 6 张表数据全部清零 ✅
  - **Bug 2**：上传图片 → 清空全部 / 部分删除 / 单图替换 → DB 与磁盘同步 ✅

  ## 部署 / Deployment

  无需数据库迁移。`build.sh rebuild` 或 `update.sh update` 更新容器即可生效。
  No DB migration required. Update containers via `build.sh rebuild` or `update.sh update`.