### PR TITLE
修复 Star History 图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,4 +471,4 @@ curl -fsSL https://xy-update.zhinianboke.com/deploy.sh | sed 's/\r$//' | bash
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zhinianboke/xianyu-auto-reply&type=Date)](https://www.star-history.com/#zhinianboke/xianyu-auto-reply&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=zhinianboke/xianyu-auto-reply&type=Date)](https://star-history.dera.page/#zhinianboke/xianyu-auto-reply&Date)


### PR DESCRIPTION
README 中的 Star History 图表因 GitHub stargazer API 限制已经损坏，无法正常加载。本项目已切换到新的数据源，无需 API Token 即可正常展示图表，建议尽快合并以修复该问题。