### PR TITLE
feat: 支持可编辑通知模板

### DIFF
--- a/common/db/compat.py
+++ b/common/db/compat.py
@@ -659,6 +659,8 @@ class DBManagerCompat:
                     'order_id': order.order_no,
                     'account_id': order.account_id,
                     'item_id': order.item_id,
+                    'buyer_nick': order.buyer_nick,
+                    'buyer_fish_nick': order.buyer_fish_nick,
                     'buyer_id': order.buyer_id,
                     'chat_id': order.chat_id,
                     'status': order.status,

--- a/common/tests/test_notification_dispatch.py
+++ b/common/tests/test_notification_dispatch.py
@@ -1,0 +1,189 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "websocket"))
+
+from app.services.xianyu.notification_manager import NotificationManager  # noqa: E402
+from app.services.xianyu.auto_reply_service import AutoReplyService  # noqa: E402
+
+
+class NotificationDispatchTest(unittest.IsolatedAsyncioTestCase):
+    async def test_channels_render_their_own_chat_templates(self):
+        manager = NotificationManager("seller")
+        notifications = [
+            {
+                "enabled": True,
+                "channel_type": "bark",
+                "channel_config": {"device_key": "a", "chat_template": "买家={{buyer_nick}}"},
+            },
+            {
+                "enabled": True,
+                "channel_type": "feishu",
+                "channel_config": {"webhook_url": "https://example.com", "chat_template": "消息={{message}}"},
+            },
+        ]
+
+        with patch(
+            "app.services.xianyu.notification_manager.send_bark_notification",
+            new=AsyncMock(return_value=True),
+        ) as bark_send, patch(
+            "app.services.xianyu.notification_manager.send_feishu_notification",
+            new=AsyncMock(return_value=True),
+        ) as feishu_send:
+            await manager._send_to_channels(
+                notifications,
+                "系统默认正文",
+                template_type="chat",
+                template_context={"buyer_nick": "小王", "message": "你好"},
+            )
+
+        self.assertEqual(bark_send.await_args.args[1], "买家=小王")
+        self.assertEqual(feishu_send.await_args.args[1], "消息=你好")
+
+    async def test_delivery_template_uses_order_nickname_amount_and_quantity(self):
+        manager = NotificationManager("seller")
+        with patch("common.db.compat.db_manager.get_message_filter_keywords", return_value=[]), patch(
+            "common.db.compat.db_manager.get_account_notifications",
+            return_value=[
+                {
+                    "enabled": True,
+                    "channel_type": "bark",
+                    "channel_config": {
+                        "device_key": "a",
+                        "delivery_template": "{{buyer_nick}}|{{amount}}|{{quantity}}|{{result}}",
+                    },
+                }
+            ],
+        ), patch(
+            "common.db.compat.db_manager.get_cookie_details",
+            return_value={"remark": "主账号"},
+        ), patch(
+            "common.db.compat.db_manager.get_order_by_id",
+            return_value={"buyer_fish_nick": "金鱼小姐21", "amount": "2", "quantity": 1},
+        ), patch(
+            "app.services.xianyu.notification_manager.send_bark_notification",
+            new=AsyncMock(return_value=True),
+        ) as bark_send:
+            await manager.send_delivery_failure_notification(
+                "等待你发货",
+                "342188141",
+                "1071626525089",
+                "发货成功",
+                "chat-1",
+                order_id="order-1",
+            )
+
+        self.assertEqual(bark_send.await_args.args[1], "金鱼小姐21|¥2.00|1|发货成功")
+
+    async def test_delivery_default_keeps_original_layout_and_adds_amount_and_quantity(self):
+        manager = NotificationManager("seller")
+        with patch("common.db.compat.db_manager.get_message_filter_keywords", return_value=[]), patch(
+            "common.db.compat.db_manager.get_account_notifications",
+            return_value=[{"enabled": True, "channel_type": "bark", "channel_config": {"device_key": "a"}}],
+        ), patch(
+            "common.db.compat.db_manager.get_cookie_details",
+            return_value={"remark": "主账号"},
+        ), patch(
+            "common.db.compat.db_manager.get_order_by_id",
+            return_value={"buyer_fish_nick": "金鱼小姐21", "amount": "2", "quantity": 1},
+        ), patch(
+            "app.services.xianyu.notification_manager.send_bark_notification",
+            new=AsyncMock(return_value=True),
+        ) as bark_send:
+            await manager.send_delivery_failure_notification(
+                "等待你发货",
+                "342188141",
+                "1071626525089",
+                "发货成功",
+                "chat-1",
+                order_id="order-1",
+            )
+
+        message = bark_send.await_args.args[1]
+        self.assertIn("买家: 金鱼小姐21 (ID: 342188141)", message)
+        self.assertIn("订单金额: ¥2.00", message)
+        self.assertIn("购买数量: 1", message)
+        self.assertNotIn("订单ID:", message)
+
+    async def test_auto_reply_service_uses_chat_template(self):
+        service = object.__new__(AutoReplyService)
+        service.cookie_id = "seller"
+        with patch(
+            "common.db.compat.db_manager.get_account_notifications",
+            return_value=[
+                {
+                    "enabled": True,
+                    "channel_type": "bark",
+                    "channel_config": {"device_key": "a", "chat_template": "{{buyer_nick}}: {{message}}"},
+                }
+            ],
+        ), patch(
+            "common.db.compat.db_manager.get_cookie_details",
+            return_value={"remark": "主账号"},
+        ), patch(
+            "common.utils.notification_utils.send_bark_notification",
+            new=AsyncMock(return_value=True),
+        ) as bark_send:
+            await service._send_notification("小王", "buyer-1", "你好", "chat-1", "item-1", "2026-08-11 11:00:00")
+
+        self.assertEqual(bark_send.await_args.args[1], "小王: 你好")
+
+    async def test_account_template_receives_verification_link(self):
+        manager = NotificationManager("seller-account-template")
+        with patch(
+            "common.db.compat.db_manager.get_account_notifications",
+            return_value=[
+                {
+                    "enabled": True,
+                    "channel_type": "email",
+                    "channel_config": {"account_template": "{{title}}|{{detail}}|{{verification_url}}"},
+                }
+            ],
+        ), patch(
+            "common.db.compat.db_manager.get_cookie_details",
+            return_value={"remark": "主账号"},
+        ), patch(
+            "app.services.xianyu.notification_manager.send_email_notification",
+            new=AsyncMock(return_value=True),
+        ) as email_send:
+            await manager.send_token_refresh_notification(
+                "请完成人脸验证",
+                "face_verification_required",
+                verification_url="https://example.com/verify",
+            )
+
+        self.assertEqual(
+            email_send.await_args.args[1],
+            "⚠️ 需要人脸验证|请完成人脸验证|https://example.com/verify",
+        )
+
+    async def test_account_template_preserves_email_attachment(self):
+        manager = NotificationManager("seller")
+        with patch(
+            "app.services.xianyu.notification_manager.send_email_notification",
+            new=AsyncMock(return_value=True),
+        ) as email_send:
+            await manager._send_to_channels(
+                [
+                    {
+                        "enabled": True,
+                        "channel_type": "email",
+                        "channel_config": {"account_template": "{{title}}: {{detail}}"},
+                    }
+                ],
+                "系统默认正文",
+                attachment_path="/tmp/captcha.png",
+                template_type="account",
+                template_context={"title": "需要验证", "detail": "请完成人脸验证"},
+            )
+
+        self.assertEqual(email_send.await_args.args[1], "需要验证: 请完成人脸验证")
+        self.assertEqual(email_send.await_args.args[2], "/tmp/captcha.png")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/common/tests/test_notification_template.py
+++ b/common/tests/test_notification_template.py
@@ -1,0 +1,72 @@
+import unittest
+
+from common.utils.notification_template import (
+    render_notification_template,
+    validate_notification_template,
+)
+
+
+class NotificationTemplateTest(unittest.TestCase):
+    def test_renders_multiline_template_and_repeated_variables(self):
+        message = render_notification_template(
+            {"delivery_template": "买家: {{buyer_nick}}\n订单: {{order_id}}\n再次确认: {{buyer_nick}}"},
+            "delivery",
+            {"buyer_nick": "金鱼小姐21", "order_id": "123"},
+            "默认正文",
+        )
+
+        self.assertEqual(message, "买家: 金鱼小姐21\n订单: 123\n再次确认: 金鱼小姐21")
+
+    def test_empty_template_uses_default_message(self):
+        self.assertEqual(
+            render_notification_template(
+                {"chat_template": "   "},
+                "chat",
+                {"buyer_nick": "买家"},
+                "默认聊天正文",
+            ),
+            "默认聊天正文",
+        )
+
+    def test_unknown_variable_falls_back_to_default_message(self):
+        self.assertEqual(
+            render_notification_template(
+                {"delivery_template": "订单 {{unknown_field}}"},
+                "delivery",
+                {},
+                "默认发货正文",
+            ),
+            "默认发货正文",
+        )
+
+    def test_invalid_placeholder_syntax_falls_back_to_default_message(self):
+        self.assertEqual(
+            render_notification_template(
+                {"account_template": "{{title"},
+                "account",
+                {"title": "账号异常"},
+                "默认账号正文",
+            ),
+            "默认账号正文",
+        )
+
+    def test_missing_context_value_is_rendered_as_unknown(self):
+        self.assertEqual(
+            render_notification_template(
+                {"account_template": "{{title}}\n{{verification_info}}"},
+                "account",
+                {"title": "需要验证"},
+                "默认账号正文",
+            ),
+            "需要验证\n未知",
+        )
+
+    def test_validation_rejects_variables_not_available_to_template_type(self):
+        self.assertEqual(
+            validate_notification_template("{{result}}", "chat"),
+            "不支持的占位符: result",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/common/utils/notification_template.py
+++ b/common/utils/notification_template.py
@@ -1,0 +1,103 @@
+"""通知正文模板的安全渲染工具。"""
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from loguru import logger
+
+
+TEMPLATE_CONFIG_KEYS = {
+    "chat": "chat_template",
+    "delivery": "delivery_template",
+    "account": "account_template",
+}
+
+TEMPLATE_VARIABLES = {
+    "chat": {
+        "account",
+        "account_id",
+        "account_remark",
+        "buyer_nick",
+        "buyer_id",
+        "message",
+        "item_id",
+        "chat_id",
+        "time",
+    },
+    "delivery": {
+        "account",
+        "account_id",
+        "account_remark",
+        "buyer_nick",
+        "buyer_id",
+        "message",
+        "item_id",
+        "chat_id",
+        "time",
+        "order_id",
+        "amount",
+        "quantity",
+        "result",
+    },
+    "account": {
+        "account",
+        "account_id",
+        "account_remark",
+        "title",
+        "notification_type",
+        "detail",
+        "chat_id",
+        "verification_url",
+        "verification_info",
+        "time",
+    },
+}
+
+_PLACEHOLDER_RE = re.compile(r"{{\s*([A-Za-z_][A-Za-z0-9_]*)\s*}}")
+
+
+def validate_notification_template(template: str, template_type: str) -> str | None:
+    """校验通知模板；返回错误说明，合法时返回 ``None``。"""
+    if template_type not in TEMPLATE_CONFIG_KEYS:
+        return f"不支持的通知模板类型: {template_type}"
+    if not isinstance(template, str):
+        return "模板必须是文本"
+
+    matches = list(_PLACEHOLDER_RE.finditer(template))
+    remaining = _PLACEHOLDER_RE.sub("", template)
+    if "{{" in remaining or "}}" in remaining:
+        return "占位符必须使用 {{variable}} 格式"
+
+    allowed_variables = TEMPLATE_VARIABLES[template_type]
+    unknown_variables = sorted({match.group(1) for match in matches} - allowed_variables)
+    if unknown_variables:
+        return f"不支持的占位符: {', '.join(unknown_variables)}"
+    return None
+
+
+def render_notification_template(
+    config_data: Mapping[str, Any] | None,
+    template_type: str,
+    context: Mapping[str, Any],
+    default_message: str,
+) -> str:
+    """按渠道配置渲染模板；模板缺失或无效时回退系统默认正文。"""
+    config_data = config_data or {}
+    config_key = TEMPLATE_CONFIG_KEYS.get(template_type)
+    template = config_data.get(config_key) if config_key else None
+
+    if not isinstance(template, str) or not template.strip():
+        return default_message
+
+    validation_error = validate_notification_template(template, template_type)
+    if validation_error:
+        logger.warning("通知{}模板无效，已使用系统默认正文: {}", template_type, validation_error)
+        return default_message
+
+    def replace_placeholder(match: re.Match[str]) -> str:
+        value = context.get(match.group(1))
+        return "未知" if value is None else str(value)
+
+    return _PLACEHOLDER_RE.sub(replace_placeholder, template)

--- a/frontend/src/pages/notifications/NotificationChannels.tsx
+++ b/frontend/src/pages/notifications/NotificationChannels.tsx
@@ -106,6 +106,124 @@ const channelTypes = [
 
 type ChannelType = typeof channelTypes[number]['type']
 
+type NotificationTemplateType = 'chat' | 'delivery' | 'account'
+
+const templateConfigKeys: Record<NotificationTemplateType, string> = {
+  chat: 'chat_template',
+  delivery: 'delivery_template',
+  account: 'account_template',
+}
+
+const templateVariables: Record<NotificationTemplateType, Array<{ name: string; label: string }>> = {
+  chat: [
+    { name: 'account', label: '闲鱼账号' },
+    { name: 'account_id', label: '账号 ID' },
+    { name: 'account_remark', label: '账号备注' },
+    { name: 'buyer_nick', label: '买家昵称' },
+    { name: 'buyer_id', label: '买家 ID' },
+    { name: 'message', label: '消息内容' },
+    { name: 'item_id', label: '商品 ID' },
+    { name: 'chat_id', label: '聊天 ID' },
+    { name: 'time', label: '通知时间' },
+  ],
+  delivery: [
+    { name: 'account', label: '闲鱼账号' },
+    { name: 'account_id', label: '账号 ID' },
+    { name: 'account_remark', label: '账号备注' },
+    { name: 'buyer_nick', label: '买家昵称' },
+    { name: 'buyer_id', label: '买家 ID' },
+    { name: 'message', label: '消息内容' },
+    { name: 'item_id', label: '商品 ID' },
+    { name: 'chat_id', label: '聊天 ID' },
+    { name: 'time', label: '通知时间' },
+    { name: 'order_id', label: '订单 ID' },
+    { name: 'amount', label: '订单金额' },
+    { name: 'quantity', label: '购买数量' },
+    { name: 'result', label: '发货结果' },
+  ],
+  account: [
+    { name: 'account', label: '闲鱼账号' },
+    { name: 'account_id', label: '账号 ID' },
+    { name: 'account_remark', label: '账号备注' },
+    { name: 'title', label: '通知标题' },
+    { name: 'notification_type', label: '通知类型' },
+    { name: 'detail', label: '详细说明' },
+    { name: 'chat_id', label: '聊天 ID' },
+    { name: 'verification_url', label: '验证链接' },
+    { name: 'verification_info', label: '验证信息' },
+    { name: 'time', label: '通知时间' },
+  ],
+}
+
+const defaultTemplates: Record<NotificationTemplateType, string> = {
+  chat: `【闲鱼消息】
+闲鱼账号: {{account}}
+发送者: {{buyer_nick}}
+消息: {{message}}
+商品ID: {{item_id}}
+时间: {{time}}`,
+  delivery: `🚨 自动发货通知
+
+闲鱼账号: {{account}}
+买家: {{buyer_nick}} (ID: {{buyer_id}})
+订单金额: {{amount}}
+购买数量: {{quantity}}
+商品ID: {{item_id}}
+聊天ID: {{chat_id}}
+结果: {{result}}
+时间: {{time}}
+
+请及时处理！`,
+  account: `{{title}}
+
+闲鱼账号: {{account}}
+时间: {{time}}
+详情: {{detail}}
+
+请检查账号状态。`,
+}
+
+const templateDefinitions: Array<{ type: NotificationTemplateType; label: string }> = [
+  { type: 'chat', label: '聊天消息模板' },
+  { type: 'delivery', label: '自动发货模板' },
+  { type: 'account', label: '账号状态模板' },
+]
+
+const getTemplateValidationError = (template: string, templateType: NotificationTemplateType): string | null => {
+  if (!template.trim()) return null
+
+  const placeholderPattern = /{{\s*([A-Za-z_][A-Za-z0-9_]*)\s*}}/g
+  const placeholders = [...template.matchAll(placeholderPattern)]
+  const remaining = template.replace(placeholderPattern, '')
+  if (remaining.includes('{{') || remaining.includes('}}')) {
+    return '占位符必须使用 {{variable}} 格式'
+  }
+
+  const unknownVariables = [...new Set(placeholders.map((match) => match[1]).filter((name) => !templateVariables[templateType].some((variable) => variable.name === name)))]
+  if (unknownVariables.length > 0) {
+    return `不支持的占位符: ${unknownVariables.join(', ')}`
+  }
+  return null
+}
+
+const splitTemplateConfig = (config?: Record<string, unknown>) => {
+  const templates: Record<NotificationTemplateType, string> = { ...defaultTemplates }
+  const channelConfig: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(config || {})) {
+    const templateType = templateDefinitions.find((definition) => templateConfigKeys[definition.type] === key)?.type
+    if (templateType) {
+      if (typeof value === 'string' && value.trim()) {
+        templates[templateType] = value
+      }
+    } else {
+      channelConfig[key] = value
+    }
+  }
+
+  return { templates, channelConfig }
+}
+
 const channelTypeLabels: Record<string, string> = Object.fromEntries(
   channelTypes.map(c => [c.type, c.label])
 )
@@ -120,6 +238,7 @@ export function NotificationChannels() {
   const [selectedType, setSelectedType] = useState<ChannelType | null>(null)
   const [formName, setFormName] = useState('')
   const [formConfig, setFormConfig] = useState('')
+  const [formTemplates, setFormTemplates] = useState<Record<NotificationTemplateType, string>>({ ...defaultTemplates })
   const [formEnabled, setFormEnabled] = useState(true)
   const [saving, setSaving] = useState(false)
 
@@ -222,6 +341,7 @@ export function NotificationChannels() {
     } else {
       setFormConfig('')
     }
+    setFormTemplates({ ...defaultTemplates })
     setFormEnabled(true)
     setIsModalOpen(true)
   }
@@ -233,13 +353,15 @@ export function NotificationChannels() {
     setEditingChannel(channel)
     setFormName(channel.name)
     // 编辑时如果配置为空，也填充默认样例
-    if (channel.config && Object.keys(channel.config).length > 0) {
-      setFormConfig(JSON.stringify(channel.config, null, 2))
+    const { templates, channelConfig } = splitTemplateConfig(channel.config)
+    if (Object.keys(channelConfig).length > 0) {
+      setFormConfig(JSON.stringify(channelConfig, null, 2))
     } else if (typeConfig?.defaultConfig) {
       setFormConfig(JSON.stringify(typeConfig.defaultConfig, null, 2))
     } else {
       setFormConfig('')
     }
+    setFormTemplates(templates)
     setFormEnabled(channel.enabled)
     setIsModalOpen(true)
   }
@@ -260,7 +382,7 @@ export function NotificationChannels() {
 
     setSaving(true)
     try {
-      let config = {}
+      let config: Record<string, unknown> = {}
       if (formConfig.trim()) {
         try {
           config = JSON.parse(formConfig)
@@ -268,6 +390,19 @@ export function NotificationChannels() {
           addToast({ type: 'error', message: '配置JSON格式错误' })
           setSaving(false)
           return
+        }
+      }
+
+      for (const definition of templateDefinitions) {
+        delete config[templateConfigKeys[definition.type]]
+        const template = formTemplates[definition.type]
+        const validationError = getTemplateValidationError(template, definition.type)
+        if (validationError) {
+          addToast({ type: 'error', message: `${definition.label}${validationError}` })
+          return
+        }
+        if (template.trim() && template !== defaultTemplates[definition.type]) {
+          config[templateConfigKeys[definition.type]] = template
         }
       }
 
@@ -451,7 +586,7 @@ export function NotificationChannels() {
       {/* 配置弹窗 */}
       {isModalOpen && selectedType && (
         <div className="modal-overlay">
-          <div className="modal-content max-w-lg">
+          <div className="modal-content max-w-lg max-h-[90vh] overflow-y-auto">
             <div className="modal-header flex items-center justify-between">
               <h2 className="text-lg font-semibold">
                 {editingChannel ? '编辑' : '配置'}{channelTypeLabels[selectedType]}
@@ -483,6 +618,30 @@ export function NotificationChannels() {
                   <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
                     {getConfigHint(selectedType)}
                   </p>
+                </div>
+                <div className="border-t border-slate-200 dark:border-slate-700 pt-4 space-y-4">
+                  <div>
+                    <p className="input-label">通知正文模板</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      预填为系统默认正文；修改后才会保存为自定义模板，留空可恢复系统默认正文。支持英文占位符，例如 {'{{buyer_nick}}'}。
+                    </p>
+                  </div>
+                  {templateDefinitions.map((definition) => (
+                    <div key={definition.type}>
+                      <label className="input-label">{definition.label}</label>
+                      <textarea
+                        value={formTemplates[definition.type]}
+                        onChange={(event) => setFormTemplates((templates) => ({
+                          ...templates,
+                          [definition.type]: event.target.value,
+                        }))}
+                        className="input-ios h-32 resize-y font-mono text-sm"
+                      />
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 break-words">
+                        可用变量：{templateVariables[definition.type].map(({ name, label }) => `{{${name}}}（${label}）`).join('、')}
+                      </p>
+                    </div>
+                  ))}
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-slate-700 dark:text-slate-200">启用此渠道</span>

--- a/websocket/app/services/xianyu/auto_delivery_handler.py
+++ b/websocket/app/services/xianyu/auto_delivery_handler.py
@@ -478,12 +478,20 @@ class AutoDeliveryHandler:
             buyer_id=buyer_id,
         )
 
-    async def send_delivery_failure_notification(self, send_user_name, send_user_id, item_id, error_message, chat_id):
+    async def send_delivery_failure_notification(self, send_user_name, send_user_id, item_id, error_message,
+                                                 chat_id, order_id=None):
         """发送发货通知 - 直接调用NotificationManager"""
         try:
             from app.services.xianyu.notification_manager import NotificationManager
             notification_manager = NotificationManager(self.cookie_id)
-            return await notification_manager.send_delivery_failure_notification(send_user_name, send_user_id, item_id, error_message, chat_id)
+            return await notification_manager.send_delivery_failure_notification(
+                send_user_name,
+                send_user_id,
+                item_id,
+                error_message,
+                chat_id,
+                order_id=order_id,
+            )
         except Exception as e:
             logger.error(f"【{self.cookie_id}】发送发货通知失败: {self._safe_str(e)}")
     
@@ -1508,6 +1516,7 @@ class AutoDeliveryHandler:
                                         send_user_name, send_user_id, item_id,
                                         send_before_confirm_fail_msg,
                                         chat_id,
+                                        order_id=order_id,
                                     )
                             else:
                                 send_before_confirm_fail_msg = "⚠️ 卡券已发送成功，但自动确认发货已关闭，请手动确认发货"
@@ -1519,6 +1528,7 @@ class AutoDeliveryHandler:
                                 send_user_name, send_user_id, item_id,
                                 send_before_confirm_fail_msg,
                                 chat_id,
+                                order_id=order_id,
                             )
                         elif send_before_confirm_active and any_send_failed:
                             send_before_confirm_fail_msg = "⚠️ 卡券发送存在失败，已跳过确认发货，请检查买家是否收到完整内容后手动确认发货"
@@ -1527,13 +1537,17 @@ class AutoDeliveryHandler:
                                 send_user_name, send_user_id, item_id,
                                 send_before_confirm_fail_msg,
                                 chat_id,
+                                order_id=order_id,
                             )
 
                         # 如果有消息发送失败，额外发通知告知（不影响订单状态）
                         if any_send_failed:
                             fail_notify_msg = "部分发货消息发送失败（WebSocket连接断开），请检查买家是否收到完整内容"
                             logger.error(f'[{msg_time}] 【{self.cookie_id}】订单 {order_id} {fail_notify_msg}')
-                            await self.send_delivery_failure_notification(send_user_name, send_user_id, item_id, fail_notify_msg, chat_id)
+                            await self.send_delivery_failure_notification(
+                                send_user_name, send_user_id, item_id, fail_notify_msg, chat_id,
+                                order_id=order_id,
+                            )
 
                         # 发送成功通知（仅 IM 通知，fail_reason 写库延后到 update_order_delivery_info 之后，
                         # 否则会被 update_order_delivery_info 内部的 delivery_fail_reason=None 清空）
@@ -1545,6 +1559,7 @@ class AutoDeliveryHandler:
                                 f"⚠️ 对接卡券暂不支持多数量发货：订单数量 {quantity_to_send} 张，"
                                 f"已自动发送 {len(delivery_contents)} 张，剩余 {remaining} 张请手动补发或改用自有卡券",
                                 chat_id,
+                                order_id=order_id,
                             )
                         elif quantity_degraded_for_fixed_content:
                             # text/image 固定内容卡券退化场景：商家应改用 data/api 类型卡券支持多数量
@@ -1555,11 +1570,19 @@ class AutoDeliveryHandler:
                                 f"订单数量 {quantity_to_send} 张，仅发送 1 张固定内容（剩余 {remaining} 张未发）。"
                                 f"如需多数量发送不同卡密，请改用 data 或 api 类型卡券",
                                 chat_id,
+                                order_id=order_id,
                             )
                         elif len(delivery_contents) > 1:
-                            await self.send_delivery_failure_notification(send_user_name, send_user_id, item_id, f"多数量发货成功，共发送 {len(delivery_contents)} 个卡券", chat_id)
+                            await self.send_delivery_failure_notification(
+                                send_user_name, send_user_id, item_id,
+                                f"多数量发货成功，共发送 {len(delivery_contents)} 个卡券", chat_id,
+                                order_id=order_id,
+                            )
                         else:
-                            await self.send_delivery_failure_notification(send_user_name, send_user_id, item_id, "发货成功", chat_id)
+                            await self.send_delivery_failure_notification(
+                                send_user_name, send_user_id, item_id, "发货成功", chat_id,
+                                order_id=order_id,
+                            )
                         
                         # 更新订单状态和发货信息（不受消息发送结果影响）
                         # card_only 场景：订单已被关闭，仅记录补发卡券内容，不动 status / fail_reason
@@ -1670,7 +1693,10 @@ class AutoDeliveryHandler:
                             # 更新订单发货失败原因
                             await self._update_delivery_fail_reason(order_id, fail_msg)
                             # 发送自动发货失败通知
-                            await self.send_delivery_failure_notification(send_user_name, send_user_id, item_id, fail_msg, chat_id)
+                            await self.send_delivery_failure_notification(
+                                send_user_name, send_user_id, item_id, fail_msg, chat_id,
+                                order_id=order_id,
+                            )
 
                 except Exception as e:
                     fail_msg = f"自动发货处理异常: {str(e)}"
@@ -1686,7 +1712,10 @@ class AutoDeliveryHandler:
                         # 更新订单发货失败原因
                         await self._update_delivery_fail_reason(order_id, fail_msg)
                         # 发送自动发货异常通知
-                        await self.send_delivery_failure_notification(send_user_name, send_user_id, item_id, fail_msg, chat_id)
+                        await self.send_delivery_failure_notification(
+                            send_user_name, send_user_id, item_id, fail_msg, chat_id,
+                            order_id=order_id,
+                        )
 
                 logger.info(f'[{msg_time}] 【{self.cookie_id}】自动发货处理完成: {lock_key}')
             

--- a/websocket/app/services/xianyu/auto_reply_service.py
+++ b/websocket/app/services/xianyu/auto_reply_service.py
@@ -32,6 +32,7 @@ from common.models.xy_order import XYOrder
 from common.db.session import async_session_maker
 from common.db.redis_client import distributed_lock
 from common.utils.default_reply_api import call_reply_api
+from common.utils.notification_template import render_notification_template
 
 from app.services.xianyu.resource_manager import pause_manager
 from app.services.xianyu.auto_reply_log_service import AutoReplyLogService
@@ -1001,6 +1002,17 @@ class AutoReplyService:
             if item_id:
                 notification_content += f"商品ID: {item_id}\n"
             notification_content += f"时间: {msg_time}"
+            template_context = {
+                "account": account_desc,
+                "account_id": self.cookie_id,
+                "account_remark": remark or "未知",
+                "buyer_nick": send_user_name or "未知",
+                "buyer_id": send_user_id or "未知",
+                "message": send_message or "",
+                "item_id": item_id or "未知",
+                "chat_id": chat_id or "未知",
+                "time": msg_time or time.strftime('%Y-%m-%d %H:%M:%S'),
+            }
             
             # 发送通知到各渠道
             for notification in notifications:
@@ -1026,23 +1038,29 @@ class AutoReplyService:
                     )
                     
                     config_data = parse_notification_config(channel_config)
+                    channel_message = render_notification_template(
+                        config_data,
+                        "chat",
+                        template_context,
+                        notification_content,
+                    )
                     
                     if channel_type in ('dingtalk', 'ding_talk'):
-                        await send_dingtalk_notification(config_data, notification_content)
+                        await send_dingtalk_notification(config_data, channel_message)
                     elif channel_type in ('feishu', 'lark'):
-                        await send_feishu_notification(config_data, notification_content)
+                        await send_feishu_notification(config_data, channel_message)
                     elif channel_type == 'bark':
-                        await send_bark_notification(config_data, notification_content)
+                        await send_bark_notification(config_data, channel_message)
                     elif channel_type == 'email':
-                        await send_email_notification(config_data, notification_content)
+                        await send_email_notification(config_data, channel_message)
                     elif channel_type == 'webhook':
-                        await send_webhook_notification(config_data, notification_content)
+                        await send_webhook_notification(config_data, channel_message)
                     elif channel_type in ('wechat', 'wechat_work'):
-                        await send_wechat_notification(config_data, notification_content)
+                        await send_wechat_notification(config_data, channel_message)
                     elif channel_type == 'telegram':
-                        await send_telegram_notification(config_data, notification_content)
+                        await send_telegram_notification(config_data, channel_message)
                     elif channel_type == 'pushplus':
-                        await send_pushplus_notification(config_data, notification_content)
+                        await send_pushplus_notification(config_data, channel_message)
                     else:
                         logger.warning(f"【{self.cookie_id}】不支持的通知渠道类型: {channel_type}")
                         

--- a/websocket/app/services/xianyu/notification_manager.py
+++ b/websocket/app/services/xianyu/notification_manager.py
@@ -11,6 +11,7 @@
 import time
 import asyncio
 import hashlib
+from decimal import Decimal, InvalidOperation
 from loguru import logger
 
 from common.utils.notification_utils import (
@@ -26,6 +27,7 @@ from common.utils.notification_utils import (
 )
 from common.services.token_api_mode import TOKEN_API_NAMES
 from common.utils.text_utils import safe_str
+from common.utils.notification_template import render_notification_template
 
 
 class NotificationManager:
@@ -92,7 +94,7 @@ class NotificationManager:
                         remaining_seconds = int(self.notification_cooldown - time_since_last)
                         logger.warning(f"📱 通知在冷却期内（剩余 {remaining_seconds} 秒），跳过重复发送")
                         return
-                
+
                 self.last_notification_time[notification_hash] = current_time
                 
                 # 清理过期记录
@@ -131,14 +133,30 @@ class NotificationManager:
                              f"时间: {time.strftime('%Y-%m-%d %H:%M:%S')}\n\n"
 
             # 发送通知到各渠道
-            await self._send_to_channels(notifications, notification_msg)
+            await self._send_to_channels(
+                notifications,
+                notification_msg,
+                template_type="chat",
+                template_context={
+                    "account": account_desc,
+                    "account_id": self.cookie_id,
+                    "account_remark": remark or "未知",
+                    "buyer_nick": send_user_name or "未知",
+                    "buyer_id": send_user_id or "未知",
+                    "message": send_message or "",
+                    "item_id": item_id or "未知",
+                    "chat_id": chat_id or "未知",
+                    "time": time.strftime('%Y-%m-%d %H:%M:%S'),
+                },
+            )
 
         except Exception as e:
             logger.error(f"📱 处理消息通知失败: {self._safe_str(e)}")
 
     async def send_delivery_failure_notification(self, send_user_name: str, send_user_id: str,
-                                                  item_id: str, error_message: str, chat_id: str = None):
-        """发送自动发货失败通知"""
+                                                  item_id: str, error_message: str, chat_id: str = None,
+                                                  order_id: str = None):
+        """发送自动发货结果通知。"""
         try:
             from common.db.compat import db_manager
 
@@ -171,19 +189,62 @@ class NotificationManager:
             except Exception as e:
                 logger.warning(f"获取账号详情失败: {e}")
 
-            # 构建通知内容（与旧框架保持一致）
+            buyer_nick = send_user_name or "未知"
+            amount = "未知"
+            quantity = "未知"
+            if order_id:
+                try:
+                    order = db_manager.get_order_by_id(order_id, self.cookie_id)
+                    if order:
+                        buyer_nick = (
+                            order.get("buyer_fish_nick")
+                            or order.get("buyer_nick")
+                            or buyer_nick
+                        )
+                        raw_amount = order.get("amount")
+                        if raw_amount is not None:
+                            amount = f"¥{Decimal(str(raw_amount)):.2f}"
+                        if order.get("quantity") is not None:
+                            quantity = str(order["quantity"])
+                except (InvalidOperation, ValueError, TypeError) as e:
+                    logger.warning(f"读取订单 {order_id} 的通知金额或数量失败: {self._safe_str(e)}")
+                except Exception as e:
+                    logger.warning(f"读取订单 {order_id} 的通知信息失败: {self._safe_str(e)}")
+
+            # 构建通知内容
             account_desc = f"{self.cookie_id}({remark})" if remark else self.cookie_id
             notification_message = f"🚨 自动发货通知\n\n" \
                                  f"闲鱼账号: {account_desc}\n" \
-                                 f"买家: {send_user_name} (ID: {send_user_id})\n" \
-                                 f"商品ID: {item_id}\n" \
+                                 f"买家: {buyer_nick} (ID: {send_user_id or '未知'})\n" \
+                                 f"订单金额: {amount}\n" \
+                                 f"购买数量: {quantity}\n" \
+                                 f"商品ID: {item_id or '未知'}\n" \
                                  f"聊天ID: {chat_id or '未知'}\n" \
                                  f"结果: {error_message}\n" \
                                  f"时间: {time.strftime('%Y-%m-%d %H:%M:%S')}\n\n" \
                                  f"请及时处理！"
 
             # 发送通知到各渠道
-            await self._send_to_channels(notifications, notification_message)
+            await self._send_to_channels(
+                notifications,
+                notification_message,
+                template_type="delivery",
+                template_context={
+                    "account": account_desc,
+                    "account_id": self.cookie_id,
+                    "account_remark": remark or "未知",
+                    "buyer_nick": buyer_nick,
+                    "buyer_id": send_user_id or "未知",
+                    "message": "",
+                    "item_id": item_id or "未知",
+                    "chat_id": chat_id or "未知",
+                    "time": time.strftime('%Y-%m-%d %H:%M:%S'),
+                    "order_id": order_id or "未知",
+                    "amount": amount,
+                    "quantity": quantity,
+                    "result": error_message or "未知",
+                },
+            )
 
         except Exception as e:
             logger.error(f"发送自动发货通知异常: {self._safe_str(e)}")
@@ -280,7 +341,24 @@ class NotificationManager:
             else:
                 notification_msg = f"{notification_title}\n\n闲鱼账号: {account_desc}\n时间: {time.strftime('%Y-%m-%d %H:%M:%S')}\n详情: {error_message}\n\n请检查账号状态。\n"
 
-            notification_sent = await self._send_to_channels(notifications, notification_msg, attachment_path)
+            notification_sent = await self._send_to_channels(
+                notifications,
+                notification_msg,
+                attachment_path,
+                template_type="account",
+                template_context={
+                    "account": account_desc,
+                    "account_id": self.cookie_id,
+                    "account_remark": remark or "未知",
+                    "title": notification_title,
+                    "notification_type": notification_type,
+                    "detail": error_message or "未知",
+                    "chat_id": chat_id or "未知",
+                    "verification_url": verification_url or "",
+                    "verification_info": f"验证链接: {verification_url}" if verification_url else "",
+                    "time": time.strftime('%Y-%m-%d %H:%M:%S'),
+                },
+            )
 
             if notification_sent:
                 self.last_notification_time[notification_type] = current_time
@@ -336,7 +414,8 @@ class NotificationManager:
                 return True
         return False
 
-    async def _send_to_channels(self, notifications: list, message: str, attachment_path: str = None) -> bool:
+    async def _send_to_channels(self, notifications: list, message: str, attachment_path: str = None,
+                                template_type: str = None, template_context: dict = None) -> bool:
         """发送通知到各个渠道
         
         Args:
@@ -361,30 +440,36 @@ class NotificationManager:
             try:
                 config_data = parse_notification_config(channel_config)
                 logger.info(f"📱 解析后配置: {config_data}")
+                channel_message = render_notification_template(
+                    config_data,
+                    template_type,
+                    template_context or {},
+                    message,
+                ) if template_type else message
 
                 if channel_type in ('ding_talk', 'dingtalk'):
-                    await send_dingtalk_notification(config_data, message)
+                    await send_dingtalk_notification(config_data, channel_message)
                     notification_sent = True
                 elif channel_type in ('feishu', 'lark'):
-                    await send_feishu_notification(config_data, message)
+                    await send_feishu_notification(config_data, channel_message)
                     notification_sent = True
                 elif channel_type == 'bark':
-                    await send_bark_notification(config_data, message)
+                    await send_bark_notification(config_data, channel_message)
                     notification_sent = True
                 elif channel_type == 'email':
-                    await send_email_notification(config_data, message, attachment_path)
+                    await send_email_notification(config_data, channel_message, attachment_path)
                     notification_sent = True
                 elif channel_type == 'webhook':
-                    await send_webhook_notification(config_data, message)
+                    await send_webhook_notification(config_data, channel_message)
                     notification_sent = True
                 elif channel_type in ('wechat', 'wechat_work'):
-                    await send_wechat_notification(config_data, message)
+                    await send_wechat_notification(config_data, channel_message)
                     notification_sent = True
                 elif channel_type == 'telegram':
-                    await send_telegram_notification(config_data, message)
+                    await send_telegram_notification(config_data, channel_message)
                     notification_sent = True
                 elif channel_type == 'pushplus':
-                    await send_pushplus_notification(config_data, message)
+                    await send_pushplus_notification(config_data, channel_message)
                     notification_sent = True
                 else:
                     logger.warning(f"不支持的通知渠道类型: {channel_type}")

--- a/websocket/app/services/xianyu/yifan_api_handler.py
+++ b/websocket/app/services/xianyu/yifan_api_handler.py
@@ -62,6 +62,17 @@ class YifanApiHandler:
     async def send_notification(self, send_user_name, send_user_id, content, item_id, chat_id):
         return await self.parent.send_notification(send_user_name, send_user_id, content, item_id, chat_id)
 
+    async def send_delivery_failure_notification(self, send_user_name, send_user_id, item_id,
+                                                 error_message, chat_id, order_id=None):
+        return await self.parent.send_delivery_failure_notification(
+            send_user_name,
+            send_user_id,
+            item_id,
+            error_message,
+            chat_id,
+            order_id=order_id,
+        )
+
 
     # ==================== 亦凡API卡券获取 ====================
 
@@ -204,10 +215,12 @@ class YifanApiHandler:
                             error_msg = result.get('msg', '未知错误')
                             logger.error(f"亦凡API调用失败: code={result.get('code')}, msg={error_msg}")
                             
-                            # 发送通知给用户
+                            # 发送自动发货失败通知
                             if chat_id and buyer_id:
-                                notification_msg = f"❌ 自动发货失败\n错误信息: {error_msg}\n请联系客服处理"
-                                await self.send_notification("系统", buyer_id, notification_msg, item_id or "unknown", chat_id)
+                                await self.send_delivery_failure_notification(
+                                    "系统", buyer_id, item_id or "unknown", error_msg, chat_id,
+                                    order_id=order_id,
+                                )
                             
                             return None
                     except Exception as e:
@@ -310,10 +323,12 @@ class YifanApiHandler:
                             error_msg = result.get('msg', '未知错误')
                             logger.error(f"亦凡API调用失败: code={result.get('code')}, msg={error_msg}")
                             
-                            # 发送通知给用户
+                            # 发送自动发货失败通知
                             if chat_id and buyer_id:
-                                notification_msg = f"❌ 自动发货失败\n错误信息: {error_msg}\n请联系客服处理"
-                                await self.send_notification("系统", buyer_id, notification_msg, item_id or "unknown", chat_id)
+                                await self.send_delivery_failure_notification(
+                                    "系统", buyer_id, item_id or "unknown", error_msg, chat_id,
+                                    order_id=order_id,
+                                )
                             
                             return None
                     except Exception as e:


### PR DESCRIPTION
## 变更内容

- 为每个通知渠道增加可编辑的聊天消息、自动发货和账号状态正文模板，使用白名单 `{{variable}}` 占位符安全替换。
- 自动发货通知补充订单中的真实买家昵称、金额和购买数量；发货成功与失败共享 `{{result}}`。
- 配置页展示字段中文说明，预填系统默认正文；未修改初始正文直接保存时不会覆盖服务端默认分支。
- 亦凡卡券错误改走自动发货模板，账号验证链接和附件继续透传。

## 根因

原有通知正文在后端固定拼接，渠道之间无法使用不同格式；自动发货通知也缺少订单中的买家昵称、金额和数量。

## 用户影响

用户可按 Bark、飞书、钉钉等渠道分别配置正文格式；未配置或无效模板时仍使用既有默认通知，自动发货通知可直接看到买家、金额和数量。

## 不涉及范围

- 不新增数据库字段或迁移，模板保存在现有渠道 `config` JSON。
- 不修改版本号、锁文件或更新日志。
- 不修改连接、重启与消息接收流程，不新增消息丢失窗口。

## 验证

- `/Users/bigo/Desktop/workplace/xianyu-auto-reply/backend-web/.venv/bin/python -m unittest common.tests.test_notification_template common.tests.test_notification_dispatch`（12 项通过）
- `/Users/bigo/Desktop/workplace/xianyu-auto-reply/backend-web/.venv/bin/python -m py_compile common/utils/notification_template.py websocket/app/services/xianyu/notification_manager.py websocket/app/services/xianyu/auto_reply_service.py websocket/app/services/xianyu/auto_delivery_handler.py websocket/app/services/xianyu/yifan_api_handler.py`（通过）
- `npm run build`（通过）
- `npm run lint` 未通过：上游仓库缺少 ESLint 配置文件，属于基线问题。
