### PR TITLE
feat: 支持配置擦亮任务执行范围

### DIFF
--- a/backend-web/app/api/routes/admin.py
+++ b/backend-web/app/api/routes/admin.py
@@ -38,6 +38,7 @@ from app.services.user_service import UserService
 from app.services.recharge_service import RechargeService
 from common.services.settlement_service import BALANCE_KEY
 
+from common.scheduled_task_time import validate_daily_time_range
 from common.utils.time_utils import get_beijing_now_naive, safe_isoformat
 router = APIRouter(tags=["admin"])
 settings = get_settings()
@@ -773,6 +774,8 @@ async def list_scheduled_tasks(
                 "task_name": task.task_name,
                 "interval_seconds": task.interval_seconds,
                 "enabled": task.enabled,
+                "run_start_time": task.run_start_time,
+                "run_end_time": task.run_end_time,
                 "description": task.description,
                 "created_at": safe_isoformat(task.created_at),
                 "updated_at": safe_isoformat(task.updated_at),
@@ -797,6 +800,8 @@ async def update_scheduled_task(
     task_code: str,
     interval_seconds: int | None = None,
     enabled: bool | None = None,
+    run_start_time: str | None = None,
+    run_end_time: str | None = None,
     _: User = Depends(deps.get_current_admin_user),
     session: AsyncSession = Depends(deps.get_db_session),
 ) -> dict:
@@ -833,6 +838,20 @@ async def update_scheduled_task(
         
         if enabled is not None:
             task.enabled = enabled
+
+        if run_start_time is not None or run_end_time is not None:
+            if task_code != "polish":
+                return {
+                    "success": False,
+                    "message": "仅擦亮任务支持配置执行范围",
+                    "data": None,
+                }
+            start_time, end_time = validate_daily_time_range(
+                run_start_time if run_start_time is not None else task.run_start_time,
+                run_end_time if run_end_time is not None else task.run_end_time,
+            )
+            task.run_start_time = start_time
+            task.run_end_time = end_time
         
         await session.commit()
         await session.refresh(task)
@@ -865,6 +884,8 @@ async def update_scheduled_task(
                 "task_name": task.task_name,
                 "interval_seconds": task.interval_seconds,
                 "enabled": task.enabled,
+                "run_start_time": task.run_start_time,
+                "run_end_time": task.run_end_time,
                 "description": task.description,
             },
         }

--- a/common/db/init_database.py
+++ b/common/db/init_database.py
@@ -1171,6 +1171,8 @@ class DatabaseInitializer:
                 `task_name` VARCHAR(100) NOT NULL COMMENT '任务名称',
                 `interval_seconds` INT NOT NULL DEFAULT 60 COMMENT '执行间隔(秒)',
                 `enabled` TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用',
+                `run_start_time` VARCHAR(5) NOT NULL DEFAULT '00:00' COMMENT '执行范围开始时间(HH:MM)',
+                `run_end_time` VARCHAR(5) NOT NULL DEFAULT '23:59' COMMENT '执行范围结束时间(HH:MM)',
                 `description` TEXT COMMENT '任务描述',
                 `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
                 `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
@@ -1857,6 +1859,10 @@ class DatabaseInitializer:
     
     # 字段迁移定义：表名 -> [(字段名, 字段定义, 在哪个字段后面)]
     COLUMN_MIGRATIONS = {
+        "xy_scheduled_tasks": [
+            ("run_start_time", "VARCHAR(5) NOT NULL DEFAULT '00:00' COMMENT '执行范围开始时间(HH:MM)'", "enabled"),
+            ("run_end_time", "VARCHAR(5) NOT NULL DEFAULT '23:59' COMMENT '执行范围结束时间(HH:MM)'", "run_start_time"),
+        ],
         "xy_token_cache": [
             ("renew_expire_at", "DATETIME DEFAULT NULL COMMENT '续期Token过期时间'", "expire_at"),
         ],

--- a/common/models/scheduled_task.py
+++ b/common/models/scheduled_task.py
@@ -23,5 +23,6 @@ class ScheduledTask(TimestampMixin, Base):
     task_name: Mapped[str] = mapped_column(String(100), nullable=False, comment="任务名称")
     interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=60, comment="执行间隔(秒)")
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, comment="是否启用")
+    run_start_time: Mapped[str] = mapped_column(String(5), nullable=False, default="00:00", comment="执行范围开始时间(HH:MM)")
+    run_end_time: Mapped[str] = mapped_column(String(5), nullable=False, default="23:59", comment="执行范围结束时间(HH:MM)")
     description: Mapped[str | None] = mapped_column(Text, comment="任务描述")
-

--- a/common/scheduled_task_time.py
+++ b/common/scheduled_task_time.py
@@ -1,0 +1,34 @@
+"""定时任务执行范围的时间校验工具。"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+
+_DAILY_TIME_PATTERN = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
+def validate_daily_time_range(start_time: str, end_time: str) -> tuple[str, str]:
+    """校验同一自然日内的 HH:MM 执行范围并返回规范化值。"""
+    if not isinstance(start_time, str) or not isinstance(end_time, str):
+        raise ValueError("执行时间必须使用 HH:MM 格式")
+
+    start_value = start_time.strip()
+    end_value = end_time.strip()
+    if not _DAILY_TIME_PATTERN.fullmatch(start_value) or not _DAILY_TIME_PATTERN.fullmatch(end_value):
+        raise ValueError("执行时间必须使用 HH:MM 格式")
+
+    start_minutes = int(start_value[:2]) * 60 + int(start_value[3:])
+    end_minutes = int(end_value[:2]) * 60 + int(end_value[3:])
+    if start_minutes > end_minutes:
+        raise ValueError("开始时间不能晚于结束时间")
+    return start_value, end_value
+
+
+def is_within_daily_time_range(now: datetime, start_time: str, end_time: str) -> bool:
+    """判断给定时间是否落在同一自然日内、两端均包含的 HH:MM 范围。"""
+    start_value, end_value = validate_daily_time_range(start_time, end_time)
+    current_minutes = now.hour * 60 + now.minute
+    start_minutes = int(start_value[:2]) * 60 + int(start_value[3:])
+    end_minutes = int(end_value[:2]) * 60 + int(end_value[3:])
+    return start_minutes <= current_minutes <= end_minutes

--- a/common/tests/test_polish_schedule_window.py
+++ b/common/tests/test_polish_schedule_window.py
@@ -1,0 +1,26 @@
+"""擦亮任务执行范围的回归测试。"""
+from __future__ import annotations
+
+from datetime import datetime
+import unittest
+
+from common.scheduled_task_time import is_within_daily_time_range, validate_daily_time_range
+
+
+class PolishScheduleWindowTest(unittest.TestCase):
+    def test_time_range_includes_start_and_end_minutes(self):
+        self.assertTrue(is_within_daily_time_range(datetime(2026, 8, 27, 11, 0), "11:00", "23:59"))
+        self.assertTrue(is_within_daily_time_range(datetime(2026, 8, 27, 23, 59, 59), "11:00", "23:59"))
+        self.assertFalse(is_within_daily_time_range(datetime(2026, 8, 27, 10, 59, 59), "11:00", "23:59"))
+        self.assertFalse(is_within_daily_time_range(datetime(2026, 8, 28, 0, 0), "11:00", "23:59"))
+
+    def test_time_range_requires_valid_same_day_hhmm_values(self):
+        self.assertEqual(validate_daily_time_range("00:00", "23:59"), ("00:00", "23:59"))
+        with self.assertRaisesRegex(ValueError, "HH:MM"):
+            validate_daily_time_range("9:00", "23:59")
+        with self.assertRaisesRegex(ValueError, "开始时间"):
+            validate_daily_time_range("23:59", "11:00")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api/scheduledTasks.ts
+++ b/frontend/src/api/scheduledTasks.ts
@@ -17,6 +17,8 @@ export interface ScheduledTask {
   task_name: string
   interval_seconds: number
   enabled: boolean
+  run_start_time: string
+  run_end_time: string
   description: string | null
   task_running: boolean
   created_at: string | null
@@ -34,6 +36,8 @@ export interface ScheduledTasksResponse {
 export interface UpdateScheduledTaskParams {
   interval_seconds?: number
   enabled?: boolean
+  run_start_time?: string
+  run_end_time?: string
 }
 
 /** 更新定时任务响应 */
@@ -65,6 +69,12 @@ export async function updateScheduledTask(
   }
   if (params.enabled !== undefined) {
     query.set('enabled', String(params.enabled))
+  }
+  if (params.run_start_time !== undefined) {
+    query.set('run_start_time', params.run_start_time)
+  }
+  if (params.run_end_time !== undefined) {
+    query.set('run_end_time', params.run_end_time)
   }
   return put<UpdateScheduledTaskResponse>(`${ADMIN_PREFIX}/scheduled-tasks/${taskCode}?${query.toString()}`)
 }

--- a/frontend/src/pages/admin/ScheduledTasks.tsx
+++ b/frontend/src/pages/admin/ScheduledTasks.tsx
@@ -4,7 +4,7 @@
  * 功能：
  * 1. 显示定时任务列表（任务名称、间隔时间、是否启用、运行状态）
  * 2. 支持开启/关闭定时任务
- * 3. 支持修改定时任务间隔时间
+ * 3. 支持修改定时任务间隔时间和擦亮任务执行范围
  * 4. 修改后实时生效
  */
 import { useState, useEffect } from 'react'
@@ -23,6 +23,9 @@ export function ScheduledTasks() {
   // 编辑状态
   const [editingTask, setEditingTask] = useState<string | null>(null)
   const [editInterval, setEditInterval] = useState<number>(0)
+  const [editingTimeRangeTask, setEditingTimeRangeTask] = useState<string | null>(null)
+  const [editRunStartTime, setEditRunStartTime] = useState('00:00')
+  const [editRunEndTime, setEditRunEndTime] = useState('23:59')
   const [updating, setUpdating] = useState<string | null>(null)
   const [triggering, setTriggering] = useState<string | null>(null)
 
@@ -93,6 +96,42 @@ export function ScheduledTasks() {
     setEditInterval(0)
   }
 
+  const handleStartTimeRangeEdit = (task: ScheduledTask) => {
+    setEditingTimeRangeTask(task.task_code)
+    setEditRunStartTime(task.run_start_time || '00:00')
+    setEditRunEndTime(task.run_end_time || '23:59')
+  }
+
+  const handleCancelTimeRangeEdit = () => {
+    setEditingTimeRangeTask(null)
+  }
+
+  const handleSaveTimeRange = async (taskCode: string) => {
+    if (editRunStartTime > editRunEndTime) {
+      addToast({ type: 'error', message: '开始时间不能晚于结束时间' })
+      return
+    }
+
+    setUpdating(taskCode)
+    try {
+      const result = await updateScheduledTask(taskCode, {
+        run_start_time: editRunStartTime,
+        run_end_time: editRunEndTime,
+      })
+      if (result.success) {
+        addToast({ type: 'success', message: result.message })
+        setEditingTimeRangeTask(null)
+        loadTasks()
+      } else {
+        addToast({ type: 'error', message: result.message || '更新失败' })
+      }
+    } catch (error: any) {
+      addToast({ type: 'error', message: error.response?.data?.detail || '更新失败' })
+    } finally {
+      setUpdating(null)
+    }
+  }
+
   // 保存间隔时间
   const handleSaveInterval = async (taskCode: string) => {
     if (editInterval < 1) {
@@ -127,7 +166,7 @@ export function ScheduledTasks() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="page-title">定时任务管理</h1>
-          <p className="page-description">管理系统定时任务的执行间隔和启用状态</p>
+          <p className="page-description">管理系统定时任务的执行间隔、执行范围和启用状态</p>
         </div>
         <div className="flex gap-3">
           <button onClick={loadTasks} disabled={loading} className="btn-ios-secondary">
@@ -157,6 +196,7 @@ export function ScheduledTasks() {
                 <th>任务名称</th>
                 <th>任务代码</th>
                 <th>执行间隔</th>
+                <th>执行范围</th>
                 <th>启用状态</th>
                 <th>描述</th>
                 <th>操作</th>
@@ -165,7 +205,7 @@ export function ScheduledTasks() {
             <tbody>
               {tasks.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="text-center py-8 text-slate-500 dark:text-slate-400">
+                  <td colSpan={7} className="text-center py-8 text-slate-500 dark:text-slate-400">
                     <div className="flex flex-col items-center gap-2">
                       <Clock className="w-12 h-12 text-slate-300 dark:text-slate-600" />
                       <p>暂无定时任务</p>
@@ -220,6 +260,59 @@ export function ScheduledTasks() {
                             onClick={() => handleStartEdit(task)}
                             className="p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
                             title="编辑"
+                          >
+                            <Edit2 className="w-3.5 h-3.5 text-slate-400" />
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                    <td>
+                      {task.task_code !== 'polish' ? (
+                        <span className="text-slate-400 dark:text-slate-500">-</span>
+                      ) : editingTimeRangeTask === task.task_code ? (
+                        <div className="flex items-center gap-2 whitespace-nowrap">
+                          <input
+                            type="time"
+                            value={editRunStartTime}
+                            onChange={(e) => setEditRunStartTime(e.target.value)}
+                            className="px-2 py-1 border border-slate-300 dark:border-slate-600 rounded bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 text-sm"
+                            aria-label="擦亮任务开始执行时间"
+                          />
+                          <span className="text-sm text-slate-500">至</span>
+                          <input
+                            type="time"
+                            value={editRunEndTime}
+                            onChange={(e) => setEditRunEndTime(e.target.value)}
+                            className="px-2 py-1 border border-slate-300 dark:border-slate-600 rounded bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 text-sm"
+                            aria-label="擦亮任务结束执行时间"
+                          />
+                          <button
+                            onClick={() => handleSaveTimeRange(task.task_code)}
+                            disabled={updating === task.task_code}
+                            className="p-1 rounded hover:bg-green-50 dark:hover:bg-green-900/20 transition-colors"
+                            title="保存执行范围"
+                          >
+                            {updating === task.task_code ? (
+                              <Loader2 className="w-4 h-4 animate-spin text-green-500" />
+                            ) : (
+                              <Check className="w-4 h-4 text-green-500" />
+                            )}
+                          </button>
+                          <button
+                            onClick={handleCancelTimeRangeEdit}
+                            className="p-1 rounded hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                            title="取消"
+                          >
+                            <X className="w-4 h-4 text-red-500" />
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{task.run_start_time}–{task.run_end_time}</span>
+                          <button
+                            onClick={() => handleStartTimeRangeEdit(task)}
+                            className="p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                            title="编辑执行范围"
                           >
                             <Edit2 className="w-3.5 h-3.5 text-slate-400" />
                           </button>

--- a/scheduler/app/services/scheduled_task_service.py
+++ b/scheduler/app/services/scheduled_task_service.py
@@ -16,6 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.models.scheduled_task import ScheduledTask
+from common.scheduled_task_time import validate_daily_time_range
 
 
 # 任务代码常量
@@ -46,7 +47,12 @@ TASK_CODE_IMAGE_CLEANUP = "image_cleanup"
 DEFAULT_CONFIGS = {
     TASK_CODE_REDELIVERY: {"interval_seconds": 5, "enabled": True},
     TASK_CODE_RATE: {"interval_seconds": 20, "enabled": True},
-    TASK_CODE_POLISH: {"interval_seconds": 60, "enabled": True},
+    TASK_CODE_POLISH: {
+        "interval_seconds": 60,
+        "enabled": True,
+        "run_start_time": "00:00",
+        "run_end_time": "23:59",
+    },
     TASK_CODE_DAY_SWITCH: {"interval_seconds": 60, "enabled": True},
     TASK_CODE_CLEANUP_BROWSER_DATA: {"interval_seconds": 600, "enabled": False},
     TASK_CODE_FETCH_ORDERS: {"interval_seconds": 600, "enabled": True},
@@ -108,6 +114,11 @@ class ScheduledTaskService:
                     "interval_seconds": task.interval_seconds,
                     "enabled": task.enabled,
                 }
+                if task_code == TASK_CODE_POLISH:
+                    config.update(
+                        run_start_time=task.run_start_time,
+                        run_end_time=task.run_end_time,
+                    )
                 # 更新缓存
                 self._config_cache[task_code] = config
                 logger.info(
@@ -148,6 +159,8 @@ class ScheduledTaskService:
         task_code: str,
         interval_seconds: Optional[int] = None,
         enabled: Optional[bool] = None,
+        run_start_time: Optional[str] = None,
+        run_end_time: Optional[str] = None,
     ) -> Optional[ScheduledTask]:
         """
         更新定时任务配置
@@ -156,6 +169,8 @@ class ScheduledTaskService:
             task_code: 任务代码
             interval_seconds: 执行间隔（秒），None表示不更新
             enabled: 是否启用，None表示不更新
+            run_start_time: 执行范围开始时间，仅擦亮任务支持
+            run_end_time: 执行范围结束时间，仅擦亮任务支持
             
         Returns:
             更新后的任务配置，如果任务不存在返回None
@@ -173,6 +188,16 @@ class ScheduledTaskService:
         
         if enabled is not None:
             task.enabled = enabled
+
+        if run_start_time is not None or run_end_time is not None:
+            if task_code != TASK_CODE_POLISH:
+                raise ValueError("仅擦亮任务支持配置执行范围")
+            start_time, end_time = validate_daily_time_range(
+                run_start_time if run_start_time is not None else task.run_start_time,
+                run_end_time if run_end_time is not None else task.run_end_time,
+            )
+            task.run_start_time = start_time
+            task.run_end_time = end_time
         
         await self.session.commit()
         await self.session.refresh(task)
@@ -183,10 +208,16 @@ class ScheduledTaskService:
         )
         
         # 更新缓存
-        self._config_cache[task_code] = {
+        config = {
             "interval_seconds": task.interval_seconds,
             "enabled": task.enabled,
         }
+        if task_code == TASK_CODE_POLISH:
+            config.update(
+                run_start_time=task.run_start_time,
+                run_end_time=task.run_end_time,
+            )
+        self._config_cache[task_code] = config
         
         # 通知调度器刷新配置
         await self._notify_scheduler_reload(task_code)

--- a/scheduler/app/services/scheduler_service.py
+++ b/scheduler/app/services/scheduler_service.py
@@ -65,6 +65,8 @@ from app.services.scheduled_task_service import (
     TASK_CODE_IMAGE_CLEANUP,
 )
 from common.db.session import async_session_maker
+from common.scheduled_task_time import is_within_daily_time_range
+from common.utils.time_utils import get_beijing_now_naive
 
 
 class SchedulerService:
@@ -596,12 +598,17 @@ class SchedulerService:
         while self._running:
             config = ScheduledTaskService.get_cached_config(TASK_CODE_POLISH)
             if not config:
-                config = {"interval_seconds": 60, "enabled": True}
+                config = {
+                    "interval_seconds": 60,
+                    "enabled": True,
+                    "run_start_time": "00:00",
+                    "run_end_time": "23:59",
+                }
             
             interval = config.get("interval_seconds", 60)
             enabled = config.get("enabled", True)
             
-            if enabled:
+            if enabled and self._is_polish_run_window(config):
                 try:
                     await self._polish_task.execute()
                 except asyncio.CancelledError:
@@ -618,6 +625,21 @@ class SchedulerService:
                 break
         
         logger.info("[定时任务调度] 擦亮任务循环结束")
+
+    @staticmethod
+    def _is_polish_run_window(config: dict) -> bool:
+        """仅在擦亮任务配置的北京时间执行范围内运行。"""
+        start_time = config.get("run_start_time", "00:00")
+        end_time = config.get("run_end_time", "23:59")
+        try:
+            return is_within_daily_time_range(
+                get_beijing_now_naive(),
+                start_time,
+                end_time,
+            )
+        except ValueError as error:
+            logger.error(f"[定时任务调度] 擦亮任务执行范围无效: {error}")
+            return False
     
     async def _run_day_switch_loop(self) -> None:
         """平台日切换任务执行循环"""


### PR DESCRIPTION
## 变更内容
- 为擦亮定时任务增加可配置的每日执行范围（默认 00:00–23:59）。
- 管理后台仅在“擦亮任务”行提供开始/结束时间编辑。
- 调度器按北京时间判断范围，起止分钟均包含；手动执行不受该范围限制。
- 增加时间格式与边界的回归测试。

## 根因
原有擦亮任务只有启停和间隔配置，无法限制它在每天的指定时段内执行。

## 业务背景
擦亮效果与用户活跃时段有关：早上约 8:00–9:00 的通勤时段，以及中午约 11:00–12:30 的休息时段，通常更容易获得浏览和曝光；常规工作时段的优先级相对较低。不同运营策略会选择不同的高活跃连续时段，例如 11:00–12:30，因此需要支持按每日执行范围控制自动擦亮，避免在低优先级时段执行。

## 用户影响
例如设为 11:00–23:59 后，自动擦亮只会在该时段运行；其他定时任务行为不变。

## 不涉及范围
- 不改变账号级的擦亮开关语义。
- 不新增跨天时间段支持。
- 不含版本号、锁文件、更新日志或部署改动。

## 验证
- python3 -m unittest common.tests.test_polish_schedule_window（通过）
- python3 -m compileall -q common scheduler backend-web（通过）
- npm run --prefix frontend build（通过）
- git diff --check base/main...HEAD（通过）