### PR TITLE
feat: 支持卡券通过无需邮寄表单发货

### DIFF
--- a/backend-web/app/api/routes/cards.py
+++ b/backend-web/app/api/routes/cards.py
@@ -30,6 +30,7 @@ class CardCreate(BaseModel):
     description: Optional[str] = None
     enabled: Optional[bool] = True
     delay_seconds: Optional[int] = 0
+    use_no_logistics_form: bool = False
     price: Optional[str] = None  # 对接价格
     is_dockable: Optional[bool] = False  # 是否可对接
     fee_payer: Optional[str] = None  # 手续费支付方式：distributor/dealer
@@ -52,6 +53,7 @@ class CardUpdate(BaseModel):
     description: Optional[str] = None
     enabled: Optional[bool] = None
     delay_seconds: Optional[int] = None
+    use_no_logistics_form: Optional[bool] = None
     price: Optional[str] = None  # 对接价格
     is_dockable: Optional[bool] = None  # 是否可对接
     fee_payer: Optional[str] = None  # 手续费支付方式：distributor/dealer
@@ -79,6 +81,7 @@ class BatchSaveCardRequest(BaseModel):
     description: Optional[str] = None
     enabled: Optional[bool] = True
     delay_seconds: Optional[int] = 0
+    use_no_logistics_form: bool = False
     price: Optional[str] = None  # 对接价格
     is_dockable: Optional[bool] = False  # 是否可对接
     fee_payer: Optional[str] = None  # 手续费支付方式：distributor/dealer
@@ -258,6 +261,7 @@ async def create_card(
             description=card_data.description,
             enabled=card_data.enabled or True,
             delay_seconds=card_data.delay_seconds or 0,
+            use_no_logistics_form=card_data.use_no_logistics_form,
             price=card_data.price,
             is_dockable=card_data.is_dockable or False,
             fee_payer=card_data.fee_payer if card_data.is_dockable else None,
@@ -454,6 +458,7 @@ async def batch_save_card(
             description=request.description,
             enabled=request.enabled or True,
             delay_seconds=request.delay_seconds or 0,
+            use_no_logistics_form=request.use_no_logistics_form,
             price=request.price,
             is_dockable=request.is_dockable or False,
             fee_payer=request.fee_payer if request.is_dockable else None,

--- a/backend-web/app/services/card_service.py
+++ b/backend-web/app/services/card_service.py
@@ -38,7 +38,8 @@ class CardService:
     # 等大字段，避免一次性返回全部卡券时传输/读取超大内容）
     _LITE_COLUMNS = (
         Card.id, Card.user_id, Card.item_id, Card.name, Card.type,
-        Card.enabled, Card.delay_seconds, Card.delivery_count, Card.price,
+        Card.enabled, Card.delay_seconds, Card.use_no_logistics_form,
+        Card.delivery_count, Card.price,
         Card.is_dockable, Card.fee_payer, Card.min_price, Card.dock_visibility,
         Card.is_multi_spec, Card.spec_name, Card.spec_value,
         Card.created_at, Card.updated_at,
@@ -477,6 +478,7 @@ class CardService:
         description: Optional[str] = None,
         enabled: bool = True,
         delay_seconds: int = 0,
+        use_no_logistics_form: bool = False,
         price: Optional[str] = None,
         is_dockable: bool = False,
         fee_payer: Optional[str] = None,
@@ -502,6 +504,9 @@ class CardService:
         )
         if duplicate_msg:
             raise ValueError(duplicate_msg)
+
+        if use_no_logistics_form and card_type != "text":
+            raise ValueError("无需邮寄表单发货仅支持固定文字卡券")
         
         card = Card(
             user_id=user_id,
@@ -516,6 +521,7 @@ class CardService:
             description=description,
             enabled=enabled,
             delay_seconds=delay_seconds,
+            use_no_logistics_form=use_no_logistics_form,
             price=price,
             is_dockable=is_dockable,
             fee_payer=fee_payer,
@@ -553,6 +559,13 @@ class CardService:
         new_is_multi_spec = kwargs.get("is_multi_spec", card.is_multi_spec)
         new_spec_name = kwargs.get("spec_name", card.spec_name)
         new_spec_value = kwargs.get("spec_value", card.spec_value)
+        new_type = kwargs.get("type", card.type)
+        new_use_no_logistics_form = kwargs.get(
+            "use_no_logistics_form", card.use_no_logistics_form
+        )
+
+        if new_use_no_logistics_form and new_type != "text":
+            raise ValueError("无需邮寄表单发货仅支持固定文字卡券")
 
         # 检查重复（排除自身）
         duplicate_msg = await self.check_card_duplicate(
@@ -619,6 +632,7 @@ class CardService:
         description: Optional[str] = None,
         enabled: bool = True,
         delay_seconds: int = 0,
+        use_no_logistics_form: bool = False,
         price: Optional[str] = None,
         is_dockable: bool = False,
         fee_payer: Optional[str] = None,
@@ -638,6 +652,9 @@ class CardService:
         Returns:
             {"card_id": 新建卡券ID, "bindCount": 绑定商品数}
         """
+        if use_no_logistics_form and card_type != "text":
+            raise ValueError("无需邮寄表单发货仅支持固定文字卡券")
+
         # 1. 创建卡券（不设置 item_id，因为走关联表）
         card = Card(
             user_id=user_id,
@@ -652,6 +669,7 @@ class CardService:
             description=description,
             enabled=enabled,
             delay_seconds=delay_seconds,
+            use_no_logistics_form=use_no_logistics_form,
             price=price,
             is_dockable=is_dockable,
             fee_payer=fee_payer,
@@ -757,6 +775,7 @@ class CardService:
             "description": card.description,
             "enabled": card.enabled,
             "delay_seconds": card.delay_seconds,
+            "use_no_logistics_form": card.use_no_logistics_form,
             "delivery_count": card.delivery_count,
             "price": card.price,
             "is_dockable": card.is_dockable,
@@ -791,6 +810,7 @@ class CardService:
             "type": card.type,
             "enabled": card.enabled,
             "delay_seconds": card.delay_seconds,
+            "use_no_logistics_form": card.use_no_logistics_form,
             "delivery_count": card.delivery_count,
             "price": card.price,
             "is_dockable": card.is_dockable,
@@ -829,6 +849,7 @@ class CardService:
             "description": card.description,
             "enabled": card.enabled,
             "delay_seconds": card.delay_seconds,
+            "use_no_logistics_form": card.use_no_logistics_form,
             "delivery_count": card.delivery_count,
             "price": card.price,
             "is_dockable": card.is_dockable,

--- a/common/db/init_database.py
+++ b/common/db/init_database.py
@@ -664,6 +664,7 @@ class DatabaseInitializer:
                 description TEXT COMMENT '卡券描述',
                 enabled TINYINT(1) DEFAULT 1 COMMENT '是否启用',
                 delay_seconds INT DEFAULT 0 COMMENT '延迟秒数',
+                use_no_logistics_form TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否通过无需邮寄表单发货',
                 delivery_count INT DEFAULT 0 COMMENT '发货次数',
                 price VARCHAR(32) COMMENT '对接价格',
                 is_dockable TINYINT(1) DEFAULT 0 COMMENT '是否可对接',
@@ -1974,6 +1975,7 @@ class DatabaseInitializer:
         ],
         "xy_cards": [
             ("delivery_count", "INT DEFAULT 0 COMMENT '发货次数'", "delay_seconds"),
+            ("use_no_logistics_form", "TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否通过无需邮寄表单发货'", "delay_seconds"),
             ("price", "VARCHAR(32) COMMENT '对接价格'", "delivery_count"),
             ("is_dockable", "TINYINT(1) DEFAULT 0 COMMENT '是否可对接'", "price"),
             ("image_urls", "TEXT COMMENT '多图片URL列表(JSON数组，最多3张)'", "image_url"),

--- a/common/models/card.py
+++ b/common/models/card.py
@@ -31,6 +31,9 @@ class Card(Base):
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True, comment='卡券描述')
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, comment='是否启用')
     delay_seconds: Mapped[int] = mapped_column(Integer, default=0, comment='延迟秒数')
+    use_no_logistics_form: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0", comment='是否通过无需邮寄表单发货'
+    )
     delivery_count: Mapped[int] = mapped_column(Integer, default=0, comment='发货次数')
     price: Mapped[Optional[str]] = mapped_column(String(32), nullable=True, comment='对接价格')
     is_dockable: Mapped[bool] = mapped_column(Boolean, default=False, comment='是否可对接')
@@ -70,4 +73,3 @@ class Card(Base):
         viewonly=True,
         lazy="select",
     )
-

--- a/common/services/card_matcher.py
+++ b/common/services/card_matcher.py
@@ -624,6 +624,7 @@ class CardMatcher:
             "description": card.description,
             "enabled": card.enabled,
             "delay_seconds": card.delay_seconds or 0,
+            "use_no_logistics_form": bool(card.use_no_logistics_form),
             "delivery_count": card.delivery_count,
             "is_multi_spec": card.is_multi_spec or False,
             "spec_name": card.spec_name,

--- a/frontend/src/api/cards.ts
+++ b/frontend/src/api/cards.ts
@@ -12,6 +12,7 @@ export interface CardData {
   description?: string
   enabled?: boolean
   delay_seconds?: number
+  use_no_logistics_form?: boolean
   delivery_count?: number  // 发货次数
   price?: string | null     // 对接价格
   is_dockable?: boolean    // 是否可对接

--- a/frontend/src/pages/cards/CardFormModal.tsx
+++ b/frontend/src/pages/cards/CardFormModal.tsx
@@ -53,6 +53,7 @@ interface CardFormData {
   dataContent: string
   imageUrls: string[]
   delaySeconds: number
+  useNoLogisticsForm: boolean
   price: string
   isDockable: boolean
   feePayer: string
@@ -96,6 +97,7 @@ export function cardToFormData(card: CardData): CardFormData {
     dataContent: card.data_content || '',
     imageUrls: imageUrlsList,
     delaySeconds: card.delay_seconds || 0,
+    useNoLogisticsForm: card.use_no_logistics_form || false,
     price: card.price || '',
     isDockable: card.is_dockable || false,
     feePayer: card.fee_payer || '',
@@ -129,6 +131,7 @@ export const emptyCardFormData: CardFormData = {
   dataContent: '',
   imageUrls: [],
   delaySeconds: 0,
+  useNoLogisticsForm: false,
   price: '',
   isDockable: false,
   feePayer: '',
@@ -279,6 +282,7 @@ export function CardFormModal({ cardId, initialData, onClose, onSaved }: CardFor
         description: formData.description.trim() || undefined,
         enabled: true,
         delay_seconds: formData.delaySeconds,
+        use_no_logistics_form: formData.type === 'text' && formData.useNoLogisticsForm,
         price: formData.price.trim() || null,
         is_dockable: formData.isDockable,
         fee_payer: formData.isDockable ? formData.feePayer : null,
@@ -352,7 +356,10 @@ export function CardFormModal({ cardId, initialData, onClose, onSaved }: CardFor
                 <label className="input-label">卡券类型 <span className="text-red-500">*</span></label>
                 <Select
                   value={formData.type}
-                  onChange={(v) => updateField('type', v as CardFormData['type'])}
+                  onChange={(v) => {
+                    updateField('type', v as CardFormData['type'])
+                    if (v !== 'text') updateField('useNoLogisticsForm', false)
+                  }}
                   options={cardTypeOptions}
                 />
               </div>
@@ -472,6 +479,18 @@ export function CardFormModal({ cardId, initialData, onClose, onSaved }: CardFor
                     placeholder="请输入要发送的固定文字内容..."
                   />
                 </div>
+                <label className="mt-3 flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={formData.useNoLogisticsForm}
+                    onChange={(e) => updateField('useNoLogisticsForm', e.target.checked)}
+                    className="mt-0.5 w-4 h-4 rounded border-gray-300"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-gray-900 dark:text-white">填写到无需邮寄凭证</span>
+                    <span className="block text-xs text-gray-500 mt-0.5">开启后不再向买家发送卡券聊天消息</span>
+                  </span>
+                </label>
               </div>
             )}
 

--- a/websocket/app/services/shipping/confirm_service.py
+++ b/websocket/app/services/shipping/confirm_service.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from typing import Any, Dict, Optional
 
@@ -38,6 +39,7 @@ class ConfirmShippingService(BaseShippingService):
         order_id: str,
         item_id: Optional[str] = None,
         retry_count: int = 0,
+        trade_text: Optional[str] = None,
     ) -> Dict[str, Any]:
         """自动确认发货
         
@@ -45,6 +47,7 @@ class ConfirmShippingService(BaseShippingService):
             order_id: 订单ID
             item_id: 商品ID(可选,用于Token刷新)
             retry_count: 当前重试次数
+            trade_text: 无需邮寄凭证内容
             
         Returns:
             结果字典,包含success或error字段
@@ -82,8 +85,21 @@ class ConfirmShippingService(BaseShippingService):
             'sessionOption': 'AutoLoginOnly',
         }
 
-        # 构建请求数据
-        data_val = '{"orderId":"' + order_id + '", "tradeText":"","picList":[],"newUnconsign":true}'
+        # 未传凭证时保持原请求内容不变，避免影响现有确认发货流程。
+        normalized_trade_text = trade_text.strip() if isinstance(trade_text, str) else ""
+        if normalized_trade_text:
+            data_val = json.dumps(
+                {
+                    "orderId": order_id,
+                    "tradeText": normalized_trade_text,
+                    "picList": [],
+                    "newUnconsign": True,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        else:
+            data_val = '{"orderId":"' + order_id + '", "tradeText":"","picList":[],"newUnconsign":true}'
         data = {'data': data_val}
 
         # 获取Token并生成签名
@@ -126,7 +142,9 @@ class ConfirmShippingService(BaseShippingService):
                     logger.warning(f"【{self.account_id}】❌ 自动确认发货失败: {ret_msg}")
                     
                     # 重试
-                    return await self.auto_confirm(order_id, item_id, retry_count + 1)
+                    return await self.auto_confirm(
+                        order_id, item_id, retry_count + 1, trade_text=normalized_trade_text
+                    )
 
         except Exception as e:
             logger.error(f"【{self.account_id}】自动确认发货API请求异常: {self._safe_str(e)}")
@@ -135,7 +153,9 @@ class ConfirmShippingService(BaseShippingService):
             # 网络异常也进行重试
             if retry_count < 2:
                 logger.info(f"【{self.account_id}】网络异常,准备重试...")
-                return await self.auto_confirm(order_id, item_id, retry_count + 1)
+                return await self.auto_confirm(
+                    order_id, item_id, retry_count + 1, trade_text=normalized_trade_text
+                )
 
             return {"error": f"网络异常: {self._safe_str(e)}", "order_id": order_id}
 

--- a/websocket/app/services/xianyu/auto_delivery_handler.py
+++ b/websocket/app/services/xianyu/auto_delivery_handler.py
@@ -1274,6 +1274,7 @@ class AutoDeliveryHandler:
                     delivery_contents = []
                     success_count = 0
                     order_already_shipped = False  # 标记订单是否已发货
+                    form_delivery_content = None  # 无需邮寄表单成功时记录凭证，但不发送聊天消息
                     # 对接卡券退化标记：多数量循环里若第 1 张匹配到对接卡券，强制 break 退化为 1 张
                     # 规避底层 _create_agent_order + settlement_service 在 N 次调用时引发的金额 bug
                     quantity_degraded_for_dock = False
@@ -1298,6 +1299,8 @@ class AutoDeliveryHandler:
                             )
                             if isinstance(delivery_result, dict):
                                 delivery_content = delivery_result.get('content')
+                                if delivery_result.get('form_only_delivered'):
+                                    form_delivery_content = delivery_content
                                 platform_shipping_confirmed = (
                                     platform_shipping_confirmed
                                     or bool(delivery_result.get('platform_shipping_confirmed'))
@@ -1351,8 +1354,27 @@ class AutoDeliveryHandler:
                         except Exception as e:
                             logger.error(f"第 {i+1}/{quantity_to_send} 个卡券获取异常: {self._safe_str(e)}")
 
+                    # 无需邮寄表单已经在确认发货接口提交成功，只落库，不再发送聊天消息。
+                    if form_delivery_content:
+                        self.mark_delivery_sent(order_id)
+                        try:
+                            from common.services.order_service import OrderService
+                            from common.db.session import async_session_maker
+                            async with async_session_maker() as db_session:
+                                await OrderService(db_session).update_order_delivery_info(
+                                    order_no=order_id,
+                                    status="shipped",
+                                    delivery_method="auto",
+                                    delivery_content=form_delivery_content,
+                                    buyer_fish_nick=local_buyer_fish_nick,
+                                )
+                            logger.info(
+                                f"【{self.cookie_id}】订单 {order_id} 已通过无需邮寄表单发货，未发送聊天消息"
+                            )
+                        except Exception as e:
+                            logger.error(f"【{self.cookie_id}】更新表单发货订单状态失败: {self._safe_str(e)}")
                     # 如果订单已发货，不需要发送通知
-                    if order_already_shipped:
+                    elif order_already_shipped:
                         logger.info(f'[{msg_time}] 【{self.cookie_id}】订单 {order_id} 已发货，无需重复处理')
                     elif delivery_contents:
                         # 标记已发货（防重复）- 基于订单ID
@@ -1833,7 +1855,7 @@ class AutoDeliveryHandler:
 
     # ==================== 确认发货 ====================
 
-    async def auto_confirm(self, order_id, item_id=None, retry_count=0):
+    async def auto_confirm(self, order_id, item_id=None, retry_count=0, trade_text=None):
         """自动确认发货 - 使用重构后的确认发货服务"""
         try:
             if self.is_only_send_card_enabled():
@@ -1864,7 +1886,9 @@ class AutoDeliveryHandler:
                 confirm_service = ConfirmShippingService(db_session, self.session, account_pk)
                 
                 # 调用确认方法
-                result = await confirm_service.auto_confirm(order_id, item_id, retry_count)
+                result = await confirm_service.auto_confirm(
+                    order_id, item_id, retry_count, trade_text=trade_text
+                )
                 
                 # 同步更新后的cookies
                 if confirm_service.cookies_str and confirm_service.cookies_str != self.cookies_str:
@@ -2144,6 +2168,7 @@ class AutoDeliveryHandler:
                 'card_image_urls': card.get('image_urls'),  # 多图片URL列表
                 'card_api_config': card.get('api_config'),
                 'card_delay_seconds': card.get('delay_seconds', 0),
+                'use_no_logistics_form': bool(card.get('use_no_logistics_form', False)),
                 'card_description': card.get('description'),
                 'is_multi_spec': card.get('is_multi_spec', False),
                 'spec_name': card.get('spec_name'),
@@ -2166,6 +2191,16 @@ class AutoDeliveryHandler:
                 await asyncio.sleep(delay_seconds)
                 logger.info(f"延时完成")
 
+            use_no_logistics_form = rule.get('use_no_logistics_form', False)
+            form_trade_text = str(rule.get('card_text_content') or '').strip()
+            if use_no_logistics_form:
+                if rule['card_type'] != 'text' or not form_trade_text:
+                    self._last_delivery_fail_reason = "无需邮寄表单发货仅支持非空的固定文字卡券"
+                    return None
+                if not order_id or skip_confirm or not self.is_auto_confirm_enabled():
+                    self._last_delivery_fail_reason = "无需邮寄表单发货需要订单ID并开启自动确认发货"
+                    return None
+
             # 如果调用方明确指示跳过确认发货（如"禁止发货 + 关闭订单后只发卡券"场景），
             # 直接跳过 confirm 步骤，但仍要继续走下方的卡券生成与发送流程。
             if skip_confirm and order_id:
@@ -2177,7 +2212,11 @@ class AutoDeliveryHandler:
             # 如果开启了"卡券发送成功再确认发货"开关，跳过此处的确认发货，
             # 由外层 _handle_auto_delivery 在卡券发送成功后再执行确认发货。
             # 前提：自动确认发货必须开启，否则整个发货流程都不应执行。
-            send_before_confirm_mode = not skip_confirm and self.is_send_before_confirm_enabled()
+            send_before_confirm_mode = (
+                not use_no_logistics_form
+                and not skip_confirm
+                and self.is_send_before_confirm_enabled()
+            )
             if send_before_confirm_mode and order_id:
                 if not self.is_auto_confirm_enabled():
                     self._last_delivery_fail_reason = f"自动确认发货已关闭，且卡券发送成功再确认发货开关已开启，无法发送卡券"
@@ -2211,8 +2250,15 @@ class AutoDeliveryHandler:
 
                     if should_confirm:
                         logger.info(f"开始自动确认发货: 订单ID={order_id}, 商品ID={item_id}")
-                        confirm_result = await self.auto_confirm(order_id, item_id)
+                        confirm_result = await self.auto_confirm(
+                            order_id,
+                            item_id,
+                            trade_text=form_trade_text if use_no_logistics_form else None,
+                        )
                         if confirm_result.get('skipped_only_send_card'):
+                            if use_no_logistics_form:
+                                self._last_delivery_fail_reason = "只发卡券模式已开启，无法提交无需邮寄表单"
+                                return None
                             skipped_only_send_card = True
                             skip_confirm = True
                             logger.info(
@@ -2257,6 +2303,9 @@ class AutoDeliveryHandler:
                         else:
                             confirm_error = confirm_result.get('error', '未知错误')
                             logger.warning(f"⚠️ 自动确认发货失败: {confirm_error}")
+                            if use_no_logistics_form:
+                                self._last_delivery_fail_reason = f"无需邮寄表单发货失败: {confirm_error}"
+                                return None
                             # 检查“发货成功再发卡券”开关，如果开启则不发送卡券
                             if self.is_confirm_before_send_enabled():
                                 self._last_delivery_fail_reason = f"自动确认发货失败，发货成功再发卡券开关已开启，不发送卡券: {confirm_error}"
@@ -2416,6 +2465,9 @@ class AutoDeliveryHandler:
                     logger.warning(f"卡券没有配置图片和文字内容: 卡券ID={rule['card_id']}")
                     delivery_content = None
 
+                if use_no_logistics_form:
+                    delivery_content = form_trade_text
+
                 if delivery_content:
                     # 增加发货次数统计
                     db_manager.increment_delivery_count(rule['card_id'])
@@ -2439,6 +2491,7 @@ class AutoDeliveryHandler:
                         'content': delivery_content,
                         'platform_shipping_confirmed': platform_shipping_confirmed,
                         'skipped_only_send_card': skipped_only_send_card,
+                        'form_only_delivered': use_no_logistics_form,
                     }
                 else:
                     self._last_delivery_fail_reason = f"获取发货内容失败: 卡券ID={rule['card_id']}, 卡券名称={rule.get('card_name')}, 类型={rule.get('card_type')}"


### PR DESCRIPTION
## 修改内容

- 为固定文字卡券新增“填写到无需邮寄凭证”开关，默认关闭
- 开启后把固定文字内容写入闲鱼确认发货接口的 `tradeText`
- 表单提交成功后只更新订单和发货统计，不再向买家发送卡券聊天消息
- 补充开关所需的数据库迁移、卡券 API 和卡券匹配字段传递

> #242 / #244 调整的是商品发布阶段的配送方式；本 PR 处理的是成交后的卡券自动发货凭证，两者链路不同。

## 兼容性

- 新字段默认关闭，现有卡券继续沿用原聊天发货流程
- 关闭开关时，原确认发货请求体保持不变
- 仅非空的固定文字卡券可启用；其他卡券类型会被后端拒绝
- 表单发货要求订单 ID 且账号已开启自动确认发货，不满足条件时停止处理
- 原有对接卡券校验、代理订单结算和发货次数统计仍沿用原流程

## 本地验证

- `python3 -m compileall -q common backend-web/app websocket/app`
- `git diff --check`
- 前端 Docker builder 执行 `tsc && vite build` 通过
- 独立临时 MySQL 数据库验证新字段建表，以及 CardService/CardMatcher 的创建、读取、匹配和更新
- 隔离 WebSocket 容器验证：关闭开关时原请求体完全一致；开启后中文、换行、引号可安全写入 `tradeText`，失败重试不丢失
- 隔离发货分支验证：关闭开关保留原发送顺序；开启后提交表单并返回禁止聊天发送标志

测试过程中未重启现有服务，临时数据库和测试镜像均已清理。
