### PR TITLE
feat: 支持人工回复后暂停 AI 回复

### DIFF
--- a/backend-web/app/services/ai_reply_service.py
+++ b/backend-web/app/services/ai_reply_service.py
@@ -33,6 +33,8 @@ DEFAULT_AI_SETTINGS = {
     "custom_prompts": "",
     "ai_time_range_start": "",
     "ai_time_range_end": "",
+    "manual_reply_ai_pause_enabled": False,
+    "manual_reply_ai_pause_minutes": 10,
 }
 
 
@@ -61,6 +63,12 @@ class AIReplySettingsService:
         payload["custom_prompts"] = payload.get("custom_prompts") or ""
         payload["ai_time_range_start"] = payload.get("ai_time_range_start") or ""
         payload["ai_time_range_end"] = payload.get("ai_time_range_end") or ""
+        payload["manual_reply_ai_pause_enabled"] = bool(
+            payload.get("manual_reply_ai_pause_enabled", False)
+        )
+        payload["manual_reply_ai_pause_minutes"] = max(
+            1, min(1440, int(payload.get("manual_reply_ai_pause_minutes", 10) or 10))
+        )
         return payload
 
     async def get_settings(self, account: XYAccount) -> dict:
@@ -100,6 +108,14 @@ class AIReplySettingsService:
             merged["ai_time_range_start"] = payload.get("ai_time_range_start") or ""
         if "ai_time_range_end" in payload:
             merged["ai_time_range_end"] = payload.get("ai_time_range_end") or ""
+        if "manual_reply_ai_pause_enabled" in payload:
+            merged["manual_reply_ai_pause_enabled"] = bool(
+                payload.get("manual_reply_ai_pause_enabled")
+            )
+        if "manual_reply_ai_pause_minutes" in payload:
+            merged["manual_reply_ai_pause_minutes"] = int(
+                payload.get("manual_reply_ai_pause_minutes") or 10
+            )
         merged["provider_type"] = normalize_ai_provider_type(
             merged.get("provider_type"),
             merged.get("base_url"),

--- a/common/models/auto_reply_message_log.py
+++ b/common/models/auto_reply_message_log.py
@@ -63,7 +63,7 @@ class XYAutoReplyMessageLog(Base):
     reply_image_url: Mapped[str | None] = mapped_column(String(1000), comment="回复图片URL")
     reply_segments: Mapped[list | None] = mapped_column(JSON, comment="拆分后的回复分段")
     error_message: Mapped[str | None] = mapped_column(Text, comment="错误信息")
-    send_status: Mapped[str] = mapped_column(String(20), nullable=False, default="unknown", comment="发送状态：success-发送成功/failed-发送失败/unknown-未知(无响应)/timeout-超时(无响应超过阈值)")
+    send_status: Mapped[str] = mapped_column(String(20), nullable=False, default="unknown", comment="发送状态：success-发送成功/failed-发送失败/unknown-未知(无响应)/timeout-超时(无响应超过阈值)/paused-AI暂停回复")
     send_fail_reason: Mapped[str | None] = mapped_column(Text, comment="发送失败原因（如被安全拦截的明文文案）")
     raw_message_json: Mapped[dict | None] = mapped_column(JSON, comment="原始消息JSON")
     context_snapshot: Mapped[dict | None] = mapped_column(JSON, comment="上下文快照")

--- a/common/schemas/ai_reply.py
+++ b/common/schemas/ai_reply.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AIReplySettings(BaseModel):
@@ -17,6 +17,8 @@ class AIReplySettings(BaseModel):
     custom_prompts: str = ""
     ai_time_range_start: str = ""
     ai_time_range_end: str = ""
+    manual_reply_ai_pause_enabled: bool = False
+    manual_reply_ai_pause_minutes: int = Field(default=10, ge=1, le=1440)
 
 
 class AIReplySettingsUpdate(BaseModel):
@@ -34,6 +36,8 @@ class AIReplySettingsUpdate(BaseModel):
     enabled: bool | None = None
     ai_time_range_start: str | None = None
     ai_time_range_end: str | None = None
+    manual_reply_ai_pause_enabled: bool | None = None
+    manual_reply_ai_pause_minutes: int | None = Field(default=None, ge=1, le=1440)
 
 
 class AIModelListRequest(BaseModel):

--- a/common/tests/test_manual_ai_reply_pause.py
+++ b/common/tests/test_manual_ai_reply_pause.py
@@ -1,0 +1,62 @@
+"""人工回复 AI 精确暂停的源码契约回归测试。"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _function_source(path: Path, class_name: str, function_name: str) -> str:
+    source = path.read_text(encoding="utf-8-sig")
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name == function_name:
+                    return ast.get_source_segment(source, child) or ""
+    raise AssertionError(f"未找到 {class_name}.{function_name}")
+
+
+class ManualAiReplyPauseTest(unittest.TestCase):
+    def test_pause_key_includes_account_buyer_and_item(self):
+        source = _function_source(
+            ROOT / "websocket/app/services/xianyu/resource_manager.py",
+            "AutoReplyPauseManager",
+            "pause_ai_reply_for_manual_message",
+        )
+        self.assertIn("self.buyer_contexts.get", source)
+        self.assertIn("self.paused_ai_contexts[(cookie_id, buyer_id, target_item_id)]", source)
+        self.assertIn("target_item_id = str(item_id or remembered_item_id).strip()", source)
+
+    def test_ai_only_pause_is_configurable_and_checked_before_sending(self):
+        schema = (ROOT / "common/schemas/ai_reply.py").read_text(encoding="utf-8")
+        auto_reply = (ROOT / "websocket/app/services/xianyu/auto_reply_service.py").read_text(encoding="utf-8")
+        ai_engine = (ROOT / "websocket/app/services/xianyu/ai_reply_engine.py").read_text(encoding="utf-8")
+        frontend = (ROOT / "frontend/src/pages/accounts/Accounts.tsx").read_text(encoding="utf-8")
+
+        self.assertIn("manual_reply_ai_pause_enabled", schema)
+        self.assertIn("manual_reply_ai_pause_minutes", schema)
+        self.assertIn("get_remaining_ai_pause_time", auto_reply)
+        self.assertIn("is_ai_reply_paused(cookie_id, user_id, item_id)", ai_engine)
+        self.assertIn("人工回复后暂停 AI", frontend)
+
+    def test_paused_ai_reply_is_recorded_as_a_dedicated_log(self):
+        auto_reply = (ROOT / "websocket/app/services/xianyu/auto_reply_service.py").read_text(encoding="utf-8")
+        frontend = (ROOT / "frontend/src/pages/autoReplyLogs/AutoReplyLogs.tsx").read_text(encoding="utf-8")
+
+        self.assertIn("_record_manual_reply_ai_paused_log", auto_reply)
+        self.assertIn('\"reply_strategy\": \"ai\"', auto_reply)
+        self.assertIn('\"matched_rule_type\": \"ai\"', auto_reply)
+        self.assertIn('\"send_status\": \"paused\"', auto_reply)
+        self.assertIn(
+            'f\"暂停ai回复{pause_minutes}分钟，预计恢复时间：{pause_end_time}\"',
+            auto_reply,
+        )
+        self.assertIn("paused: '暂停回复'", frontend)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -475,6 +475,8 @@ export interface AIReplySettings {
   custom_prompts?: string
   ai_time_range_start?: string
   ai_time_range_end?: string
+  manual_reply_ai_pause_enabled?: boolean
+  manual_reply_ai_pause_minutes?: number
   // 兼容旧字段（前端内部使用）
   enabled?: boolean
 }
@@ -511,6 +513,12 @@ export const updateAIReplySettings = (cookieId: string, settings: Partial<AIRepl
   if (settings.custom_prompts !== undefined) payload.custom_prompts = settings.custom_prompts
   if (settings.ai_time_range_start !== undefined) payload.ai_time_range_start = settings.ai_time_range_start
   if (settings.ai_time_range_end !== undefined) payload.ai_time_range_end = settings.ai_time_range_end
+  if (settings.manual_reply_ai_pause_enabled !== undefined) {
+    payload.manual_reply_ai_pause_enabled = settings.manual_reply_ai_pause_enabled
+  }
+  if (settings.manual_reply_ai_pause_minutes !== undefined) {
+    payload.manual_reply_ai_pause_minutes = settings.manual_reply_ai_pause_minutes
+  }
   return put(`${AI_SETTINGS_PREFIX}/${cookieId}`, payload)
 }
 

--- a/frontend/src/pages/accounts/Accounts.tsx
+++ b/frontend/src/pages/accounts/Accounts.tsx
@@ -185,6 +185,8 @@ export function Accounts() {
   const [aiCustomPrompts, setAiCustomPrompts] = useState('')
   const [aiTimeRangeStart, setAiTimeRangeStart] = useState('')
   const [aiTimeRangeEnd, setAiTimeRangeEnd] = useState('')
+  const [aiManualReplyPauseEnabled, setAiManualReplyPauseEnabled] = useState(false)
+  const [aiManualReplyPauseMinutes, setAiManualReplyPauseMinutes] = useState(10)
   const [aiSettingsSaving, setAiSettingsSaving] = useState(false)
   const [aiSettingsLoading, setAiSettingsLoading] = useState(false)
   const [aiTesting, setAiTesting] = useState(false)
@@ -494,6 +496,8 @@ export function Accounts() {
     setEditPasswordVisible(false)
     setAiTimeRangeStart('')
     setAiTimeRangeEnd('')
+    setAiManualReplyPauseEnabled(false)
+    setAiManualReplyPauseMinutes(10)
   }, [activeModal, cancelPwdSession, clearPwdCheck, clearPwdSuccessCloseTimer, clearQrCheck, pwdSessionId, pwdStatus])
 
   // ==================== 管理员默认密码检查 ====================
@@ -1381,6 +1385,8 @@ export function Accounts() {
       }
       setAiTimeRangeStart(formatTime(settings.ai_time_range_start))
       setAiTimeRangeEnd(formatTime(settings.ai_time_range_end))
+      setAiManualReplyPauseEnabled(settings.manual_reply_ai_pause_enabled ?? false)
+      setAiManualReplyPauseMinutes(settings.manual_reply_ai_pause_minutes ?? 10)
     } catch (error) {
       const detail = getApiErrorMessage(error, '加载AI设置失败')
       addToast({ type: 'error', message: detail })
@@ -1487,6 +1493,8 @@ export function Accounts() {
         custom_prompts: aiCustomPrompts,
         ai_time_range_start: aiTimeRangeStart,
         ai_time_range_end: aiTimeRangeEnd,
+        manual_reply_ai_pause_enabled: aiManualReplyPauseEnabled,
+        manual_reply_ai_pause_minutes: aiManualReplyPauseMinutes,
       })
       if (!result.success) {
         addToast({ type: 'warning', message: result.message || 'AI配置未填写完整，无法开启AI回复' })
@@ -1530,6 +1538,8 @@ export function Accounts() {
         custom_prompts: aiCustomPrompts,
         ai_time_range_start: aiTimeRangeStart,
         ai_time_range_end: aiTimeRangeEnd,
+        manual_reply_ai_pause_enabled: aiManualReplyPauseEnabled,
+        manual_reply_ai_pause_minutes: aiManualReplyPauseMinutes,
       })
       if (!saveResult.success) {
         addToast({ type: 'warning', message: saveResult.message || 'AI配置未填写完整，无法测试AI连接' })
@@ -3500,6 +3510,45 @@ export function Accounts() {
                           </span>
                         )}
                       </p>
+                    </div>
+                  )}
+
+                  {aiEnabled && (
+                    <div className="bg-slate-50 dark:bg-slate-800/40 rounded-xl p-3.5 border border-slate-100 dark:border-slate-800 space-y-3">
+                      <div className="flex items-center justify-between gap-4">
+                        <div>
+                          <p className="text-sm font-medium text-slate-900 dark:text-slate-100">人工回复后暂停 AI</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">仅暂停相同商品 ID 和买家 ID 的 AI 回复，关键词和默认回复仍正常执行。</p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setAiManualReplyPauseEnabled(value => !value)}
+                          className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
+                            aiManualReplyPauseEnabled ? 'bg-blue-600' : 'bg-slate-300 dark:bg-slate-600'
+                          }`}
+                          aria-label="切换人工回复后暂停 AI"
+                        >
+                          <span
+                            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                              aiManualReplyPauseEnabled ? 'translate-x-6' : 'translate-x-1'
+                            }`}
+                          />
+                        </button>
+                      </div>
+                      {aiManualReplyPauseEnabled && (
+                        <div className="flex items-center gap-3">
+                          <label className="input-label mb-0 shrink-0">暂停时长</label>
+                          <input
+                            type="number"
+                            value={aiManualReplyPauseMinutes}
+                            onChange={(e) => setAiManualReplyPauseMinutes(Number(e.target.value))}
+                            className="input-ios w-28"
+                            min="1"
+                            max="1440"
+                          />
+                          <span className="text-sm text-slate-500 dark:text-slate-400">分钟（1–1440）</span>
+                        </div>
+                      )}
                     </div>
                   )}
 

--- a/frontend/src/pages/autoReplyLogs/AutoReplyLogs.tsx
+++ b/frontend/src/pages/autoReplyLogs/AutoReplyLogs.tsx
@@ -53,6 +53,7 @@ const DECISION_REASON_LABELS: Record<string, string> = {
   chat_paused_after_delay: '延迟后会话已暂停',
   empty_reply: '回复内容为空',
   default_reply_once: '默认回复仅回复一次',
+  manual_reply_ai_paused: '人工回复后暂停 AI',
 }
 
 function formatDateTime(value?: string | null) {
@@ -107,6 +108,7 @@ const SEND_STATUS_LABELS: Record<string, string> = {
   failed: '发送失败',
   unknown: '待确认',
   timeout: '超时',
+  paused: '暂停回复',
 }
 
 const SEND_STATUS_CLASSES: Record<string, string> = {
@@ -114,6 +116,7 @@ const SEND_STATUS_CLASSES: Record<string, string> = {
   failed: 'text-red-600 dark:text-red-400',
   unknown: 'text-slate-500 dark:text-slate-400',
   timeout: 'text-amber-600 dark:text-amber-400',
+  paused: 'text-yellow-600 dark:text-yellow-400',
 }
 
 function buildSendStatusLabel(value?: string | null) {
@@ -307,6 +310,7 @@ export function AutoReplyLogs() {
                 <option value="failed">发送失败</option>
                 <option value="unknown">待确认</option>
                 <option value="timeout">超时</option>
+                <option value="paused">暂停回复</option>
               </select>
             </div>
             <button onClick={handleSearch} className="btn-ios-primary">

--- a/websocket/app/services/xianyu/ai_reply_engine.py
+++ b/websocket/app/services/xianyu/ai_reply_engine.py
@@ -417,6 +417,8 @@ class AIReplyEngine:
             "custom_prompts": "",
             "ai_time_range_start": "",
             "ai_time_range_end": "",
+            "manual_reply_ai_pause_enabled": False,
+            "manual_reply_ai_pause_minutes": 10,
         }
 
     def _extract_ai_settings(self, ai_settings: Dict[str, Any]) -> Dict[str, Any]:
@@ -437,6 +439,12 @@ class AIReplyEngine:
         payload["custom_prompts"] = payload.get("custom_prompts") or ""
         payload["ai_time_range_start"] = payload.get("ai_time_range_start") or ""
         payload["ai_time_range_end"] = payload.get("ai_time_range_end") or ""
+        payload["manual_reply_ai_pause_enabled"] = bool(
+            payload.get("manual_reply_ai_pause_enabled", False)
+        )
+        payload["manual_reply_ai_pause_minutes"] = max(
+            1, min(1440, int(payload.get("manual_reply_ai_pause_minutes", 10) or 10))
+        )
         return payload
     
     def _get_api_provider_name(self, settings: Dict) -> str:
@@ -786,6 +794,14 @@ class AIReplyEngine:
                 settings = await self.get_ai_settings(cookie_id, db_session)
                 if not settings.get("ai_enabled"):
                     return None
+                if (
+                    settings.get("manual_reply_ai_pause_enabled")
+                    and pause_manager.is_ai_reply_paused(cookie_id, user_id, item_id)
+                ):
+                    logger.info(
+                        f"【{cookie_id}】AI 回复前检测到人工回复暂停：buyer_id={user_id}, item_id={item_id}"
+                    )
+                    return None
                 
                 # 获取对话历史
                 context_stmt = (
@@ -926,7 +942,13 @@ class AIReplyEngine:
                 
                 if reply:
                     # 二次检测：大模型返回后，若人工已介入暂停，则放弃本次回复
-                    if pause_manager.is_chat_paused(chat_id, cookie_id):
+                    if (
+                        pause_manager.is_chat_paused(chat_id, cookie_id)
+                        or (
+                            settings.get("manual_reply_ai_pause_enabled")
+                            and pause_manager.is_ai_reply_paused(cookie_id, user_id, item_id)
+                        )
+                    ):
                         logger.info(f"【{cookie_id}】AI回复生成成功，但检测到会话 {chat_id} 已被人工介入暂停，跳过保存和发送")
                         return None
 

--- a/websocket/app/services/xianyu/auto_reply_service.py
+++ b/websocket/app/services/xianyu/auto_reply_service.py
@@ -246,6 +246,40 @@ class AutoReplyService:
     async def _record_auto_reply_log(self, log_payload: Dict[str, Any]) -> int | None:
         """写入自动回复日志，返回日志主键ID（供异步回写发送状态）"""
         return await self.auto_reply_log_service.record_message(log_payload)
+
+    async def _record_manual_reply_ai_paused_log(
+        self, log_payload: Dict[str, Any], remaining_seconds: int, pause_minutes: int
+    ) -> None:
+        """记录人工回复暂停 AI 的消息日志，不影响后续默认回复。"""
+        pause_end_time = time.strftime(
+            "%Y-%m-%d %H:%M:%S",
+            time.localtime(time.time() + remaining_seconds),
+        )
+        context_snapshot = dict(log_payload.get("context_snapshot") or {})
+        context_snapshot.update({
+            "manual_reply_ai_pause_remaining_seconds": remaining_seconds,
+            "manual_reply_ai_pause_ends_at": pause_end_time,
+            "manual_reply_ai_pause_buyer_id": log_payload.get("sender_user_id"),
+            "manual_reply_ai_pause_item_id": log_payload.get("item_id") or "",
+        })
+        paused_log_payload = {
+            **log_payload,
+            "process_status": "skipped",
+            "decision_reason": "manual_reply_ai_paused",
+            "reply_strategy": "ai",
+            "reply_mode": "none",
+            "matched_rule_type": "ai",
+            "reply_text": None,
+            "reply_image_url": None,
+            "reply_segments": [],
+            "send_status": "paused",
+            "send_fail_reason": (
+                f"暂停ai回复{pause_minutes}分钟，预计恢复时间：{pause_end_time}"
+            ),
+            "send_result_json": None,
+            "context_snapshot": context_snapshot,
+        }
+        await self._record_auto_reply_log(paused_log_payload)
     
     # ==================== 消息去重功能(参照旧框架reply_scheduler.py) ====================
     
@@ -580,10 +614,15 @@ class AutoReplyService:
             myid = getattr(self.xianyu_instance, 'myid', self.cookie_id)
             self._merge_log_context(log_payload, myid=myid)
             if send_user_id == myid:
-                # 手动发出消息，暂停该会话的自动回复
+                # 手动发出消息。启用 AI 专用暂停时，仅暂停同买家同商品的 AI；
+                # 未启用时保留原有按会话暂停全部自动回复的行为。
                 log_payload["process_status"] = "skipped"
                 log_payload["decision_reason"] = "self_message"
-                pause_manager.pause_chat(chat_id, self.cookie_id)
+                ai_pause_enabled = await self._pause_ai_reply_after_manual_message(
+                    chat_id, item_id, log_payload
+                )
+                if not ai_pause_enabled:
+                    pause_manager.pause_chat(chat_id, self.cookie_id)
                 return
             
             # 2. 检查是否是系统消息（参照旧框架message_handler_core.py）
@@ -650,6 +689,13 @@ class AutoReplyService:
                         )
                     return
             # 商品ID不存在时继续执行原有逻辑
+
+            # 保存买家和商品上下文。人工回复消息只会携带卖家自己的 ID，
+            # 需复用此前买家消息中的 buyer_id，才能按买家+商品精确暂停 AI。
+            # 仅记录已排除系统消息且已通过商品归属校验的真实买家消息。
+            pause_manager.remember_buyer_context(
+                chat_id, self.cookie_id, send_user_id, item_id
+            )
             
             # 5. 检查消息等待时间(去重，参照旧框架reply_scheduler.py)
             # 同一会话的同一消息内容在等待时间内不重复回复
@@ -847,7 +893,14 @@ class AutoReplyService:
             try:
                 # 取出待检测的发送 (future, mid)（临时键，不写入数据库）
                 pending_send_waiters = log_payload.pop("_pending_send_waiters", None)
-                log_id = await self._record_auto_reply_log(log_payload)
+                ai_pause_log_recorded = log_payload.pop("_manual_reply_ai_pause_log_recorded", False)
+                # AI 暂停后没有其他规则实际回复时，AI 暂停日志已单独写入，无需重复记录“未匹配规则”。
+                should_skip_final_log = (
+                    ai_pause_log_recorded
+                    and log_payload.get("decision_reason") == "no_rule_matched"
+                    and not pending_send_waiters
+                )
+                log_id = None if should_skip_final_log else await self._record_auto_reply_log(log_payload)
                 # 若消息已发出且日志写入成功，起后台任务异步等待发送结果并回写状态
                 if log_id and pending_send_waiters:
                     self._spawn_send_status_writeback(log_id, pending_send_waiters)
@@ -1811,6 +1864,23 @@ class AutoReplyService:
                 return None
 
             ai_settings = await ai_engine.get_ai_settings(self.cookie_id, session)
+            if ai_settings.get("manual_reply_ai_pause_enabled"):
+                pause_minutes = int(ai_settings.get("manual_reply_ai_pause_minutes", 10) or 10)
+                remaining = pause_manager.get_remaining_ai_pause_time(
+                    self.cookie_id, send_user_id, item_id or ""
+                )
+                if remaining:
+                    logger.info(
+                        f"【{self.cookie_id}】买家 {send_user_id} 商品 {item_id} 正在人工回复 AI 暂停期，"
+                        f"剩余 {remaining} 秒"
+                    )
+                    if reply_trace is not None:
+                        await self._record_manual_reply_ai_paused_log(
+                            reply_trace, remaining, pause_minutes
+                        )
+                        # 若未命中默认回复，最终日志已由上方的 AI 暂停记录覆盖，避免再写一条“未匹配规则”。
+                        reply_trace["_manual_reply_ai_pause_log_recorded"] = True
+                    return None
             ai_provider_name = ai_engine._get_api_provider_name(ai_settings)
             if reply_trace is not None:
                 reply_trace["ai_model_name"] = ai_settings.get("model_name")
@@ -1887,6 +1957,37 @@ class AutoReplyService:
         except Exception as e:
             logger.error(f"【{self.cookie_id}】获取AI回复失败: {e}")
             return None
+
+    async def _pause_ai_reply_after_manual_message(
+        self, chat_id: str, item_id: str, log_payload: Dict[str, Any]
+    ) -> bool:
+        """人工回复后，按账号、买家和商品维度暂停 AI 回复。"""
+        try:
+            from app.services.xianyu.ai_reply_engine import get_ai_reply_engine
+
+            async with async_session_maker() as session:
+                settings = await get_ai_reply_engine().get_ai_settings(
+                    self.cookie_id, session
+                )
+
+            if not settings.get("manual_reply_ai_pause_enabled"):
+                return False
+
+            pause_minutes = int(settings.get("manual_reply_ai_pause_minutes", 10) or 10)
+            paused_context = pause_manager.pause_ai_reply_for_manual_message(
+                chat_id, self.cookie_id, item_id, pause_minutes
+            )
+            if paused_context:
+                buyer_id, paused_item_id = paused_context
+                log_payload.setdefault("context_snapshot", {}).update({
+                    "manual_reply_ai_pause_minutes": pause_minutes,
+                    "manual_reply_ai_pause_buyer_id": buyer_id,
+                    "manual_reply_ai_pause_item_id": paused_item_id,
+                })
+            return True
+        except Exception as e:
+            logger.warning(f"【{self.cookie_id}】设置人工回复 AI 暂停失败: {e}")
+            return False
 
     async def _check_user_has_orders(self, session: AsyncSession, buyer_user_id: str) -> bool:
         """检查指定买家在当前账号下是否有订单记录

--- a/websocket/app/services/xianyu/resource_manager.py
+++ b/websocket/app/services/xianyu/resource_manager.py
@@ -30,6 +30,70 @@ class AutoReplyPauseManager:
         # key: (cookie_id, chat_id) 元组，value: pause_until_timestamp
         # 设计要点：暂停必须按账号隔离，避免账号A对某个chat手动回复后账号B在相同chat上也被误暂停
         self.paused_chats: dict[tuple[str, str], float] = {}
+        # 最近一次买家消息上下文：用于将人工回复精确关联到买家和商品。
+        # key: (cookie_id, chat_id), value: (buyer_id, item_id, recorded_at)
+        self.buyer_contexts: dict[tuple[str, str], tuple[str, str, float]] = {}
+        # AI 专用暂停：不影响关键词和默认回复。
+        # key: (cookie_id, buyer_id, item_id), value: pause_until_timestamp
+        self.paused_ai_contexts: dict[tuple[str, str, str], float] = {}
+
+    def remember_buyer_context(
+        self, chat_id: str, cookie_id: str, buyer_id: str, item_id: str
+    ) -> None:
+        """记录买家发来的消息上下文，供随后人工回复建立精确 AI 暂停。"""
+        normalized_chat_id = str(chat_id or "").strip()
+        normalized_buyer_id = str(buyer_id or "").strip()
+        normalized_item_id = str(item_id or "").strip()
+        if not normalized_chat_id or not normalized_buyer_id or not normalized_item_id:
+            return
+        self.buyer_contexts[(cookie_id, normalized_chat_id)] = (
+            normalized_buyer_id,
+            normalized_item_id,
+            time.time(),
+        )
+
+    def pause_ai_reply_for_manual_message(
+        self, chat_id: str, cookie_id: str, item_id: str, pause_minutes: int
+    ) -> tuple[str, str] | None:
+        """按当前会话的买家和商品，暂停该精确维度的 AI 回复。"""
+        normalized_chat_id = str(chat_id or "").strip()
+        context = self.buyer_contexts.get((cookie_id, normalized_chat_id))
+        if not context:
+            logger.info(
+                f"【{cookie_id}】人工回复 AI 暂停未生效：未找到会话 {normalized_chat_id} 的买家上下文"
+            )
+            return None
+
+        buyer_id, remembered_item_id, _ = context
+        target_item_id = str(item_id or remembered_item_id).strip()
+        if not buyer_id or not target_item_id or pause_minutes <= 0:
+            return None
+
+        pause_until = time.time() + pause_minutes * 60
+        self.paused_ai_contexts[(cookie_id, buyer_id, target_item_id)] = pause_until
+        end_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(pause_until))
+        logger.info(
+            f"【{cookie_id}】人工回复后暂停 AI：buyer_id={buyer_id}, item_id={target_item_id}, "
+            f"时长={pause_minutes}分钟，恢复时间: {end_time}"
+        )
+        return buyer_id, target_item_id
+
+    def get_remaining_ai_pause_time(
+        self, cookie_id: str, buyer_id: str, item_id: str
+    ) -> int:
+        """获取指定买家和商品的 AI 暂停剩余秒数。"""
+        key = (str(cookie_id or ""), str(buyer_id or ""), str(item_id or ""))
+        pause_until = self.paused_ai_contexts.get(key)
+        if not pause_until:
+            return 0
+        remaining = max(0, int(pause_until - time.time()))
+        if remaining == 0:
+            self.paused_ai_contexts.pop(key, None)
+        return remaining
+
+    def is_ai_reply_paused(self, cookie_id: str, buyer_id: str, item_id: str) -> bool:
+        """检查指定买家和商品是否仍在 AI 专用暂停期内。"""
+        return self.get_remaining_ai_pause_time(cookie_id, buyer_id, item_id) > 0
 
     def pause_chat(self, chat_id: str, cookie_id: str):
         """暂停指定chat_id的自动回复,使用账号特定的暂停时间
@@ -113,6 +177,20 @@ class AutoReplyPauseManager:
 
         for key in expired_keys:
             del self.paused_chats[key]
+
+        expired_ai_keys = [
+            key for key, pause_until in self.paused_ai_contexts.items()
+            if current_time >= pause_until
+        ]
+        for key in expired_ai_keys:
+            del self.paused_ai_contexts[key]
+
+        stale_context_keys = [
+            key for key, (_, _, recorded_at) in self.buyer_contexts.items()
+            if current_time - recorded_at >= 24 * 60 * 60
+        ]
+        for key in stale_context_keys:
+            del self.buyer_contexts[key]
 
 
 # 全局暂停管理器实例


### PR DESCRIPTION
## 变更内容
- 在 AI 设置中增加“人工回复后暂停 AI”开关与 1–1440 分钟时长。
- 人工回复后按账号、买家 ID、商品 ID 精确暂停 AI；关键词和默认回复保持可用。
- AI 生成前及生成后都会复核暂停状态，避免人工介入后的并发误回复。
- 买家消息命中暂停时写入 AI 回复日志：回复内容为空、发送状态为黄色“暂停回复”，并显示预计恢复时间。

## 根因与影响
此前人工回复只按会话暂停全部自动回复，无法满足只暂停同一买家和商品的 AI 回复需求。该改动将暂停作用域收窄为 AI，并保留原配置关闭时的原有会话暂停行为。

## 不涉及
- 不包含卡券 `buyer_name` 或侧边栏版本展示改动。
- 不持久化暂停状态；服务重启后内存中的临时暂停会失效。

## 验证
- `python3 -m py_compile common/schemas/ai_reply.py backend-web/app/services/ai_reply_service.py websocket/app/services/xianyu/resource_manager.py websocket/app/services/xianyu/ai_reply_engine.py websocket/app/services/xianyu/auto_reply_service.py`
- `python3 -m unittest common.tests.test_manual_ai_reply_pause`（3 项通过）
- `cd frontend && npm run build`（通过；保留既有动态/静态导入提示）
- `git diff --check`