### PR TITLE
fix: 对齐卖家订单请求与当前 API

### DIFF
--- a/common/services/order_service.py
+++ b/common/services/order_service.py
@@ -1053,7 +1053,8 @@ class OrderService:
             is_token_expired_error, handle_token_expired_response,
             update_account_cookies_in_db,
             is_session_expired_error, trigger_password_login_async,
-            mark_account_session_expired
+            mark_account_session_expired,
+            extract_cookies_from_response, merge_cookies,
         )
         
         cookies = trans_cookies(cookies_str)
@@ -1075,21 +1076,25 @@ class OrderService:
             't': timestamp,
             'sign': sign,
             'v': '1.0',
-            'type': 'json',
+            # 卖家端页面使用 originaljson；json 会在部分账号上被判定为
+            # 非卖家端请求，表现为 TOKEN_EMPTY 后 PERMISSION_EXCEPTION。
+            'type': 'originaljson',
             'accountSite': 'xianyu',
             'dataType': 'json',
             'timeout': '20000',
             'api': 'mtop.taobao.idle.trade.merchant.sold.get',
             'valueType': 'string',
             'sessionOption': 'AutoLoginOnly',
+            'spm_cnt': 'a21107h.42826273.0.0',
         }
         
         headers = {
             'accept': 'application/json',
             'content-type': 'application/x-www-form-urlencoded',
-            'idle_site_biz_code': 'COMMONPRO',
-            'cookie': cookies_str,
-            'Referer': 'https://seller.goofish.com/',
+            'cookie': cookies_str.replace('\n', '').replace('\r', ''),
+            # 卖家接口会校验来源；缺少 Origin 会被误报为 Session 过期/无权限。
+            'origin': 'https://seller.goofish.com',
+            'referer': 'https://seller.goofish.com/',
             'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/138.0.0.0 Safari/537.36',
         }
         
@@ -1105,7 +1110,13 @@ class OrderService:
                 headers=headers,
                 timeout=aiohttp.ClientTimeout(total=20)
             ) as response:
-                res_json = await response.json()
+                res_json = await response.json(content_type=None)
+                # 成功响应也可能下发新的签名 Cookie，供后续分页使用。
+                response_cookies = extract_cookies_from_response(response)
+                response_cookies_str = (
+                    merge_cookies(cookies_str, response_cookies)
+                    if response_cookies else cookies_str
+                )
                 
                 ret = res_json.get('ret', [])
                 ret_str = ret[0] if ret else ''
@@ -1164,7 +1175,7 @@ class OrderService:
             'items': items,
             'next_page': next_page,
             'total_count': total_count,
-            'cookies_str': cookies_str,
+            'cookies_str': response_cookies_str,
         }
 
     def _parse_sold_order_item(self, item: dict) -> Optional[dict]:


### PR DESCRIPTION
## 问题
闲鱼卖家订单接口 `mtop.taobao.idle.trade.merchant.sold.get` 在令牌刷新后返回 `PERMISSION_EXCEPTION`，导致获取 0 条订单。与同账号的其他实现对比后，确认订单请求格式已不符合当前卖家端接口要求。

## 修复
- 使用卖家端要求的 `type=originaljson`
- 添加卖家端 `spm_cnt`
- 添加 `Origin: https://seller.goofish.com`
- 移除会导致接口拒绝的 `idle_site_biz_code: COMMONPRO`
- 允许解析非标准 Content-Type 的 JSON 响应
- 合并成功响应下发的新 Cookie，供后续分页和任务使用

## 验证
- `python -m py_compile common/services/order_service.py`
- Docker Backend/Scheduler 重建并启动成功
- 修复后接口返回 `SUCCESS::调用成功`
- 首轮同步获取 30 条订单（新增 23、更新 7）

未包含任何 Cookie、Token 或其他敏感数据。