### PR TITLE
feat: 左侧栏展示当前版本号

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -32,6 +32,7 @@ import {
 import { useMenuVisibilityStore } from '@/store/menuVisibilityStore'
 import { useUIStore } from '@/store/uiStore'
 import { cn } from '@/utils/cn'
+import packageJson from '../../../package.json'
 
 interface SidebarProps {
   systemName?: string
@@ -278,14 +279,22 @@ export function Sidebar({ systemName = '闲鱼管理系统' }: SidebarProps) {
             !showLabel ? 'justify-center px-2' : 'justify-between px-4'
           )}
         >
-          <div className="flex items-center gap-2.5">
+          <div className="flex items-center gap-2.5 min-w-0">
             <div className="w-8 h-8 rounded-lg bg-blue-500 flex items-center justify-center flex-shrink-0">
               <MessageSquare className="w-4 h-4 text-white" />
             </div>
             {showLabel && (
-              <span className="font-semibold text-sm text-slate-900 dark:text-white truncate max-w-[140px]">
-                {systemName}
-              </span>
+              <>
+                <span className="font-semibold text-sm text-slate-900 dark:text-white truncate max-w-[96px]">
+                  {systemName}
+                </span>
+                <span
+                  className="text-[11px] text-slate-500 dark:text-slate-400 whitespace-nowrap"
+                  title={`当前版本 v${packageJson.version}`}
+                >
+                  v{packageJson.version}
+                </span>
+              </>
             )}
           </div>
           {sidebarMobileOpen && (
@@ -390,4 +399,3 @@ export function Sidebar({ systemName = '闲鱼管理系统' }: SidebarProps) {
     </>
   )
 }
-


### PR DESCRIPTION
## 变更

- 左侧栏系统名称旁展示当前前端版本号，悬停可查看完整版本信息。
- 版本来源直接读取 `frontend/package.json`，避免重复维护。
- 前端版本从 `1.0.0` 递增至 `1.0.1`，并新增中文 `CHANGELOG.md` 记录。

## 范围

- 仅包含版本号展示所需前端改动。
- 不包含“人工回复后暂停 AI”或卡券 API 的 `buyer_name` 变更。

## 来源

从 fork 提交 `199f9c3` 中仅提取侧边栏版本展示部分，并基于上游 `main` 独立整理。

## 验证

- `npm ci && npm run build`（`frontend`，通过）
- `git diff --check base/main...HEAD`（通过）