### PR TITLE
feat: 卡券 API 请求支持买家昵称

### DIFF
--- a/frontend/src/pages/cards/CardFormModal.tsx
+++ b/frontend/src/pages/cards/CardFormModal.tsx
@@ -37,6 +37,7 @@ const postParams = [
   { name: 'spec_value', desc: '规格值' },
   { name: 'cookie_id', desc: 'cookies账号id' },
   { name: 'buyer_id', desc: '买家id' },
+  { name: 'buyer_name', desc: '买家昵称' },
 ]
 
 // 卡券表单数据类型


### PR DESCRIPTION
## 变更内容

- 在卡券配置的 POST 请求参数快捷列表中新增 `buyer_name`（买家昵称）。
- 前端组件版本更新至 1.0.1，并补充中文更新日志。

## 根因与用户影响

后端已经能在卡券 API 请求中解析 `{buyer_name}`，但前端快捷参数列表未展示该参数，用户无法通过点击快速插入。合并后可直接选择该参数，将买家昵称带入卡券 API 请求。

## 不涉及范围

- 不修改卡券 API 后端参数解析和发货逻辑。
- 不包含“人工回复后暂停 AI”功能。
- 不包含左上角版本号展示功能。

## 验证

- `npm ci --ignore-scripts`
- `npm run build`（通过）
- `git diff --check base/main...HEAD`（通过）
