### PR TITLE
fix: prevent captcha risk logs from remaining processing

### DIFF
--- a/tests/test_risk_log_engine_normalization.py
+++ b/tests/test_risk_log_engine_normalization.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WEBSOCKET_ROOT = REPO_ROOT / "websocket"
+if str(WEBSOCKET_ROOT) not in sys.path:
+    sys.path.insert(0, str(WEBSOCKET_ROOT))
+
+from app.utils.captcha_engine import normalize_captcha_engine  # noqa: E402
+
+
+class CaptchaEngineNormalizationTests(unittest.TestCase):
+    def test_remote_diagnostic_is_stored_as_engine_and_error(self):
+        reason = "('Connection aborted.', RemoteDisconnected('Remote end closed'))"
+
+        engine, error = normalize_captcha_engine(f"remote:{reason}")
+
+        self.assertEqual(engine, "remote")
+        self.assertEqual(error, reason)
+
+    def test_existing_error_is_not_overwritten(self):
+        engine, error = normalize_captcha_engine(
+            "remote:transport detail",
+            "上层返回的失败原因",
+        )
+
+        self.assertEqual(engine, "remote")
+        self.assertEqual(error, "上层返回的失败原因")
+
+    def test_unknown_long_engine_is_bounded(self):
+        engine, error = normalize_captcha_engine("x" * 64)
+
+        self.assertEqual(len(engine), 32)
+        self.assertEqual(error, f"滑块引擎返回异常标识: {'x' * 64}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/websocket/app/api/routes/internal.py
+++ b/websocket/app/api/routes/internal.py
@@ -35,6 +35,7 @@ from common.services.token_renewal_cache_service import (
 )
 from common.services.token_api_mode import load_token_api_mode
 from common.utils.xianyu_utils import trans_cookies
+from app.utils.captcha_engine import normalize_captcha_engine
 
 router = APIRouter(prefix="/internal", tags=["internal"])
 
@@ -447,7 +448,8 @@ async def solve_captcha(request: SolveCaptchaRequest):
             from common.db.compat import db_manager as _dm
             kwargs = {"processing_status": status, "processing_result": result}
             if engine is not None:
-                kwargs["captcha_engine"] = engine
+                normalized_engine, error = normalize_captcha_engine(engine, error)
+                kwargs["captcha_engine"] = normalized_engine
             if error is not None:
                 kwargs["error_message"] = error
             _dm.update_risk_control_log(log_id=log_id, **kwargs)

--- a/websocket/app/utils/captcha_engine.py
+++ b/websocket/app/utils/captcha_engine.py
@@ -1,0 +1,32 @@
+"""Helpers for persisting captcha engine metadata safely."""
+
+from __future__ import annotations
+
+
+def normalize_captcha_engine(
+    engine: object,
+    error: str | None = None,
+) -> tuple[str, str | None]:
+    """Keep the database engine label bounded and preserve diagnostics.
+
+    ``captcha_engine`` is a short ``VARCHAR`` used for filtering and display.
+    Remote workers may append a full exception to the engine label (for
+    example ``remote:Connection aborted...``); persisting that value can make
+    MySQL reject the whole risk-log update and leave it in ``processing``.
+    Store a stable engine name and return the diagnostic separately for
+    ``error_message``.
+    """
+    normalized = str(engine).strip()
+    if normalized.startswith("remote:"):
+        remote_reason = normalized.split(":", 1)[1].strip()
+        normalized = "remote"
+        if remote_reason and not error:
+            error = remote_reason
+
+    # Keep this guard aligned with the current schema (VARCHAR(32)) so future
+    # engine implementations cannot reintroduce the same persistence failure.
+    if len(normalized) > 32:
+        if not error:
+            error = f"滑块引擎返回异常标识: {normalized}"
+        normalized = normalized[:32]
+    return normalized, error


### PR DESCRIPTION
## Problem

When the remote captcha worker failed, the diagnostic exception was appended to `captcha_engine`. That column is `VARCHAR(32)`, so MySQL rejected the risk-log update and left the record permanently in `processing`.

## Fix

- Normalize `remote:<diagnostic>` to the stable `remote` engine label.
- Persist the diagnostic in `error_message` instead of the bounded engine column.
- Bound unknown future engine labels to 32 characters as a defensive guard.
- Add regression tests for remote diagnostics, existing errors, and oversized labels.

## Verification

- `python -m unittest tests.test_risk_log_engine_normalization`
- `python -m py_compile websocket/app/utils/captcha_engine.py websocket/app/api/routes/internal.py`
- `git diff --check`