### PR TITLE
fix: 补全限流订单规格

### DIFF
--- a/common/services/order_service.py
+++ b/common/services/order_service.py
@@ -1728,6 +1728,20 @@ class OrderDetailService:
         if '*' in old_value and '*' not in new_value:
             return True
         return False
+
+    @staticmethod
+    def _is_rate_limited_error(ret_list: list[str]) -> bool:
+        """判断订单详情接口是否因平台限流或繁忙被拒绝。"""
+        error_text = ' '.join(str(ret) for ret in ret_list).lower()
+        rate_limit_markers = (
+            'fail_biz_common_system_error2',
+            '闲鱼太累了',
+            '限流',
+            '频繁',
+            'traffic_limit',
+            'rate limit',
+        )
+        return any(marker in error_text for marker in rate_limit_markers)
     
     async def _fetch_order_detail(self, order_id: str, retry_count: int = 0) -> Optional[Dict]:
         """通过API获取订单详情
@@ -1809,12 +1823,19 @@ class OrderDetailService:
                         ret_str = ', '.join(ret_list) if ret_list else '无返回信息'
                         logger.warning(f"【{self.cookie_id}】订单 {order_id} API调用失败: {ret_str}")
                         
-                        # 令牌过期时，用更新后的cookie重试
+                        # 令牌过期或平台限流时，退避后重试。
                         from common.utils.cookie_refresh import is_token_expired_error
-                        if is_token_expired_error(ret_list):
+                        token_expired = is_token_expired_error(ret_list)
+                        rate_limited = self._is_rate_limited_error(ret_list)
+                        if token_expired or rate_limited:
                             if retry_count < max_retry - 1:
-                                logger.info(f"【{self.cookie_id}】订单 {order_id} 令牌过期，已更新Cookie，准备重试({retry_count + 1}/{max_retry - 1})...")
-                                await asyncio.sleep(0.5)
+                                retry_delay = 0.5 if token_expired else 5 * (retry_count + 1)
+                                retry_reason = '令牌过期，已更新Cookie' if token_expired else '平台限流/繁忙'
+                                logger.info(
+                                    f"【{self.cookie_id}】订单 {order_id} {retry_reason}，"
+                                    f"{retry_delay}秒后重试({retry_count + 1}/{max_retry - 1})..."
+                                )
+                                await asyncio.sleep(retry_delay)
                                 return await self._fetch_order_detail(order_id, retry_count + 1)
                         
                         return None

--- a/common/tests/test_order_detail_recovery.py
+++ b/common/tests/test_order_detail_recovery.py
@@ -1,0 +1,51 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _method_source(path: Path, class_name: str, method_name: str) -> str:
+    source = path.read_text(encoding="utf-8")
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name == method_name:
+                    return ast.get_source_segment(source, child) or ""
+    raise AssertionError(f"未找到 {class_name}.{method_name}")
+
+
+class OrderDetailRecoveryTest(unittest.TestCase):
+    def test_rate_limited_order_detail_uses_backoff_retry(self):
+        source = _method_source(
+            ROOT / "common/services/order_service.py",
+            "OrderDetailService",
+            "_fetch_order_detail",
+        )
+
+        self.assertIn("rate_limited = self._is_rate_limited_error(ret_list)", source)
+        self.assertIn("retry_delay = 0.5 if token_expired else 5 * (retry_count + 1)", source)
+        self.assertIn("await asyncio.sleep(retry_delay)", source)
+
+    def test_rate_limit_detector_covers_platform_busy_response(self):
+        source = _method_source(
+            ROOT / "common/services/order_service.py",
+            "OrderDetailService",
+            "_is_rate_limited_error",
+        )
+
+        self.assertIn("fail_biz_common_system_error2", source)
+        self.assertIn("闲鱼太累了", source)
+
+    def test_redelivery_uses_order_detail_parser(self):
+        source = _method_source(
+            ROOT / "scheduler/app/services/scheduler/redelivery_task.py",
+            "RedeliveryTask",
+            "_process_order",
+        )
+
+        self.assertIn("OrderDetailService", source)
+        self.assertIn("detail_service._parse_order_detail_response", source)
+        self.assertNotIn("checker._parse_order_detail_response", source)

--- a/scheduler/app/services/scheduler/redelivery_task.py
+++ b/scheduler/app/services/scheduler/redelivery_task.py
@@ -476,13 +476,17 @@ class RedeliveryTask:
             if need_api_fetch:
                 logger.info(f"[定时补发货] 订单 {order_no} {', '.join(fetch_reasons)}，尝试从API重新获取...")
                 try:
-                    from common.services.order_service import OrderStatusChecker
+                    from common.services.order_service import OrderDetailService, OrderStatusChecker
                     from decimal import Decimal
                     checker = OrderStatusChecker(cookie_string, account_id=order.account_id if hasattr(order, 'account_id') else None)
                     raw_detail = await checker._fetch_raw_order_detail(order_no)
                     if raw_detail:
                         # 使用完整的解析方法提取金额和规格
-                        parsed = checker._parse_order_detail_response(order_no, raw_detail)
+                        detail_service = OrderDetailService(
+                            order.account_id if hasattr(order, 'account_id') else '',
+                            checker.cookies_str,
+                        )
+                        parsed = detail_service._parse_order_detail_response(order_no, raw_detail)
                         if parsed:
                             updated_fields = []
                             # 更新金额


### PR DESCRIPTION
## 变更内容

- 订单详情接口遇到闲鱼“太累了/限流”响应时，按退避间隔重试。
- 修复定时补发货补拉详情时将原始详情交给 `OrderStatusChecker` 解析、调用不存在方法的问题；改为复用 `OrderDetailService` 的详情解析逻辑。
- 新增针对限流退避和规格回填解析器选择的回归测试。

## 根因

订单详情首次请求被限流后不会退避重试；后续补拉虽然能拿到成功响应，却调用了不存在的 `_parse_order_detail_response`，导致规格、金额和数量无法回写。

## 影响

减少短暂平台限流造成的规格缺失，并让待发货订单可在后续补拉中正确写回规格信息。

## 不涉及范围

- 不修改 `package.json`、锁文件或 `CHANGELOG.md`。
- 不改变发货状态、卡券匹配规则或订单数据模型。

## 验证

- `python3 -m unittest common.tests.test_order_detail_recovery`
- `python3 -m compileall -q common/services/order_service.py scheduler/app/services/scheduler/redelivery_task.py common/tests/test_order_detail_recovery.py`
- `git diff --check base/main...HEAD`
