### PR TITLE
fix: 支持图片卡券发货凭证及备注

### DIFF
--- a/common/utils/image_uploader.py
+++ b/common/utils/image_uploader.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import asyncio
 from io import BytesIO
 from typing import Optional
+from urllib.parse import urlparse
 
 import aiohttp
 from loguru import logger
@@ -157,6 +159,136 @@ class ImageUploader:
                 except Exception:
                     pass
     
+    async def upload_image_url(
+        self,
+        image_url: str,
+    ) -> Optional[str]:
+        """Download an image reference and re-upload it to Goofish CDN.
+
+        The consign API expects URLs returned by the Goofish image uploader;
+        the original card image URL cannot be submitted reliably as picList.
+        """
+        image_url = str(image_url or '').strip()
+        if not image_url.lower().startswith(('http://', 'https://')):
+            logger.warning(f"图片地址不是HTTP(S) URL，无法下载上传: {image_url}")
+            return None
+
+        temp_path = None
+        try:
+            if not self.session:
+                await self.create_session()
+
+            headers = {
+                'Referer': 'https://www.goofish.com/',
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+            }
+            # aiohttp may resolve the image CDN to the container's intercepted
+            # address and fail to connect.  requests uses the working network
+            # path in this deployment; use it for the source download and keep
+            # the existing aiohttp session for the Goofish upload.
+            return await self._upload_image_url_with_requests(image_url, headers)
+            async with self.session.get(
+                image_url,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as response:
+                if response.status != 200:
+                    logger.error(f"下载卡券图片失败: HTTP {response.status}, URL: {image_url}")
+                    return None
+
+                # Wait for the complete response stream instead of a bounded
+                # read, which could pass a truncated CDN response to Pillow.
+                image_data = await response.read()
+                if not image_data:
+                    logger.error(f"下载卡券图片为空: {image_url}")
+                    return None
+                if len(image_data) > 10 * 1024 * 1024:
+                    logger.error(f"卡券图片超过10MB限制，拒绝上传: {image_url}")
+                    return None
+
+            # Reject incomplete/corrupt downloads before writing or uploading.
+            try:
+                with Image.open(BytesIO(image_data)) as image:
+                    image.verify()
+            except Exception as image_error:
+                logger.error(f"Image download validation failed: {image_error}, URL: {image_url}")
+                return None
+
+            suffix = os.path.splitext(urlparse(image_url).path)[1].lower()
+            if suffix not in ('.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp'):
+                suffix = '.jpg'
+            temp_fd, temp_path = tempfile.mkstemp(suffix=suffix)
+            os.close(temp_fd)
+            with open(temp_path, 'wb') as file_obj:
+                file_obj.write(image_data)
+
+            return await self.upload_image(temp_path)
+        except Exception as e:
+            logger.error(f"下载并上传卡券图片异常: {e}")
+            return None
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                try:
+                    os.remove(temp_path)
+                except Exception:
+                    pass
+
+    async def _upload_image_url_with_requests(
+        self,
+        image_url: str,
+        headers: dict[str, str],
+    ) -> Optional[str]:
+        """Download a remote card image through the working HTTP path."""
+        import requests
+
+        def download() -> bytes:
+            last_error = None
+            for attempt in range(3):
+                request_url = image_url
+                if attempt:
+                    separator = '&' if '?' in image_url else '?'
+                    request_url = f"{image_url}{separator}_download_retry={attempt}"
+                try:
+                    response = requests.get(request_url, headers=headers, timeout=30)
+                    if response.status_code != 200:
+                        raise ValueError(f"HTTP {response.status_code}")
+                    data = response.content
+                    if not data:
+                        raise ValueError("响应内容为空")
+                    if len(data) > 10 * 1024 * 1024:
+                        raise ValueError("图片超过10MB限制")
+                    content_length = response.headers.get('Content-Length')
+                    if content_length and len(data) < int(content_length):
+                        raise ValueError(
+                            f"响应内容不完整: {len(data)}/{content_length} bytes"
+                        )
+                    with Image.open(BytesIO(data)) as image:
+                        image.verify()
+                    return data
+                except Exception as error:
+                    last_error = error
+                    if attempt < 2:
+                        continue
+            raise RuntimeError(f"图片下载失败: {last_error}")
+
+        image_data = await asyncio.to_thread(download)
+        suffix = os.path.splitext(urlparse(image_url).path)[1].lower()
+        if suffix not in ('.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp'):
+            suffix = '.jpg'
+        temp_path = None
+        try:
+            temp_fd, temp_path = tempfile.mkstemp(suffix=suffix)
+            os.close(temp_fd)
+            with open(temp_path, 'wb') as file_obj:
+                file_obj.write(image_data)
+            return await self.upload_image(temp_path)
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                try:
+                    os.remove(temp_path)
+                except Exception:
+                    pass
+
     def _parse_upload_response(self, response_text: str) -> Optional[str]:
         """解析上传响应获取图片URL"""
         try:

--- a/websocket/app/api/routes/internal.py
+++ b/websocket/app/api/routes/internal.py
@@ -9,6 +9,7 @@ WebSocket服务内部API路由
 from __future__ import annotations
 
 import asyncio
+import json
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -79,6 +80,7 @@ class ConfirmNoLogisticsRequest(BaseModel):
     item_id: str
     buyer_id: str = ""
     is_bargain: bool = False
+    card_id: int | None = None
 
 
 class CancelOrderRequest(BaseModel):
@@ -1080,13 +1082,53 @@ async def confirm_no_logistics(request: ConfirmNoLogisticsRequest):
             "data": None,
         }
 
+    trade_text = None
+    pic_list = None
+    if request.card_id and not request.is_bargain:
+        from common.models.card import Card
+        from sqlalchemy import select
+
+        async with async_session_maker() as session:
+            card_result = await session.execute(
+                select(Card).where(Card.id == request.card_id)
+            )
+            card = card_result.scalars().first()
+        if not card:
+            return {"success": False, "code": 404, "message": "卡券不存在", "data": None}
+        if card.type == "text":
+            trade_text = (card.text_content or "").strip()
+        elif card.type == "image":
+            # 图片卡券的备注对应旧版的 tradeText；图片本身仍通过 picList
+            # 作为平台发货凭证提交。
+            trade_text = (card.description or "").strip()
+            raw_urls = card.image_urls or []
+            if isinstance(raw_urls, str):
+                try:
+                    raw_urls = json.loads(raw_urls)
+                except (TypeError, json.JSONDecodeError):
+                    raw_urls = [raw_urls]
+            pic_list = [
+                str(url).strip()
+                for url in (raw_urls if isinstance(raw_urls, (list, tuple)) else [])
+                if isinstance(url, str) and url.strip()
+            ]
+            if card.image_url and card.image_url not in pic_list:
+                pic_list.append(card.image_url)
+            if not pic_list:
+                return {"success": False, "code": 400, "message": "图片卡券缺少凭证图片", "data": None}
+        else:
+            return {"success": False, "code": 400, "message": "无物流凭证仅支持文字或图片卡券", "data": None}
+
     if request.is_bargain:
         result = await xianyu_live.auto_delivery_handler.auto_freeshipping(
             request.order_no, request.item_id, request.buyer_id
         )
     else:
         result = await xianyu_live.auto_delivery_handler.auto_confirm(
-            request.order_no, request.item_id
+            request.order_no,
+            request.item_id,
+            trade_text=trade_text,
+            pic_list=pic_list,
         )
 
     if not result or not result.get("success"):
@@ -1474,6 +1516,21 @@ async def _deliver_order_impl(request: DeliverOrderRequest):
             }
         
         # 验证商品是否属于当前账号
+        # 无需邮寄凭证必须随首次确认发货请求一起提交。
+        # 先读取轻量开关，避免本入口在卡券流程前提前调用 auto_confirm，
+        # 导致图片卡券的 picList 为空。
+        no_logistics_form_card = False
+        if request.card_id:
+            async with async_session_maker() as session:
+                card_flag_stmt = select(Card.use_no_logistics_form).where(Card.id == request.card_id)
+                card_flag_result = await session.execute(card_flag_stmt)
+                no_logistics_form_card = bool(card_flag_result.scalar_one_or_none())
+            if no_logistics_form_card:
+                logger.info(
+                    f"【内部API】订单 {request.order_no} 使用无需邮寄凭证卡券，"
+                    "跳过前置确认，等待卡券流程携带 picList 一次性提交"
+                )
+
         if request.item_id:
             from common.db.session import async_session_maker
             from sqlalchemy import select
@@ -1667,7 +1724,7 @@ async def _deliver_order_impl(request: DeliverOrderRequest):
                 f"【内部API】send_before_confirm 模式：先发卡券再确认发货，跳过此处确认: "
                 f"order_no={request.order_no}"
             )
-        elif xianyu_live.is_auto_confirm_enabled():
+        elif xianyu_live.is_auto_confirm_enabled() and not no_logistics_form_card:
             logger.info(f"【内部API】开始确认发货: order_no={request.order_no}")
             confirm_result = await xianyu_live.auto_delivery_handler.auto_confirm(
                 order_id=request.order_no,
@@ -1715,7 +1772,13 @@ async def _deliver_order_impl(request: DeliverOrderRequest):
             logger.info(f"【内部API】自动确认发货已关闭，跳过确认发货")
 
         # 如果是小刀订单，调用免拼接口（card_only 模式和 send_before_confirm 模式下跳过）
-        if request.is_bargain and not order_already_shipped and not skip_shipping_confirm and not send_before_confirm_mode:
+        if (
+            request.is_bargain
+            and not order_already_shipped
+            and not skip_shipping_confirm
+            and not send_before_confirm_mode
+            and not no_logistics_form_card
+        ):
             logger.info(f"【内部API】检测到小刀订单，调用免拼发货接口: order_no={request.order_no}")
             freeshipping_result = await xianyu_live.auto_delivery_handler.auto_freeshipping(
                 order_id=request.order_no,
@@ -1966,6 +2029,101 @@ async def _deliver_order_impl(request: DeliverOrderRequest):
             }
 
         # 构建订单上下文（仅 text/data/api 文字渲染需要）
+        # 图片/文字凭证卡券必须在发送卡券前完成平台确认，
+        # 否则“无需寄件”分支会跳过前置确认，也不会进入 send_before_confirm 后置确认。
+        form_trade_text = None
+        form_pic_list = None
+        if no_logistics_form_card and send_before_confirm_mode:
+            # 先发卡券再确认发货时，先准备同一份平台凭证数据，
+            # 由下方后置确认请求携带备注和图片提交。
+            if card.type == 'text':
+                form_trade_text = (card.text_content or '').strip()
+            elif card.type == 'image':
+                form_trade_text = (card.description or '').strip()
+                raw_form_pic_list = card.image_urls or []
+                if isinstance(raw_form_pic_list, str):
+                    try:
+                        raw_form_pic_list = json.loads(raw_form_pic_list)
+                    except (TypeError, json.JSONDecodeError):
+                        raw_form_pic_list = [raw_form_pic_list]
+                form_pic_list = [
+                    str(url).strip()
+                    for url in (raw_form_pic_list if isinstance(raw_form_pic_list, (list, tuple)) else [])
+                    if isinstance(url, str) and url.strip()
+                ]
+                if card.image_url and card.image_url not in form_pic_list:
+                    form_pic_list.append(card.image_url)
+
+        if no_logistics_form_card and not platform_shipping_confirmed and not send_before_confirm_mode:
+            form_trade_text = None
+            form_pic_list = None
+            if card.type == 'text':
+                form_trade_text = (card.text_content or '').strip()
+                if not form_trade_text:
+                    return {
+                        "success": False,
+                        "code": 400,
+                        "message": "无需寄件文字凭证为空",
+                        "data": None,
+                    }
+            elif card.type == 'image':
+                # 与旧版一致：图片卡券的备注写入 tradeText，图片写入 picList。
+                form_trade_text = (card.description or '').strip()
+                raw_form_pic_list = card.image_urls or []
+                if isinstance(raw_form_pic_list, str):
+                    try:
+                        raw_form_pic_list = json.loads(raw_form_pic_list)
+                    except (TypeError, json.JSONDecodeError):
+                        raw_form_pic_list = [raw_form_pic_list]
+                form_pic_list = [
+                    str(url).strip()
+                    for url in (raw_form_pic_list if isinstance(raw_form_pic_list, (list, tuple)) else [])
+                    if isinstance(url, str) and url.strip()
+                ]
+                if card.image_url and card.image_url not in form_pic_list:
+                    form_pic_list.append(card.image_url)
+                if not form_pic_list:
+                    return {
+                        "success": False,
+                        "code": 400,
+                        "message": "无需寄件图片凭证为空",
+                        "data": None,
+                    }
+            else:
+                return {
+                    "success": False,
+                    "code": 400,
+                    "message": "无需寄件凭证仅支持文字或图片卡券",
+                    "data": None,
+                }
+
+            logger.info(
+                f"【内部API】订单 {request.order_no} 提交无需寄件凭证确认发货: "
+                f"card_type={card.type}, pic_count={len(form_pic_list or [])}"
+            )
+            confirm_result = await xianyu_live.auto_delivery_handler.auto_confirm(
+                order_id=request.order_no,
+                item_id=request.item_id,
+                trade_text=form_trade_text,
+                pic_list=form_pic_list,
+            )
+            if not confirm_result or not confirm_result.get('success'):
+                confirm_error = (
+                    (confirm_result or {}).get('error')
+                    or (confirm_result or {}).get('message')
+                    or '无需寄件凭证确认发货失败'
+                )
+                logger.warning(
+                    f"【内部API】订单 {request.order_no} 无需寄件凭证确认发货失败: {confirm_error}"
+                )
+                return {
+                    "success": False,
+                    "code": 400,
+                    "message": confirm_error,
+                    "data": confirm_result,
+                }
+            platform_shipping_confirmed = True
+
         from app.services.xianyu.delivery_utils import process_delivery_content_with_description
         _order_context = {
             'order_id': request.order_no or '',
@@ -2216,7 +2374,9 @@ async def _deliver_order_impl(request: DeliverOrderRequest):
                 if not only_send_card_mode:
                     confirm_result = await xianyu_live.auto_delivery_handler.auto_confirm(
                         order_id=request.order_no,
-                        item_id=request.item_id
+                        item_id=request.item_id,
+                        trade_text=form_trade_text,
+                        pic_list=form_pic_list,
                     )
                     if confirm_result and confirm_result.get('skipped_only_send_card'):
                         only_send_card_mode = True

--- a/websocket/app/services/shipping/confirm_service.py
+++ b/websocket/app/services/shipping/confirm_service.py
@@ -13,13 +13,16 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 import aiohttp
 from loguru import logger
 
 from app.services.shipping.base import BaseShippingService
+from common.utils.image_uploader import ImageUploader
 from common.utils.xianyu_utils import generate_sign, trans_cookies
 
 
@@ -40,6 +43,8 @@ class ConfirmShippingService(BaseShippingService):
         item_id: Optional[str] = None,
         retry_count: int = 0,
         trade_text: Optional[str] = None,
+        pic_list: Optional[list[str]] = None,
+        _prepared_pic_list: Optional[list[str]] = None,
     ) -> Dict[str, Any]:
         """自动确认发货
         
@@ -48,6 +53,7 @@ class ConfirmShippingService(BaseShippingService):
             item_id: 商品ID(可选,用于Token刷新)
             retry_count: 当前重试次数
             trade_text: 无需邮寄凭证内容
+            pic_list: 无需邮寄凭证图片 URL 列表
             
         Returns:
             结果字典,包含success或error字段
@@ -85,14 +91,38 @@ class ConfirmShippingService(BaseShippingService):
             'sessionOption': 'AutoLoginOnly',
         }
 
-        # 未传凭证时保持原请求内容不变，避免影响现有确认发货流程。
+        # 无需邮寄凭证支持文字和图片。保留空凭证时的历史请求结构，
+        # 避免影响没有配置凭证的现有确认发货流程。
         normalized_trade_text = trade_text.strip() if isinstance(trade_text, str) else ""
-        if normalized_trade_text:
+        normalized_pic_list = [
+            str(url).strip()
+            for url in (pic_list or [])
+            if isinstance(url, str) and url.strip()
+        ]
+        if normalized_pic_list:
+            if _prepared_pic_list is None:
+                prepared_pic_list = await self._prepare_pic_list(normalized_pic_list)
+                if not prepared_pic_list:
+                    logger.error(
+                        f"【{self.account_id}】卡券凭证图片上传失败，停止确认发货,订单ID: {order_id}"
+                    )
+                    return {
+                        "error": "卡券凭证图片上传失败，未调用确认发货接口",
+                        "order_id": order_id,
+                    }
+                normalized_pic_list = prepared_pic_list
+            else:
+                normalized_pic_list = [
+                    str(url).strip()
+                    for url in _prepared_pic_list
+                    if isinstance(url, str) and url.strip()
+                ]
+        if normalized_trade_text or normalized_pic_list:
             data_val = json.dumps(
                 {
                     "orderId": order_id,
                     "tradeText": normalized_trade_text,
-                    "picList": [],
+                    "picList": normalized_pic_list,
                     "newUnconsign": True,
                 },
                 ensure_ascii=False,
@@ -143,7 +173,12 @@ class ConfirmShippingService(BaseShippingService):
                     
                     # 重试
                     return await self.auto_confirm(
-                        order_id, item_id, retry_count + 1, trade_text=normalized_trade_text
+                        order_id,
+                        item_id,
+                        retry_count + 1,
+                        trade_text=normalized_trade_text,
+                        pic_list=normalized_pic_list,
+                        _prepared_pic_list=normalized_pic_list,
                     )
 
         except Exception as e:
@@ -154,10 +189,70 @@ class ConfirmShippingService(BaseShippingService):
             if retry_count < 2:
                 logger.info(f"【{self.account_id}】网络异常,准备重试...")
                 return await self.auto_confirm(
-                    order_id, item_id, retry_count + 1, trade_text=normalized_trade_text
+                    order_id,
+                    item_id,
+                    retry_count + 1,
+                    trade_text=normalized_trade_text,
+                    pic_list=normalized_pic_list,
+                    _prepared_pic_list=normalized_pic_list,
                 )
 
             return {"error": f"网络异常: {self._safe_str(e)}", "order_id": order_id}
+
+    async def _prepare_pic_list(self, pic_list: list[str]) -> Optional[list[str]]:
+        """Convert card image references into Goofish CDN URLs for picList."""
+        prepared_urls: list[str] = []
+        uploader = ImageUploader(self.cookies_str)
+
+        try:
+            async with uploader:
+                for original_url in pic_list:
+                    original_url = str(original_url).strip()
+                    logger.info(
+                        f"【{self.account_id}】发货凭证原始图片 URL: {original_url}"
+                    )
+
+                    local_path = self._resolve_local_image_path(original_url)
+                    if local_path:
+                        cdn_url = await uploader.upload_image(local_path)
+                    else:
+                        cdn_url = await uploader.upload_image_url(original_url)
+
+                    if not cdn_url:
+                        logger.error(
+                            f"【{self.account_id}】发货凭证图片上传失败，原始 URL: {original_url}"
+                        )
+                        return None
+
+                    logger.info(
+                        f"【{self.account_id}】发货凭证图片上传后的 CDN URL: {cdn_url}"
+                    )
+                    prepared_urls.append(cdn_url)
+        except Exception as e:
+            logger.error(f"【{self.account_id}】准备发货凭证图片异常: {self._safe_str(e)}")
+            return None
+
+        return prepared_urls
+
+    @staticmethod
+    def _resolve_local_image_path(image_url: str) -> Optional[str]:
+        """Resolve v2 card references saved under backend-web/static."""
+        if os.path.isfile(image_url):
+            return image_url
+        if not image_url.startswith(('/static/uploads/', 'static/uploads/')):
+            return None
+
+        static_dir = os.environ.get('STATIC_DIR', '')
+        if static_dir:
+            static_root = Path(static_dir)
+            if not static_root.is_absolute():
+                static_root = Path.cwd() / static_root
+        else:
+            static_root = Path(__file__).resolve().parents[4] / 'backend-web' / 'static'
+
+        relative_path = image_url.lstrip('/').replace('static/', '', 1)
+        local_path = static_root / relative_path
+        return str(local_path) if local_path.is_file() else None
 
     def _build_headers(self) -> Dict[str, str]:
         """构建请求头

--- a/websocket/app/services/xianyu/auto_delivery_handler.py
+++ b/websocket/app/services/xianyu/auto_delivery_handler.py
@@ -1362,6 +1362,8 @@ class AutoDeliveryHandler:
                     form_delivery_content = None  # 无需邮寄表单成功时记录凭证，但不发送聊天消息
                     # 对接卡券退化标记：多数量循环里若第 1 张匹配到对接卡券，强制 break 退化为 1 张
                     # 规避底层 _create_agent_order + settlement_service 在 N 次调用时引发的金额 bug
+                    shipping_proof_trade_text = None
+                    shipping_proof_pic_list = None
                     quantity_degraded_for_dock = False
                     # 固定内容类型（text/image）退化标记：循环 N 次只是把同一段话/同一张图重复发 N 次，
                     # 业务上无意义且会打扰买家。商家若需要多数量真正发不同内容，应使用 data 或 api 类型卡券
@@ -1386,6 +1388,10 @@ class AutoDeliveryHandler:
                                 delivery_content = delivery_result.get('content')
                                 if delivery_result.get('form_only_delivered'):
                                     form_delivery_content = delivery_content
+                                if delivery_result.get('confirm_trade_text') is not None:
+                                    shipping_proof_trade_text = delivery_result.get('confirm_trade_text')
+                                if delivery_result.get('confirm_pic_list') is not None:
+                                    shipping_proof_pic_list = delivery_result.get('confirm_pic_list')
                                 platform_shipping_confirmed = (
                                     platform_shipping_confirmed
                                     or bool(delivery_result.get('platform_shipping_confirmed'))
@@ -1660,7 +1666,12 @@ class AutoDeliveryHandler:
                         if send_before_confirm_active and not any_send_failed and not card_intercept_reason:
                             logger.info(f'[{msg_time}] 【{self.cookie_id}】卡券发送成功，开始执行确认发货: order_id={order_id}')
                             if self.is_auto_confirm_enabled():
-                                confirm_result = await self.auto_confirm(order_id, item_id)
+                                confirm_result = await self.auto_confirm(
+                                    order_id,
+                                    item_id,
+                                    trade_text=shipping_proof_trade_text,
+                                    pic_list=shipping_proof_pic_list,
+                                )
                                 if confirm_result.get('skipped_only_send_card'):
                                     only_send_card_mode = True
                                     skip_shipping_confirm = True
@@ -1940,7 +1951,15 @@ class AutoDeliveryHandler:
 
     # ==================== 确认发货 ====================
 
-    async def auto_confirm(self, order_id, item_id=None, retry_count=0, trade_text=None, force: bool = False):
+    async def auto_confirm(
+        self,
+        order_id,
+        item_id=None,
+        retry_count=0,
+        trade_text=None,
+        pic_list=None,
+        force: bool = False,
+    ):
         """自动确认发货 - 使用重构后的确认发货服务
 
         force=True 用于「同意后发货」买家在提货页点击「同意」后的显式发货动作：
@@ -1988,7 +2007,11 @@ class AutoDeliveryHandler:
                 
                 # 调用确认方法
                 result = await confirm_service.auto_confirm(
-                    order_id, item_id, retry_count, trade_text=trade_text
+                    order_id,
+                    item_id,
+                    retry_count,
+                    trade_text=trade_text,
+                    pic_list=pic_list,
                 )
                 
                 # 同步更新后的cookies
@@ -2311,9 +2334,33 @@ class AutoDeliveryHandler:
 
             use_no_logistics_form = rule.get('use_no_logistics_form', False)
             form_trade_text = str(rule.get('card_text_content') or '').strip()
+            if rule.get('card_type') == 'image':
+                # 图片卡券的备注对应平台无需寄件表单的 tradeText；图片
+                # 内容单独通过 form_pic_list 作为发货凭证提交。
+                form_trade_text = str(rule.get('card_description') or '').strip()
+            raw_form_pic_list = rule.get('card_image_urls') or []
+            if isinstance(raw_form_pic_list, str):
+                try:
+                    raw_form_pic_list = json.loads(raw_form_pic_list)
+                except (TypeError, json.JSONDecodeError):
+                    raw_form_pic_list = [raw_form_pic_list]
+            form_pic_list = [
+                url.strip()
+                for url in (raw_form_pic_list if isinstance(raw_form_pic_list, (list, tuple)) else [])
+                if isinstance(url, str) and url.strip()
+            ]
+            single_form_pic = str(rule.get('card_image_url') or '').strip()
+            if single_form_pic and single_form_pic not in form_pic_list:
+                form_pic_list.append(single_form_pic)
             if use_no_logistics_form:
-                if rule['card_type'] != 'text' or not form_trade_text:
+                if rule['card_type'] == 'text' and not form_trade_text:
                     self._last_delivery_fail_reason = "无需邮寄表单发货仅支持非空的固定文字卡券"
+                    return None
+                if rule['card_type'] == 'image' and not form_pic_list:
+                    self._last_delivery_fail_reason = "无需邮寄表单发货的图片卡券必须至少配置一张凭证图片"
+                    return None
+                if rule['card_type'] not in ('text', 'image'):
+                    self._last_delivery_fail_reason = "无需邮寄表单发货仅支持固定文字或图片卡券"
                     return None
                 if not order_id or skip_confirm or not self.is_auto_confirm_enabled():
                     self._last_delivery_fail_reason = "无需邮寄表单发货需要订单ID并开启自动确认发货"
@@ -2331,8 +2378,7 @@ class AutoDeliveryHandler:
             # 由外层 _handle_auto_delivery 在卡券发送成功后再执行确认发货。
             # 前提：自动确认发货必须开启，否则整个发货流程都不应执行。
             send_before_confirm_mode = (
-                not use_no_logistics_form
-                and not skip_confirm
+                not skip_confirm
                 and self.is_send_before_confirm_enabled()
             )
             if send_before_confirm_mode and order_id:
@@ -2365,6 +2411,7 @@ class AutoDeliveryHandler:
                         if current_time - last_confirm_time < self.order_confirm_cooldown:
                             logger.info(f"订单 {order_id} 已在 {self.order_confirm_cooldown} 秒内确认过，跳过重复确认")
                             should_confirm = False
+                            platform_shipping_confirmed = True
 
                     if should_confirm:
                         logger.info(f"开始自动确认发货: 订单ID={order_id}, 商品ID={item_id}")
@@ -2372,6 +2419,7 @@ class AutoDeliveryHandler:
                             order_id,
                             item_id,
                             trade_text=form_trade_text if use_no_logistics_form else None,
+                            pic_list=form_pic_list if use_no_logistics_form else None,
                         )
                         if confirm_result.get('skipped_only_send_card'):
                             if use_no_logistics_form:
@@ -2431,6 +2479,10 @@ class AutoDeliveryHandler:
                                 return None
 
             # 检查是否存在订单ID，只有存在订单ID才处理发货内容
+            if use_no_logistics_form and not platform_shipping_confirmed and not send_before_confirm_mode:
+                self._last_delivery_fail_reason = "无需邮寄表单发货未获得平台确认结果"
+                return None
+
             if order_id:
                 # 保存订单基本信息到数据库（如果还没有详细信息）
                 try:
@@ -2508,7 +2560,17 @@ class AutoDeliveryHandler:
                     text_content = None
 
                 # 检查是否有图片需要发送（所有卡券类型都可以配置图片）
-                image_urls = rule.get('card_image_urls') or []
+                raw_image_urls = rule.get('card_image_urls') or []
+                if isinstance(raw_image_urls, str):
+                    try:
+                        raw_image_urls = json.loads(raw_image_urls)
+                    except (TypeError, json.JSONDecodeError):
+                        raw_image_urls = [raw_image_urls]
+                image_urls = [
+                    url.strip()
+                    for url in (raw_image_urls if isinstance(raw_image_urls, (list, tuple)) else [])
+                    if isinstance(url, str) and url.strip()
+                ]
                 single_image_url = rule.get('card_image_url')
                 card_description = rule.get('card_description', '')
 
@@ -2583,7 +2645,7 @@ class AutoDeliveryHandler:
                     logger.warning(f"卡券没有配置图片和文字内容: 卡券ID={rule['card_id']}")
                     delivery_content = None
 
-                if use_no_logistics_form:
+                if use_no_logistics_form and form_trade_text and not send_before_confirm_mode:
                     delivery_content = form_trade_text
 
                 if delivery_content:
@@ -2609,7 +2671,9 @@ class AutoDeliveryHandler:
                         'content': delivery_content,
                         'platform_shipping_confirmed': platform_shipping_confirmed,
                         'skipped_only_send_card': skipped_only_send_card,
-                        'form_only_delivered': use_no_logistics_form,
+                        'form_only_delivered': use_no_logistics_form and platform_shipping_confirmed,
+                        'confirm_trade_text': form_trade_text if use_no_logistics_form else None,
+                        'confirm_pic_list': form_pic_list if use_no_logistics_form else None,
                     }
                 else:
                     self._last_delivery_fail_reason = f"获取发货内容失败: 卡券ID={rule['card_id']}, 卡券名称={rule.get('card_name')}, 类型={rule.get('card_type')}"


### PR DESCRIPTION
## 问题

原作者原有代码在卡券发货时，没有将卡券图片带入闲鱼发货凭证，也没有将卡券备注带入确认发货请求。

## 修改

本次新增卡券发货凭证和备注功能：

- 卡券发货前，将卡券图片下载并上传至闲鱼 CDN。
- 将上传后的图片地址写入确认发货请求的 `picList`，作为发货凭证。
- 将卡券备注 `card.description` 写入确认发货请求的 `tradeText`。
- 卡券正文 `text_content` 不写入平台发货凭证。
- 支持“先发送卡券，再确认发货”模式，在后置确认发货时继续携带图片和备注。
- 图片上传失败时停止确认发货，避免提交不带凭证的发货请求。

## 兼容性

- 图片卡券启用“无需寄件”发货时，至少需要配置一张卡券图片。
- 固定文字卡券仍按原有 `tradeText` 流程处理。
- 未启用“无需寄件”发货的卡券继续沿用原聊天发货流程。
- 本 PR 不包含任何卡券正文、Cookie、Token 或其他敏感数据。

## 验证

- `python -m compileall -q` 检查全部修改模块通过。
- `git diff --check` 通过。
- 已通过真实订单人工验证：手机端确认发货记录同时显示卡券图片凭证和备注。