### PR TITLE
fix: correct shipping flags, titles, and account switch UI

### DIFF
--- a/backend-web/app/services/xianyu_item_edit_mapper.py
+++ b/backend-web/app/services/xianyu_item_edit_mapper.py
@@ -23,6 +23,7 @@ from loguru import logger
 
 from app.services.xianyu_direct_payload import text as _text
 from app.services.xianyu_item_snapshot import (
+    as_bool,
     as_int,
     shipping_method_from_post_fee,
 )
@@ -341,7 +342,8 @@ def map_edit_detail_to_form(detail: dict[str, Any]) -> dict[str, Any]:
         "address_expected_text": _text(addr_dto.get("poiName")),
         "shipping_method": shipping_method,
         "postage": round(as_int(post_fee.get("postPriceInCent")) / 100, 2),
-        "support_pickup": shipping_method == "none",
+        # onlyTakeSelf 是「支持自提」独立开关，不能由发货方式推断。
+        "support_pickup": as_bool(post_fee.get("onlyTakeSelf")),
         "delivery_method": "express",
         "condition": condition,
         "brand": brand,

--- a/backend-web/app/services/xianyu_item_payload_builder.py
+++ b/backend-web/app/services/xianyu_item_payload_builder.py
@@ -24,6 +24,7 @@ from app.services.xianyu_direct_payload import (
     text as _text,
 )
 from app.services.xianyu_item_snapshot import (
+    as_bool,
     as_int,
     normalize_snapshot_post_fee,
     snapshot_address_if_unchanged,
@@ -167,12 +168,13 @@ def _build_attribute_labels(item_data: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _build_post_fee(item_data: dict[str, Any]) -> dict[str, bool]:
-    """转换已由抓包确认的包邮和仅自提发货方式。"""
+    """构造发货方式与「支持自提」分离的运费载荷。"""
     shipping_method = _text(item_data.get("shipping_method")) or "free"
+    only_take_self = as_bool(item_data.get("support_pickup"))
     if shipping_method == "free":
-        return {"canFreeShipping": True, "supportFreight": True, "onlyTakeSelf": False}
+        return {"canFreeShipping": True, "supportFreight": True, "onlyTakeSelf": only_take_self}
     if shipping_method == "none":
-        return {"canFreeShipping": False, "supportFreight": False, "onlyTakeSelf": True}
+        return {"canFreeShipping": False, "supportFreight": False, "onlyTakeSelf": only_take_self}
     raise DirectPublishError("当前接口抓包未包含非包邮运费载荷，请改为包邮或无需邮寄后发布")
 
 
@@ -417,7 +419,8 @@ async def build_item_payload(
         "quantity": "1" if is_multi_spec else _resolve_quantity(item_data),
         "simpleItem": "true",
         "imageInfoDOList": video_items + image_items,
-        "itemTextDTO": {"desc": description, "title": title, "titleDescSeparate": False},
+        # True 才会让平台分别使用 title 和 desc；False 时平台会忽略 title，按正文拆标题。
+        "itemTextDTO": {"desc": description, "title": title, "titleDescSeparate": True},
         "itemLabelExtList": labels,
         "itemProperties": item_properties,
         "userRightsProtocols": _resolve_user_rights(snapshot),

--- a/backend-web/app/services/xianyu_item_snapshot.py
+++ b/backend-web/app/services/xianyu_item_snapshot.py
@@ -101,7 +101,12 @@ def shipping_method_from_post_fee(post_fee: Any) -> str:
     """
     if not isinstance(post_fee, dict):
         return "free"
-    if as_bool(post_fee.get("onlyTakeSelf")):
+    # 「支持自提」是独立开关，不能用 onlyTakeSelf 判断「无需邮寄」。
+    # 平台的「无需邮寄」实际由 supportFreight=false 表示；包邮即使支持自提，
+    # canFreeShipping 仍然为 true，必须继续回填为 free。
+    if as_bool(post_fee.get("canFreeShipping")):
+        return "free"
+    if "supportFreight" in post_fee and not as_bool(post_fee.get("supportFreight")):
         return "none"
     template_id = _text(post_fee.get("templateId")) or _text(post_fee.get("idleTemplateId"))
     if template_id and template_id != "0":
@@ -130,6 +135,8 @@ def snapshot_post_fee_unchanged(item_data: dict[str, Any], snapshot_post_fee: An
         form_postage = int(round(float(item_data.get("postage") or 0) * 100))
     except (TypeError, ValueError):
         form_postage = 0
+    if as_bool(snapshot_post_fee.get("onlyTakeSelf")) != as_bool(item_data.get("support_pickup")):
+        return False
     return as_int(snapshot_post_fee.get("postPriceInCent")) == form_postage
 
 

--- a/backend-web/app/services/xianyu_personal_publisher.py
+++ b/backend-web/app/services/xianyu_personal_publisher.py
@@ -23,6 +23,7 @@ from app.services.xianyu_direct_payload import (
     text,
 )
 from app.services.xianyu_item_payload_builder import _build_attribute_labels, _resolve_item_address
+from app.services.xianyu_item_snapshot import as_bool
 from common.services.xianyu_mtop import mtop_call
 from common.services.xianyu_publish_media import PublishMediaError, upload_publish_image
 from common.services.xianyu_publish_video import PublishVideoError, upload_publish_videos
@@ -37,7 +38,7 @@ PUBLISH_REFERER = "https://www.goofish.com/publish"
 def _build_personal_post_fee(item_data: dict[str, Any]) -> dict[str, Any]:
     """按普通卖家网页发布组件的字段规则构造发货配置。"""
     shipping_method = text(item_data.get("shipping_method")) or "free"
-    only_take_self = bool(item_data.get("support_pickup"))
+    only_take_self = as_bool(item_data.get("support_pickup"))
     if shipping_method == "free":
         return {"canFreeShipping": True, "supportFreight": True, "onlyTakeSelf": only_take_self}
     if shipping_method == "distance":
@@ -156,7 +157,8 @@ class XianyuPersonalPublisher:
             "quantity": "1",
             "simpleItem": "true",
             "imageInfoDOList": video_items + image_items,
-            "itemTextDTO": {"desc": description, "title": title, "titleDescSeparate": False},
+            # True 才会让平台分别使用 title 和 desc；False 时平台会忽略 title，按正文拆标题。
+            "itemTextDTO": {"desc": description, "title": title, "titleDescSeparate": True},
             "itemLabelExtList": labels,
             "itemPriceDTO": {
                 "origPriceInCent": price_in_cent(

--- a/backend-web/app/services/xianyu_publisher.py
+++ b/backend-web/app/services/xianyu_publisher.py
@@ -23,6 +23,7 @@ from loguru import logger
 from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 from common.utils.browser_utils import ensure_playwright_browser_path, get_chromium_executable_path
 from common.services.publish_image_service import cleanup_temp_images, download_remote_image
+from app.services.xianyu_item_snapshot import as_bool
 
 
 class XianyuPublisher:
@@ -1729,12 +1730,47 @@ class XianyuPublisher:
                 except Exception:
                     continue
 
-        if item_data.get("support_pickup"):
+        # 闲鱼页面的「支持自提」默认状态可能是开启的，不能只在 True 时点击，
+        # 否则用户传 False 时会把页面默认值原样提交出去。
+        expected_pickup = as_bool(item_data.get("support_pickup"))
+        pickup_text = self.page.get_by_text("支持自提", exact=True).last
+        pickup_control = None
+        if await pickup_text.count() > 0:
+            # 文案与开关在不同版本页面中可能是父子节点或兄弟节点，逐级查找控件。
+            for level in range(1, 5):
+                container = pickup_text.locator("xpath=" + "/.." * level)
+                candidate = container.locator(
+                    'input[type="checkbox"], button[role="switch"], [role="switch"]'
+                ).last
+                try:
+                    if await candidate.count() > 0 and await candidate.is_visible():
+                        pickup_control = candidate
+                        break
+                except Exception:
+                    continue
+
+        if pickup_control is not None:
+            try:
+                tag_name = await pickup_control.evaluate("el => el.tagName")
+                if tag_name == "INPUT":
+                    current_pickup = await pickup_control.is_checked()
+                else:
+                    aria_checked = await pickup_control.get_attribute("aria-checked")
+                    class_name = await pickup_control.get_attribute("class") or ""
+                    current_pickup = aria_checked == "true" or "ant-switch-checked" in class_name
+                if current_pickup != expected_pickup:
+                    await pickup_control.click()
+                logger.info(f"✅ 支持自提状态：{'开启' if expected_pickup else '关闭'}")
+            except Exception as exc:
+                logger.warning(f"⚠️ 未能核验支持自提开关状态: {exc}")
+        elif expected_pickup:
+            # 只有在明确需要开启时才使用旧版兜底点击，避免 False 时误切换。
             for selector in ['label:has-text("支持自提")', 'button:has-text("支持自提")', 'text=支持自提']:
                 try:
                     element = await self.page.query_selector(selector)
                     if element and await element.is_visible():
                         await element.click()
+                        logger.info("✅ 已开启支持自提（兼容旧版页面）")
                         break
                 except Exception:
                     continue

--- a/frontend/src/pages/accounts/Accounts.tsx
+++ b/frontend/src/pages/accounts/Accounts.tsx
@@ -2335,7 +2335,7 @@ export function Accounts() {
                   <th className="whitespace-nowrap min-w-[120px]">状态</th>
                   <th className="whitespace-nowrap min-w-[90px]">在线状态</th>
                   <th className="whitespace-nowrap min-w-[90px]">配置密码</th>
-                  <th className="whitespace-nowrap min-w-[620px]">功能开关</th>
+                  <th className="whitespace-nowrap min-w-[340px]">功能开关</th>
                   <th className="whitespace-nowrap min-w-[90px]">暂停时间</th>
                   <th className="whitespace-nowrap min-w-[160px] sticky right-0 bg-slate-50 dark:bg-slate-800 z-20">操作</th>
                 </tr>
@@ -2431,132 +2431,132 @@ export function Accounts() {
                         {/* AI回复 */}
                         <button
                           onClick={() => handleToggleAI(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.aiEnabled
                               ? 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-300 dark:hover:bg-purple-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="AI回复"
                           title={`AI回复：${account.aiEnabled ? '已开启（点击关闭）' : '已关闭（点击开启）'}`}
                         >
                           <Bot className="w-3.5 h-3.5" />
-                          <span>AI回复</span>
                         </button>
                         {/* 定时补发货 */}
                         <button
                           onClick={() => handleToggleScheduledRedelivery(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.scheduled_redelivery
                               ? 'bg-teal-100 text-teal-700 hover:bg-teal-200 dark:bg-teal-900/30 dark:text-teal-300 dark:hover:bg-teal-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="定时补发货"
                           title={`定时补发货：${account.scheduled_redelivery ? '已开启（点击关闭）' : '已关闭（点击开启）'}`}
                         >
                           <Repeat className="w-3.5 h-3.5" />
-                          <span>补发货</span>
                         </button>
                         {/* 定时补评价 */}
                         <button
                           onClick={() => handleToggleScheduledRate(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.scheduled_rate
                               ? 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:hover:bg-amber-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="定时补评价"
                           title={`定时补评价：${account.scheduled_rate ? '已开启（点击关闭）' : '已关闭（点击开启）'}`}
                         >
                           <Star className="w-3.5 h-3.5" />
-                          <span>补评价</span>
                         </button>
                         {/* 商品擦亮 */}
                         <button
                           onClick={() => handleToggleAutoPolish(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.auto_polish
                               ? 'bg-fuchsia-100 text-fuchsia-700 hover:bg-fuchsia-200 dark:bg-fuchsia-900/30 dark:text-fuchsia-300 dark:hover:bg-fuchsia-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="商品自动擦亮"
                           title={`商品自动擦亮：${account.auto_polish ? '已开启（点击关闭）' : '已关闭（点击开启）'}`}
                         >
                           <RefreshCw className="w-3.5 h-3.5" />
-                          <span>擦亮</span>
                         </button>
                         {/* 自动确认发货 */}
                         <button
                           onClick={() => handleToggleAutoConfirm(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.auto_confirm
                               ? 'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-300 dark:hover:bg-green-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="自动确认发货"
                           title={`自动确认发货：${account.auto_confirm ? '已开启（点击关闭）' : '已关闭（点击开启，开启后会关闭“只发卡券不确认发货”）'}`}
                         >
                           <PackageCheck className="w-3.5 h-3.5" />
-                          <span>确认发货</span>
                         </button>
                         {/* 发货成功再发卡券 */}
                         <button
                           onClick={() => handleToggleConfirmBeforeSend(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.confirm_before_send
                               ? 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-300 dark:hover:bg-cyan-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="发货成功再发卡券"
                           title={`发货成功再发卡券：${account.confirm_before_send ? '已开启（点击关闭）' : '已关闭（点击开启，开启后确认发货失败将不发送卡券）'}`}
                         >
                           <ShieldCheck className="w-3.5 h-3.5" />
-                          <span>先发货后发卡</span>
                         </button>
                         {/* 卡券发送成功再确认发货 */}
                         <button
                           onClick={() => handleToggleSendBeforeConfirm(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.send_before_confirm
                               ? 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:hover:bg-amber-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="卡券发送成功再确认发货"
                           title={`卡券发送成功再确认发货：${account.send_before_confirm ? '已开启（点击关闭）' : '已关闭（点击开启，开启后先发卡券，发送成功后再确认发货）'}`}
                         >
                           <Send className="w-3.5 h-3.5" />
-                          <span>先发卡后发货</span>
                         </button>
                         {/* 只发卡券不确认发货 */}
                         <button
                           onClick={() => handleToggleOnlySendCard(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.only_send_card
                               ? 'bg-orange-100 text-orange-700 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:hover:bg-orange-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="只发卡券不确认发货"
                           title={`只发卡券不确认发货：${account.only_send_card ? '已开启（点击关闭，当前所有发货仅发送卡券）' : '已关闭（点击开启，开启后会关闭自动确认发货，并跳过确认发货和免拼接口）'}`}
                         >
                           <Ticket className="w-3.5 h-3.5" />
-                          <span>只发卡券</span>
                         </button>
                         {/* 自动求小红花 */}
                         <button
                           onClick={() => handleToggleAutoRedFlower(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.auto_red_flower
                               ? 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-300 dark:hover:bg-pink-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="自动求小红花"
                           title={`自动求小红花：${account.auto_red_flower ? '已开启（点击关闭）' : '已关闭（点击开启）'}`}
                         >
                           <Flower2 className="w-3.5 h-3.5" />
-                          <span>求小红花</span>
                         </button>
                         {/* 已下单用户禁止AI回复 */}
                         <button
                           onClick={() => handleToggleAiReplyBlockOrderedUsers(account)}
-                          className={`inline-flex items-center gap-1 px-2 h-7 rounded text-xs whitespace-nowrap transition-colors ${
+                          className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
                             account.ai_reply_block_ordered_users
                               ? 'bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/50'
                               : 'bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-600'
                           }`}
+                          aria-label="已下单用户禁止AI回复"
                           title={`已下单用户禁止AI回复：${account.ai_reply_block_ordered_users ? '已开启（点击关闭）对已下单用户不使用AI回复' : '已关闭（点击开启）'}`}
                         >
                           <Ban className="w-3.5 h-3.5" />
-                          <span>已购禁AI</span>
                         </button>
                       </div>
                     </td>


### PR DESCRIPTION
## 修复内容

这个 PR 合并了 3 项已验证的修复：

1. **修复「无需邮寄」误带「支持自提」**（Fixes #314）
   - `shipping_method=none` 不再强制写入 `onlyTakeSelf=true`。
   - `support_pickup` 与平台的 `onlyTakeSelf` 独立对应。
   - 编辑回填、快照比较、普通卖家发布、浏览器发布流程统一按实际开关状态处理。

2. **修复独立标题被正文第一行覆盖**
   - 两个发布接口的 `itemTextDTO.titleDescSeparate` 改为 `true`。
   - 平台会分别使用 `title` 和 `desc`，不再把正文第一行当作商品标题。

3. **修复账号管理功能开关区域过宽**
   - 功能开关恢复为紧凑的纯图标按钮。
   - 列宽从 `620px` 调整为 `340px`。
   - 增加 `aria-label`，保留 hover 说明，不影响操作识别。

## 验证

- 5 个 Python 修改文件已通过 `py_compile` 语法检查。
- 运行中的后端容器健康检查通过，发布载荷的四种运费/自提组合已验证。
- 前端部署后账号管理页面已确认恢复为纯图标按钮。
- 未执行真实商品发布。
- 本地前端 `npm run build` 未能启动，原因是当前工作区缺少 `tsc` 依赖（`tsc: not found`），不是代码编译错误。

本 PR 不包含任何 Key、Cookie、密码或其他凭证。
