### PR TITLE
feat(mobile): 闲鱼管家 v1.0.8 修复假功能 + 补齐 web 端缺失功能

### DIFF
--- a/xianyu-mobile/api/wrappers/accounts.ts
+++ b/xianyu-mobile/api/wrappers/accounts.ts
@@ -294,6 +294,82 @@ export async function importAccounts(fileUri: string): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// 手动添加账号 + AI 模型在线拉取
+// ---------------------------------------------------------------------------
+
+/**
+ * 手动粘贴 Cookie 添加账号。
+ * 后端 body 为 AccountCreate { id, value }：id=账号唯一标识，value=Cookie 原文；
+ * 创建接口不接收备注，备注需添加后通过 updateAccountRemark 单独设置。
+ * 注意：后端对"账号已存在"等业务失败仍返回 200 + { success: false }，需透传给调用方。
+ */
+export async function createAccountByCookie(
+  accountId: string,
+  cookie: string,
+): Promise<{ success: boolean; message?: string }> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.POST as any)('/api/v1/cookies', {
+    body: { id: accountId, value: cookie },
+  })) as {
+    data?: { success?: boolean; message?: string };
+    error?: unknown;
+  };
+  if (error) throw await extractError(error);
+  return { success: data?.success ?? true, message: data?.message };
+}
+
+/** AI 模型选项（后端 normalize_model_options 输出 { id, name }） */
+export interface AiModelOption {
+  id: string;
+  name: string;
+}
+
+/** 在线拉取 AI 模型列表（POST /api/v1/ai-reply-settings/models）。
+ *  dashscope_app 不支持自动获取；失败时后端返回 success=false + 空列表。 */
+export async function fetchAiModels(params: {
+  provider_type: string;
+  base_url: string;
+  api_key: string;
+}): Promise<{ success: boolean; message?: string; models: AiModelOption[] }> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.POST as any)(
+    '/api/v1/ai-reply-settings/models',
+    { body: params },
+  )) as {
+    data?: { success?: boolean; message?: string; models?: unknown };
+    error?: unknown;
+  };
+  if (error) throw await extractError(error);
+  const body = data ?? {};
+  const raw = (body as { models?: unknown }).models;
+  const models: AiModelOption[] = Array.isArray(raw)
+    ? raw
+        .map((m): AiModelOption | null => {
+          if (typeof m === 'string') {
+            const id = m.trim();
+            return id ? { id, name: id } : null;
+          }
+          if (m && typeof m === 'object') {
+            const o = m as Record<string, unknown>;
+            const id = String(o.id ?? o.name ?? o.model ?? '').trim();
+            if (!id) return null;
+            const name = String(
+              o.display_name ?? o.displayName ?? o.name ?? id,
+            ).trim();
+            return { id, name: name || id };
+          }
+          return null;
+        })
+        .filter((m): m is AiModelOption => m != null)
+    : [];
+  return {
+    success: (body as { success?: boolean }).success ?? true,
+    message: (body as { message?: string }).message,
+    models,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // 默认回复设置（每个闲鱼账号独立配置）
 // 后端路由前缀: /api/v1/default-replies
 // ---------------------------------------------------------------------------

--- a/xianyu-mobile/api/wrappers/admin.ts
+++ b/xianyu-mobile/api/wrappers/admin.ts
@@ -96,15 +96,25 @@ function parseList<T>(
   return { items, total: typeof total === 'number' ? total : items.length };
 }
 
-/** 获取用户列表（管理员） */
-export async function getAdminUsers(): Promise<AdminUser[]> {
+/**
+ * 获取用户列表（管理员）。
+ * 后端返回 `{ users: [...], success, total, limit, offset }`（admin.py list_users），
+ * 用户数组在 users 键而非 data 键。
+ * @param username 用户名筛选（模糊匹配，后端 username query 参数）
+ */
+export async function getAdminUsers(username?: string): Promise<AdminUser[]> {
   const client = await getApiClient();
-  const { data } = (await (client.GET as any)('/api/v1/admin/users')) as {
-    data?: unknown;
-    error?: unknown;
-  };
-  const body = unwrapData<unknown>(data);
-  return Array.isArray(body) ? (body as AdminUser[]) : [];
+  const query: Record<string, string | number> = { limit: 100 };
+  if (username && username.trim()) query.username = username.trim();
+  const { data } = (await (client.GET as any)('/api/v1/admin/users', {
+    params: { query },
+  })) as { data?: unknown; error?: unknown };
+  const body = unwrapData<Record<string, unknown>>(data);
+  if (Array.isArray(body?.users)) return body.users as AdminUser[];
+  // 兼容可能的裸数组 / data 包裹形态
+  if (Array.isArray(body)) return body as AdminUser[];
+  if (Array.isArray(body?.data)) return body.data as AdminUser[];
+  return [];
 }
 
 /** 创建用户（管理员） */
@@ -146,50 +156,98 @@ export async function rechargeUser(
   });
 }
 
-/** 获取管理员日志（分页） */
-export async function getAdminLogs(
-  page: number,
-  pageSize: number,
-): Promise<{ data: LogEntry[]; total: number }> {
+/**
+ * 获取系统日志（后端 GET /api/v1/admin/logs 实为 logs/*.log 的 tail）。
+ * query 为 lines（1-1000）/level，返回 `{ success, logs: ["字符串", ...], total }`，
+ * 不是分页的 { data: [LogEntry] } 结构。
+ * 每行解析行首时间戳与日志级别；无时间戳的行（如堆栈续行）沿用上一行时间以便排序后保持相邻，
+ * 最后按时间倒序返回（最新在前）。
+ */
+export async function getAdminLogs(lines = 500): Promise<LogEntry[]> {
   const client = await getApiClient();
   const { data } = (await (client.GET as any)('/api/v1/admin/logs', {
-    params: { query: { page, page_size: pageSize } },
+    params: { query: { lines } },
   })) as { data?: unknown; error?: unknown };
-  const body = unwrapData<unknown>(data);
-  if (body && typeof body === 'object' && 'data' in body) {
-    const obj = body as { data?: unknown; total?: number };
-    const arr = Array.isArray(obj.data) ? (obj.data as LogEntry[]) : [];
-    return { data: arr, total: obj.total ?? arr.length };
-  }
-  if (Array.isArray(body)) {
-    return { data: body as LogEntry[], total: body.length };
-  }
-  return { data: [], total: 0 };
+  const body = (data ?? {}) as Record<string, unknown>;
+  const arr = Array.isArray(body.logs) ? (body.logs as unknown[]) : [];
+  let seq = 0;
+  let lastTs = '';
+  const entries = arr.map((raw) => {
+    const line = String(raw ?? '');
+    const tsMatch = line.match(/^(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2})/);
+    if (tsMatch) lastTs = tsMatch[1].replace('T', ' ');
+    const levelMatch = line.match(
+      /\|\s*(TRACE|DEBUG|INFO|SUCCESS|WARNING|WARN|ERROR|CRITICAL)\s*\|/,
+    );
+    return {
+      id: seq++,
+      type: levelMatch ? levelMatch[1] : undefined,
+      content: line,
+      created_at: lastTs,
+    };
+  });
+  // 字符串时间戳格式统一，字典序即时间序；sort 稳定，同刻保持原相对顺序
+  return entries.sort((a, b) => (a.created_at < b.created_at ? 1 : a.created_at > b.created_at ? -1 : 0));
 }
 
-/** 清除管理员日志 */
-export async function clearAdminLogs(): Promise<void> {
-  const client = await getApiClient();
-  await (client.POST as any)('/api/v1/admin/logs/clear');
+/** 自动回复日志条目：content 取 reply_text，附带关键词与回复策略 */
+export interface AutoReplyLogEntry extends LogEntry {
+  /** 命中的关键词（后端 matched_keyword） */
+  keyword?: string;
+  /** 回复策略（后端 reply_strategy 的中文标签） */
+  strategy?: string;
+  /** 发送状态（success/failed/unknown/timeout） */
+  send_status?: string;
 }
 
-/** 获取自动回复日志（分页） */
-export async function getAutoReplyLogs(page: number): Promise<LogEntry[]> {
+/** 回复策略 → 中文标签（后端 reply_strategy: keyword/ai/default/auto_delivery/none...） */
+function replyStrategyLabel(strategy: unknown): string | undefined {
+  if (strategy == null) return undefined;
+  const s = String(strategy);
+  switch (s) {
+    case 'keyword':
+      return '关键词回复';
+    case 'ai':
+      return 'AI 回复';
+    case 'default':
+      return '默认回复';
+    case 'auto_delivery':
+      return '自动发货';
+    case 'none':
+      return '未匹配';
+    default:
+      return s;
+  }
+}
+
+/** 获取自动回复日志（分页）；后端字段为 keyword/reply_text/reply_strategy/created_at */
+export async function getAutoReplyLogs(page: number): Promise<AutoReplyLogEntry[]> {
   const client = await getApiClient();
   const { data } = (await (client.GET as any)('/api/v1/auto-reply-logs', {
-    params: { query: { page } },
+    params: { query: { page, page_size: 20 } },
   })) as { data?: unknown; error?: unknown };
   const body = unwrapData<unknown>(data);
-  if (Array.isArray(body)) return body as LogEntry[];
-  if (
+  let arr: unknown[] = [];
+  if (Array.isArray(body)) arr = body;
+  else if (
     body &&
     typeof body === 'object' &&
-    'data' in body &&
     Array.isArray((body as { data?: unknown }).data)
   ) {
-    return (body as { data: LogEntry[] }).data;
+    arr = (body as { data: unknown[] }).data;
   }
-  return [];
+  return arr.map((raw) => {
+    const r = (raw ?? {}) as Record<string, unknown>;
+    return {
+      id: Number(r.id ?? 0),
+      type: r.matched_rule_type != null ? String(r.matched_rule_type) : undefined,
+      content: r.reply_text != null ? String(r.reply_text) : '',
+      created_at: r.created_at != null ? String(r.created_at) : '',
+      keyword: r.matched_keyword != null ? String(r.matched_keyword) : undefined,
+      strategy: replyStrategyLabel(r.reply_strategy),
+      send_status: r.send_status != null ? String(r.send_status) : undefined,
+    } as AutoReplyLogEntry;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -547,37 +605,9 @@ export async function testRemoteSliderSolve(
   }
 }
 
-// ==================== 定时任务 ====================
-
-export interface ScheduledTask {
-  id: number;
-  task_code: string;
-  task_name: string;
-  interval_seconds: number;
-  enabled: boolean;
-  description: string | null;
-  task_running: boolean;
-}
-
-export async function getScheduledTasks(): Promise<{ tasks: ScheduledTask[]; schedulerRunning: boolean }> {
-  const client = await getApiClient();
-  const { data } = (await (client.GET as any)('/api/v1/admin/scheduled-tasks')) as { data?: unknown };
-  const body = unwrapData<Record<string, unknown>>(data);
-  const tasks = Array.isArray(body) ? body as ScheduledTask[] : (body as { data?: ScheduledTask[] })?.data ?? [];
-  return { tasks, schedulerRunning: Boolean((body as { scheduler_running?: boolean })?.scheduler_running) };
-}
-
-export async function updateScheduledTask(id: number, params: { interval_seconds?: number; enabled?: boolean }): Promise<void> {
-  const client = await getApiClient();
-  await (client.PUT as any)(`/api/v1/admin/scheduled-tasks/${id}`, { body: params });
-}
-
-export async function triggerScheduledTask(id: number): Promise<void> {
-  const client = await getApiClient();
-  await (client.POST as any)(`/api/v1/admin/scheduled-tasks/${id}/trigger`, { body: {} });
-}
-
 // ==================== 数据管理 ====================
+// 注意：定时任务封装在 api/wrappers/scheduled-tasks.ts（task_code + query 参数），
+// 此处不再提供 id 版定时任务封装，避免与后端契约不符产生 404。
 
 export async function getTableData(tableName: string): Promise<{ rows: Record<string, unknown>[]; count: number; columns: string[] }> {
   const client = await getApiClient();
@@ -588,8 +618,5 @@ export async function getTableData(tableName: string): Promise<{ rows: Record<st
   const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
   return { rows, count, columns };
 }
-
-export async function clearTableData(tableName: string): Promise<void> {
-  const client = await getApiClient();
-  await (client.DELETE as any)(`/api/v1/admin/data/${tableName}`);
-}
+// 后端 DELETE /api/v1/admin/data/{table} 为 501 占位（admin.py clear_table_placeholder），
+// 不提供清空表封装。

--- a/xianyu-mobile/api/wrappers/crawler.ts
+++ b/xianyu-mobile/api/wrappers/crawler.ts
@@ -1,0 +1,276 @@
+import { getApiClient } from './client';
+
+// ---------------------------------------------------------------------------
+// Goofish 定时采集（爬虫定时任务）
+// 后端路由前缀: /api/v1/goofish/crawler（backend-web/app/api/routes/goofish_crawler.py）
+//
+// 说明：distribution.ts 中遗留的 getCrawlerJobs/startCrawler/stopCrawler 不含
+// 创建/删除/立即执行能力，且未解析后端 { jobs: [...] } 包裹。本文件为完整实现，
+// 页面统一迁移到本文件，旧函数保持不动。
+// ---------------------------------------------------------------------------
+
+const PREFIX = '/api/v1/goofish/crawler';
+
+/** 采集任务（后端 GET /jobs 的 list 项，字段见 goofish_crawler.py list_jobs） */
+export interface CrawlerJob {
+  id: number;
+  cookie_id: string;
+  keyword: string;
+  interval_seconds: number;
+  start_page: number;
+  pages: number;
+  page_size: number;
+  fetch_detail: boolean;
+  detail_limit: number;
+  enabled: boolean;
+  running: boolean;
+  last_run_at: string | null;
+  last_error: string | null;
+  item_count: number;
+  latest_item_fetched_at: string | null;
+}
+
+/** 采集结果商品（后端 GET /jobs/{id}/items 的 list 项） */
+export interface CrawlerItem {
+  job_id?: number;
+  item_id: string;
+  title: string;
+  price: string;
+  area: string;
+  seller_name: string;
+  item_url: string;
+  main_image: string;
+  want_count: number | null;
+  view_count: number | null;
+  fetched_at: string;
+}
+
+/** 创建任务入参（对齐后端 GoofishCrawlJobCreate，数值范围由后端校验） */
+export interface CrawlerJobCreateInput {
+  cookie_id: string;
+  keyword: string;
+  /** 执行间隔（秒），60~86400 */
+  interval_seconds: number;
+  /** 起始页码，1~50 */
+  start_page: number;
+  /** 抓取页数，1~10 */
+  pages: number;
+  /** 每页数量，1~50 */
+  page_size: number;
+  fetch_detail: boolean;
+  /** 详情抓取数量限制，0~50 */
+  detail_limit: number;
+  enabled: boolean;
+}
+
+/** 立即执行一次的结果（后端返回 { success, upserted, total, error? }） */
+export interface CrawlerRunOnceResult {
+  success: boolean;
+  upserted: number;
+  total: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// 通用解析工具（与 card-relation.ts 的 unwrapData/assertOk 保持一致）
+// 注意：该路由多数接口返回裸 dict（非 ApiResponse 包裹），需同时兼容两种形态。
+// ---------------------------------------------------------------------------
+
+/** 取出 `{ success, data }` 包裹的内部 data；未包裹则原样返回 */
+function unwrapData<T>(body: unknown): T {
+  if (
+    body &&
+    typeof body === 'object' &&
+    'success' in (body as Record<string, unknown>) &&
+    'data' in (body as Record<string, unknown>)
+  ) {
+    const inner = (body as { data: unknown }).data;
+    if (inner != null) return inner as T;
+  }
+  return body as T;
+}
+
+/** 断言业务成功：body.success === false 时抛出 message（后端业务错误也返回 HTTP 200） */
+function assertOk(body: unknown, fallback = '操作失败'): void {
+  if (
+    body &&
+    typeof body === 'object' &&
+    (body as Record<string, unknown>).success === false
+  ) {
+    const msg = (body as Record<string, unknown>).message;
+    const err = (body as Record<string, unknown>).error;
+    const text = typeof msg === 'string' ? msg : typeof err === 'string' ? err : '';
+    throw new Error(text || fallback);
+  }
+}
+
+function str(val: unknown, fallback = ''): string {
+  if (val == null) return fallback;
+  const s = String(val);
+  return s === 'undefined' || s === 'null' ? fallback : s;
+}
+
+function num(val: unknown, fallback = 0): number {
+  if (val == null || val === '') return fallback;
+  const n = Number(val);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function bool(val: unknown, fallback = false): boolean {
+  if (val == null) return fallback;
+  if (typeof val === 'boolean') return val;
+  if (val === 1 || val === '1' || val === 'true') return true;
+  if (val === 0 || val === '0' || val === 'false') return false;
+  return fallback;
+}
+
+/** 从对象中取名为 keys 之一的数组字段（兼容裸数组） */
+function pickArray(body: unknown, keys: string[]): unknown[] {
+  const inner = unwrapData<unknown>(body);
+  if (Array.isArray(inner)) return inner;
+  if (inner && typeof inner === 'object') {
+    const obj = inner as Record<string, unknown>;
+    for (const k of keys) {
+      if (Array.isArray(obj[k])) return obj[k] as unknown[];
+    }
+  }
+  return [];
+}
+
+function nullableStr(val: unknown): string | null {
+  const s = str(val);
+  return s === '' ? null : s;
+}
+
+function normalizeJob(raw: Record<string, unknown>): CrawlerJob {
+  return {
+    id: num(raw.id ?? raw.job_id),
+    cookie_id: str(raw.cookie_id),
+    keyword: str(raw.keyword),
+    interval_seconds: num(raw.interval_seconds, 900),
+    start_page: num(raw.start_page, 1),
+    pages: num(raw.pages, 1),
+    page_size: num(raw.page_size, 20),
+    fetch_detail: bool(raw.fetch_detail, true),
+    detail_limit: num(raw.detail_limit, 20),
+    enabled: bool(raw.enabled, false),
+    running: bool(raw.running, false),
+    last_run_at: nullableStr(raw.last_run_at),
+    last_error: nullableStr(raw.last_error),
+    item_count: num(raw.item_count ?? raw.items_count, 0),
+    latest_item_fetched_at: nullableStr(raw.latest_item_fetched_at),
+  };
+}
+
+function normalizeItem(raw: Record<string, unknown>): CrawlerItem {
+  return {
+    job_id: raw.job_id != null ? num(raw.job_id) : undefined,
+    item_id: str(raw.item_id ?? raw.id),
+    title: str(raw.title),
+    price: str(raw.price, '0'),
+    area: str(raw.area),
+    seller_name: str(raw.seller_name),
+    item_url: str(raw.item_url),
+    main_image: str(raw.main_image),
+    want_count: raw.want_count != null ? num(raw.want_count) : null,
+    view_count: raw.view_count != null ? num(raw.view_count) : null,
+    fetched_at: str(raw.fetched_at),
+  };
+}
+
+/** 任务列表：GET /jobs → 裸 { jobs: [...] }（失败时后端也返回 { jobs: [] }） */
+export async function getCrawlerJobs(): Promise<CrawlerJob[]> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(`${PREFIX}/jobs`)) as {
+    data?: unknown;
+    error?: unknown;
+  };
+  return pickArray(data, ['jobs', 'items', 'list', 'data']).map((it) =>
+    normalizeJob((it ?? {}) as Record<string, unknown>),
+  );
+}
+
+/**
+ * 创建任务：POST /jobs。
+ * 成功返回 job_id（后端 { success: true, job_id, message }）；业务失败抛错。
+ */
+export async function createCrawlerJob(
+  input: CrawlerJobCreateInput,
+): Promise<number | null> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(`${PREFIX}/jobs`, {
+    body: input,
+  })) as { data?: unknown; error?: unknown };
+  assertOk(data, '创建失败');
+  const inner = unwrapData<Record<string, unknown>>(data);
+  const jobId =
+    inner && typeof inner === 'object'
+      ? (inner as Record<string, unknown>).job_id
+      : null;
+  return jobId != null ? num(jobId) : null;
+}
+
+/** 删除任务（连同采集结果）：DELETE /jobs/{job_id} */
+export async function deleteCrawlerJob(jobId: number): Promise<void> {
+  const client = await getApiClient();
+  const { data } = (await (client.DELETE as any)(`${PREFIX}/jobs/${jobId}`)) as {
+    data?: unknown;
+    error?: unknown;
+  };
+  assertOk(data, '删除失败');
+}
+
+/** 启动任务（enabled=True 并调度）：POST /jobs/{job_id}/start */
+export async function startCrawlerJob(jobId: number): Promise<void> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    `${PREFIX}/jobs/${jobId}/start`,
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data, '启动失败');
+}
+
+/** 停止任务（enabled=False 并取消调度）：POST /jobs/{job_id}/stop */
+export async function stopCrawlerJob(jobId: number): Promise<void> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    `${PREFIX}/jobs/${jobId}/stop`,
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data, '停止失败');
+}
+
+/**
+ * 立即执行一次：POST /jobs/{job_id}/run-once。
+ * 后端同步执行采集（可能耗时较长），返回 { success, upserted, total, error? }。
+ * 注意：该接口无论成败均返回 HTTP 200，业务失败通过返回值 success/error 表达。
+ */
+export async function runCrawlerJobOnce(
+  jobId: number,
+): Promise<CrawlerRunOnceResult> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    `${PREFIX}/jobs/${jobId}/run-once`,
+  )) as { data?: unknown; error?: unknown };
+  const inner = unwrapData<Record<string, unknown>>(data);
+  const body = (inner && typeof inner === 'object' ? inner : {}) as Record<string, unknown>;
+  return {
+    success: bool(body.success, false),
+    upserted: num(body.upserted, 0),
+    total: num(body.total, 0),
+    error: typeof body.error === 'string' ? body.error : undefined,
+  };
+}
+
+/** 采集结果：GET /jobs/{job_id}/items → 裸 { items: [...] } */
+export async function getCrawlerJobItems(
+  jobId: number,
+  limit = 50,
+  offset = 0,
+): Promise<CrawlerItem[]> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(`${PREFIX}/jobs/${jobId}/items`, {
+    params: { query: { limit, offset } },
+  })) as { data?: unknown; error?: unknown };
+  return pickArray(data, ['items', 'list', 'data']).map((it) =>
+    normalizeItem((it ?? {}) as Record<string, unknown>),
+  );
+}

--- a/xianyu-mobile/api/wrappers/dashboard.ts
+++ b/xianyu-mobile/api/wrappers/dashboard.ts
@@ -4,11 +4,25 @@ import { getApiClient, extractError } from './client';
 // 类型定义
 // ---------------------------------------------------------------------------
 
-export interface DashboardStats {
+/** 首页统计（GET /api/v1/cookies/stats，后端 DashboardStatsService 返回字段） */
+export interface CookieStats {
   total_accounts: number;
   active_accounts: number;
-  today_replies: number;
+  total_keywords: number;
   total_orders: number;
+  today_reply_count: number;
+  yesterday_reply_count: number;
+  /** null 表示不限额 */
+  account_limit: number | null;
+  used_account_count: number;
+  remaining_account_count: number | null;
+}
+
+/** 订单趋势单日数据点（GET /api/v1/cookies/stats/order-trend，date 格式 MM-DD） */
+export interface OrderTrendPoint {
+  date: string;
+  amount: number;
+  count: number;
 }
 
 export interface Notification {
@@ -194,6 +208,57 @@ function buildSummary(raw: unknown): AnalysisSummary {
       : obj.bannerDataList;
   obj.bannerDataList = normalizeBannerList(bannerSrc);
   return obj;
+}
+
+/**
+ * 首页账号统计：账号总数 / 启用数 / 关键词总数 / 总订单 /
+ * 今日·昨日回复数 / 账号额度（后端 GET /api/v1/cookies/stats）。
+ */
+export async function getCookieStats(): Promise<CookieStats> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)('/api/v1/cookies/stats')) as {
+    data?: unknown;
+    error?: unknown;
+  };
+  const raw = unwrapData<Record<string, unknown>>(data);
+  const obj = raw && typeof raw === 'object' ? raw : {};
+  const nullable = (v: unknown): number | null =>
+    v == null || v === '' ? null : toNumber(v);
+  return {
+    total_accounts: toNumber(obj.total_accounts),
+    active_accounts: toNumber(obj.active_accounts),
+    total_keywords: toNumber(obj.total_keywords),
+    total_orders: toNumber(obj.total_orders),
+    today_reply_count: toNumber(obj.today_reply_count),
+    yesterday_reply_count: toNumber(obj.yesterday_reply_count),
+    account_limit: nullable(obj.account_limit),
+    used_account_count: toNumber(obj.used_account_count),
+    remaining_account_count: nullable(obj.remaining_account_count),
+  };
+}
+
+/**
+ * 订单金额趋势（后端固定返回近 30 天，date 为 MM-DD）。
+ * days 仅用于截取最近 N 天，默认 7。
+ */
+export async function getOrderTrend(days = 7): Promise<OrderTrendPoint[]> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(
+    '/api/v1/cookies/stats/order-trend',
+  )) as { data?: unknown; error?: unknown };
+  const raw = unwrapData<{ trend?: unknown }>(data);
+  const list = raw && Array.isArray(raw.trend) ? raw.trend : [];
+  const out: OrderTrendPoint[] = [];
+  for (const item of list) {
+    if (!item || typeof item !== 'object') continue;
+    const o = item as Record<string, unknown>;
+    out.push({
+      date: String(o.date ?? ''),
+      amount: toNumber(o.amount),
+      count: toNumber(o.count),
+    });
+  }
+  return out.slice(-days);
 }
 
 /**

--- a/xianyu-mobile/api/wrappers/items.ts
+++ b/xianyu-mobile/api/wrappers/items.ts
@@ -1,4 +1,4 @@
-import { getApiClient } from './client';
+import { getApiClient, extractError } from './client';
 
 // ---------------------------------------------------------------------------
 // 闲鱼已发布商品列表（对齐 web src/api/items.ts 的 getItemsPaginated）
@@ -6,6 +6,17 @@ import { getApiClient } from './client';
 // ---------------------------------------------------------------------------
 
 const PREFIX = '/api/v1/items';
+
+/** 商品规格明细（鱼小铺多规格商品，来自 item_sku_list，含 sku_id 供改价回传） */
+export interface XianyuItemSku {
+  sku_id: string;
+  inventory_id?: string;
+  quantity?: string | number;
+  /** 该规格价格（元，字符串） */
+  price?: string;
+  /** 规格名/值组合，如 [{ name: '颜色', value: '红色' }] */
+  specs?: Array<{ name: string; value: string }>;
+}
 
 /** 已发布商品（列表展示所需字段，原始响应字段更全，此处只取展示用） */
 export interface XianyuItem {
@@ -20,6 +31,14 @@ export interface XianyuItem {
   image: string | null;
   is_seller_item: boolean;
   created_at?: string;
+  /** 是否已擦亮（列表筛选用） */
+  is_polished?: boolean;
+  /** 多规格标记（列表筛选用） */
+  is_multi_spec?: boolean;
+  /** 多数量发货标记（列表筛选用） */
+  multi_quantity_delivery?: boolean;
+  /** 多规格明细（含 sku_id/price/quantity/specs，供改价与规格展示） */
+  item_sku_list?: XianyuItemSku[];
 }
 
 export interface XianyuItemsPage {
@@ -28,6 +47,18 @@ export interface XianyuItemsPage {
   page: number;
   page_size: number;
   total_pages: number;
+}
+
+/** 商品列表筛选条件（GET /paginated 的可选 query，对齐 web ItemFilterParams） */
+export interface XianyuItemFilters {
+  /** 关键字（商品ID/标题/详情） */
+  keyword?: string;
+  /** 是否擦亮 */
+  isPolished?: boolean;
+  /** 多规格 */
+  isMultiSpec?: boolean;
+  /** 多数量发货 */
+  multiQuantityDelivery?: boolean;
 }
 
 /**
@@ -54,6 +85,25 @@ function extractImage(itemDetail: unknown): string | null {
   }
 }
 
+/** 宽松解析后端 item_sku_list 条目（字段缺失/类型异常时兜底） */
+function mapSkuList(raw: unknown): XianyuItemSku[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  return raw
+    .filter((s): s is Record<string, unknown> => !!s && typeof s === 'object')
+    .map((s) => ({
+      sku_id: String(s.sku_id ?? ''),
+      inventory_id: s.inventory_id != null ? String(s.inventory_id) : undefined,
+      quantity: (s.quantity ?? undefined) as string | number | undefined,
+      price: s.price != null ? String(s.price) : undefined,
+      specs: Array.isArray(s.specs)
+        ? (s.specs as Array<Record<string, unknown>>)
+            .filter((sp) => !!sp && typeof sp === 'object')
+            .map((sp) => ({ name: String(sp.name ?? ''), value: String(sp.value ?? '') }))
+        : undefined,
+    }))
+    .filter((s) => s.sku_id);
+}
+
 function mapItem(raw: Record<string, unknown>): XianyuItem {
   return {
     id: raw.id as string | number,
@@ -66,23 +116,36 @@ function mapItem(raw: Record<string, unknown>): XianyuItem {
     image: extractImage(raw.item_detail),
     is_seller_item: Boolean(raw.is_seller_item),
     created_at: raw.created_at as string | undefined,
+    is_polished: raw.is_polished != null ? Boolean(raw.is_polished) : undefined,
+    is_multi_spec: raw.is_multi_spec != null ? Boolean(raw.is_multi_spec) : undefined,
+    multi_quantity_delivery:
+      raw.multi_quantity_delivery != null ? Boolean(raw.multi_quantity_delivery) : undefined,
+    item_sku_list: mapSkuList(raw.item_sku_list),
   };
 }
 
 /**
  * 获取闲鱼已发布商品列表（分页）。
- * 后端: GET /api/v1/items/paginated?page&page_size&cookie_id
+ * 后端: GET /api/v1/items/paginated?page&page_size&cookie_id&keyword&is_polished&is_multi_spec&multi_quantity_delivery
  * 响应: { success, data: Item[], total, page, page_size, total_pages }
  * cookieId 为空时返回当前权限范围内所有账号的商品。
+ * filters 为可选筛选条件，字段缺省表示不过滤。
  */
 export async function getXianyuItems(
   page: number = 1,
   pageSize: number = 20,
   cookieId?: string,
+  filters?: XianyuItemFilters,
 ): Promise<XianyuItemsPage> {
   const client = await getApiClient();
   const query: Record<string, string | number> = { page, page_size: pageSize };
   if (cookieId) query.cookie_id = cookieId;
+  if (filters?.keyword) query.keyword = filters.keyword;
+  // 后端为 bool query 参数，以 'true'/'false' 字符串传递，仅在被设置时过滤
+  if (filters?.isPolished != null) query.is_polished = filters.isPolished ? 'true' : 'false';
+  if (filters?.isMultiSpec != null) query.is_multi_spec = filters.isMultiSpec ? 'true' : 'false';
+  if (filters?.multiQuantityDelivery != null)
+    query.multi_quantity_delivery = filters.multiQuantityDelivery ? 'true' : 'false';
 
   const { data } = (await (client.GET as any)(`${PREFIX}/paginated`, {
     params: { query },
@@ -109,4 +172,191 @@ export async function getXianyuItems(
         ? body.total_pages
         : total > 0 ? Math.ceil(total / pageSize) : 0,
   };
+}
+
+/**
+ * 获取单个商品详情（本地库记录，含 item_sku_list / 筛选标记等完整字段）。
+ * 后端: GET /api/v1/items/{cookie_id}/{item_id} → { item: {...} }
+ */
+export async function getXianyuItemDetail(
+  cookieId: string,
+  itemId: string,
+): Promise<{ item: XianyuItem }> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.GET as any)(
+    `${PREFIX}/${encodeURIComponent(cookieId)}/${encodeURIComponent(itemId)}`,
+  )) as { data?: unknown; error?: unknown };
+  if (error) throw await extractError(error);
+  const body = (data ?? {}) as Record<string, unknown>;
+  const raw = (body.item ?? body) as Record<string, unknown>;
+  if (!raw || typeof raw !== 'object' || !raw.item_id) throw new Error('商品不存在');
+  return { item: mapItem(raw) };
+}
+
+/** 商品同步统计（POST /items/get-all-from-account 响应） */
+export interface XianyuItemsSyncResult {
+  success: boolean;
+  message?: string;
+  /** 平台拉取到的商品总数 */
+  total_count: number;
+  /** 新增/更新入库数 */
+  saved_count: number;
+  /** 以下字段仅同步全部账号时返回 */
+  account_count?: number;
+  success_account_count?: number;
+  failed_account_count?: number;
+  /** 失败账号列表，形如 "account_id: 原因" */
+  failed_accounts?: string[];
+}
+
+/**
+ * 从闲鱼平台同步商品到本地库（后端自动遍历该账号所有页）。
+ * 后端: POST /api/v1/items/get-all-from-account
+ * cookieId 传入时同步单账号，缺省（{}）时同步当前权限范围内全部账号。
+ */
+export async function syncXianyuItemsFromAccount(
+  cookieId?: string,
+): Promise<XianyuItemsSyncResult> {
+  const client = await getApiClient();
+  const body: Record<string, string> = {};
+  if (cookieId) body.cookie_id = cookieId;
+  const { data, error } = (await (client.POST as any)(`${PREFIX}/get-all-from-account`, {
+    body,
+  })) as { data?: Record<string, unknown>; error?: unknown };
+  if (error) throw await extractError(error);
+  const res = (data ?? {}) as Record<string, unknown>;
+  if (res.success === false) {
+    throw new Error(typeof res.message === 'string' && res.message ? res.message : '同步商品失败');
+  }
+  const numOf = (k: string): number => (typeof res[k] === 'number' ? (res[k] as number) : 0);
+  return {
+    success: true,
+    message: typeof res.message === 'string' ? res.message : undefined,
+    total_count: numOf('total_count'),
+    saved_count: numOf('saved_count'),
+    account_count: res.account_count != null ? numOf('account_count') : undefined,
+    success_account_count:
+      res.success_account_count != null ? numOf('success_account_count') : undefined,
+    failed_account_count:
+      res.failed_account_count != null ? numOf('failed_account_count') : undefined,
+    failed_accounts: Array.isArray(res.failed_accounts)
+      ? (res.failed_accounts as unknown[]).map(String)
+      : undefined,
+  };
+}
+
+/** 批量下架结果（透传闲鱼 suc/fail 统计与失败商品） */
+export interface XianyuBatchOfflineResult {
+  success: boolean;
+  message?: string;
+  suc_count: number;
+  fail_count: number;
+  /** 下架失败的商品ID（闲鱼逐条返回，最多展示用） */
+  failed_item_ids: string[];
+}
+
+/**
+ * 批量下架闲鱼商品（调用闲鱼接口，使用指定账号的 Cookie，不改本地库记录）。
+ * 后端: POST /api/v1/items/batch-offline，body: { cookie_id, item_ids }
+ * 注意：所选账号必须是这些商品的归属账号。
+ */
+export async function batchOfflineXianyuItems(
+  cookieId: string,
+  itemIds: string[],
+): Promise<XianyuBatchOfflineResult> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.POST as any)(`${PREFIX}/batch-offline`, {
+    body: { cookie_id: cookieId, item_ids: itemIds },
+  })) as { data?: Record<string, unknown>; error?: unknown };
+  if (error) throw await extractError(error);
+  const res = (data ?? {}) as Record<string, unknown>;
+  const inner =
+    res.data && typeof res.data === 'object'
+      ? (res.data as Record<string, unknown>)
+      : {};
+  if (res.success === false) {
+    throw new Error(typeof res.message === 'string' && res.message ? res.message : '下架失败');
+  }
+  const numOf = (k: string): number => (typeof inner[k] === 'number' ? (inner[k] as number) : 0);
+  const results = Array.isArray(inner.results)
+    ? (inner.results as Array<Record<string, unknown>>)
+    : [];
+  return {
+    success: true,
+    message: typeof res.message === 'string' ? res.message : undefined,
+    suc_count: numOf('suc_count'),
+    fail_count: numOf('fail_count'),
+    failed_item_ids: results
+      .filter((r) => r.success === false && r.item_id != null)
+      .map((r) => String(r.item_id)),
+  };
+}
+
+/**
+ * 批量删除本地商品记录（不改闲鱼平台，孤儿商品 cookie_id 传 null）。
+ * 后端: DELETE /api/v1/items/batch，body: { items: [{ cookie_id, item_id }] }
+ */
+export async function batchDeleteItemRecords(
+  entries: Array<{ cookie_id: string | null; item_id: string }>,
+): Promise<{ success: boolean; message?: string }> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.DELETE as any)(`${PREFIX}/batch`, {
+    body: { items: entries },
+  })) as { data?: Record<string, unknown>; error?: unknown };
+  if (error) throw await extractError(error);
+  const res = (data ?? {}) as Record<string, unknown>;
+  if (res.success === false) {
+    throw new Error(
+      typeof res.message === 'string' && res.message ? res.message : '批量删除失败',
+    );
+  }
+  return {
+    success: true,
+    message: typeof res.message === 'string' ? res.message : undefined,
+  };
+}
+
+/** 断言本地标记更新类接口业务成功（HTTP 200 + success:false 视为失败） */
+function assertFlagOk(data: unknown, fallbackMsg: string): string {
+  const res = (data ?? {}) as Record<string, unknown>;
+  if (res.success === false) {
+    throw new Error(typeof res.message === 'string' && res.message ? res.message : fallbackMsg);
+  }
+  return typeof res.message === 'string' ? res.message : fallbackMsg;
+}
+
+/**
+ * 更新商品的多规格标记（本地库标记，供列表筛选）。
+ * 后端: PUT /api/v1/items/{cookie_id}/{item_id}/multi-spec，body: { is_multi_spec }
+ */
+export async function setItemMultiSpec(
+  cookieId: string,
+  itemId: string,
+  enabled: boolean,
+): Promise<string> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.PUT as any)(
+    `${PREFIX}/${encodeURIComponent(cookieId)}/${encodeURIComponent(itemId)}/multi-spec`,
+    { body: { is_multi_spec: enabled } },
+  )) as { data?: unknown; error?: unknown };
+  if (error) throw await extractError(error);
+  return assertFlagOk(data, enabled ? '多规格已开启' : '多规格已关闭');
+}
+
+/**
+ * 更新商品的多数量发货标记（本地库标记，供列表筛选）。
+ * 后端: PUT /api/v1/items/{cookie_id}/{item_id}/multi-quantity-delivery，body: { multi_quantity_delivery }
+ */
+export async function setItemMultiQuantityDelivery(
+  cookieId: string,
+  itemId: string,
+  enabled: boolean,
+): Promise<string> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.PUT as any)(
+    `${PREFIX}/${encodeURIComponent(cookieId)}/${encodeURIComponent(itemId)}/multi-quantity-delivery`,
+    { body: { multi_quantity_delivery: enabled } },
+  )) as { data?: unknown; error?: unknown };
+  if (error) throw await extractError(error);
+  return assertFlagOk(data, enabled ? '多数量发货已开启' : '多数量发货已关闭');
 }

--- a/xianyu-mobile/api/wrappers/monitor.ts
+++ b/xianyu-mobile/api/wrappers/monitor.ts
@@ -350,3 +350,471 @@ export async function deleteFallbackConfig(
   })) as { data?: unknown; error?: unknown };
   assertOk(data);
 }
+
+// ---------------------------------------------------------------------------
+// 监控任务完整字段（/product-monitor/listing-tasks）
+//
+// 后端 _task_to_dict 返回全部字段；products.ts 的 getListingTask 仅映射子集，
+// 这里提供完整版建/改任务与批量操作，供 listing-monitor 页面使用。
+// ---------------------------------------------------------------------------
+
+/** 监控类型：listing-上新监控，price_drop-降价监控 */
+export type MonitorType = 'listing' | 'price_drop';
+
+/** 监控任务完整模型（后端 _task_to_dict 全字段） */
+export interface MonitorTaskFull {
+  id: number;
+  owner_id: number | null;
+  category_id: number | null;
+  monitor_type: string;
+  keyword: string;
+  price_min: number | null;
+  price_max: number | null;
+  /** 上新天数筛选（publishDays，天，null=不限/最新） */
+  publish_days: number | null;
+  interval_minutes: number;
+  collect_pages: number;
+  proxy_url: string | null;
+  /** 采集账号ID列表 */
+  account_ids: string[];
+  /** 下单账号ID列表（私信与下单共用） */
+  order_account_ids: string[];
+  /** 私信内容（配置下单账号后必填） */
+  dm_content: string | null;
+  dm_batch_size: number;
+  order_batch_size: number;
+  /** 采集后直接下单 */
+  direct_order: boolean;
+  is_enabled: boolean;
+  last_run_at: string | null;
+  remark: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/** 新建/更新监控任务入参（对齐后端 ListingMonitorCreate/UpdateRequest） */
+export interface MonitorTaskPayload {
+  monitor_type: MonitorType | string;
+  category_id: number;
+  keyword: string;
+  price_min?: number | null;
+  price_max?: number | null;
+  /** 上新天数筛选：仅 listing 类型有效，null=最新（不限天数） */
+  publish_days?: number | null;
+  interval_minutes: number;
+  collect_pages?: number;
+  proxy_url?: string | null;
+  account_ids?: string[];
+  order_account_ids?: string[] | null;
+  dm_content?: string | null;
+  dm_batch_size?: number;
+  order_batch_size?: number;
+  direct_order?: boolean;
+  is_enabled?: boolean;
+  remark?: string | null;
+}
+
+function normalizeTaskFull(raw: Record<string, unknown>): MonitorTaskFull {
+  return {
+    id: num(raw.id),
+    owner_id: raw.owner_id != null ? num(raw.owner_id) : null,
+    category_id: raw.category_id != null ? num(raw.category_id) : null,
+    monitor_type: str(raw.monitor_type, 'listing'),
+    keyword: str(raw.keyword),
+    price_min: raw.price_min != null ? num(raw.price_min) : null,
+    price_max: raw.price_max != null ? num(raw.price_max) : null,
+    publish_days: raw.publish_days != null ? num(raw.publish_days) : null,
+    interval_minutes: num(raw.interval_minutes, 1),
+    collect_pages: num(raw.collect_pages, 1),
+    proxy_url: str(raw.proxy_url) || null,
+    account_ids: strArray(raw.account_ids),
+    order_account_ids: strArray(raw.order_account_ids),
+    dm_content: str(raw.dm_content) || null,
+    dm_batch_size: num(raw.dm_batch_size, 5),
+    order_batch_size: num(raw.order_batch_size, 5),
+    direct_order: Boolean(raw.direct_order),
+    is_enabled: raw.is_enabled != null ? Boolean(raw.is_enabled) : true,
+    last_run_at: str(raw.last_run_at) || null,
+    remark: str(raw.remark) || null,
+    created_at: str(raw.created_at) || null,
+    updated_at: str(raw.updated_at) || null,
+  };
+}
+
+/**
+ * 获取监控任务列表（完整字段版）
+ *
+ * GET /listing-tasks（分页），data 为 { list, total }，元素为 _task_to_dict 全字段。
+ * 取较大 page_size 一次拿全，用于任务卡片展示与编辑表单回填。
+ */
+export async function getMonitorTasksFull(): Promise<MonitorTaskFull[]> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(
+    '/api/v1/product-monitor/listing-tasks',
+    { params: { query: { page: 1, page_size: 200 } } },
+  )) as { data?: unknown; error?: unknown };
+  const inner = unwrapData<unknown>(data);
+  let arr: unknown[] = [];
+  if (Array.isArray(inner)) arr = inner;
+  else if (inner && typeof inner === 'object' && Array.isArray((inner as Record<string, unknown>).list)) {
+    arr = (inner as Record<string, unknown>).list as unknown[];
+  }
+  return arr.map((raw) =>
+    normalizeTaskFull((raw ?? {}) as Record<string, unknown>),
+  );
+}
+
+/**
+ * 新建监控任务（完整字段版，替代 products.ts 的 createListingTask）
+ *
+ * POST /listing-tasks。后端必填：monitor_type/category_id/keyword/interval_minutes；
+ * 配置下单账号后 dm_content 必填（或开启 direct_order）。返回新建的任务（可能缺失）。
+ */
+export async function createMonitorTask(
+  payload: MonitorTaskPayload,
+): Promise<MonitorTaskFull | null> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    '/api/v1/product-monitor/listing-tasks',
+    { body: payload },
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  const inner = unwrapData<unknown>(data);
+  if (
+    inner &&
+    typeof inner === 'object' &&
+    (inner as Record<string, unknown>).task &&
+    typeof (inner as Record<string, unknown>).task === 'object'
+  ) {
+    return normalizeTaskFull(
+      (inner as Record<string, unknown>).task as Record<string, unknown>,
+    );
+  }
+  return null;
+}
+
+/**
+ * 更新监控任务：PUT /listing-tasks/{id}，body 仅传需要修改的字段
+ * （后端 exclude_unset + partial 校验）。返回更新后的任务（可能缺失）。
+ */
+export async function updateMonitorTask(
+  taskId: number,
+  payload: Partial<MonitorTaskPayload>,
+): Promise<MonitorTaskFull | null> {
+  const client = await getApiClient();
+  const { data } = (await (client.PUT as any)(
+    `/api/v1/product-monitor/listing-tasks/${taskId}`,
+    { body: payload },
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  const inner = unwrapData<unknown>(data);
+  if (
+    inner &&
+    typeof inner === 'object' &&
+    (inner as Record<string, unknown>).task &&
+    typeof (inner as Record<string, unknown>).task === 'object'
+  ) {
+    return normalizeTaskFull(
+      (inner as Record<string, unknown>).task as Record<string, unknown>,
+    );
+  }
+  return null;
+}
+
+/** 批量结果（success_count/total_count） */
+export interface BatchResult {
+  success_count: number;
+  total_count: number;
+}
+
+function toBatchResult(data: unknown, fallbackTotal: number): BatchResult {
+  const inner = unwrapData<Record<string, unknown>>(data);
+  const obj = inner && typeof inner === 'object' ? inner : {};
+  return {
+    success_count: num(obj.success_count),
+    total_count: num(obj.total_count, fallbackTotal),
+  };
+}
+
+/** 批量删除监控任务：POST /listing-tasks/batch-delete，body { ids } */
+export async function batchDeleteMonitorTasks(
+  ids: number[],
+): Promise<BatchResult> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    '/api/v1/product-monitor/listing-tasks/batch-delete',
+    { body: { ids } },
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  return toBatchResult(data, ids.length);
+}
+
+/**
+ * 批量修改监控任务账号：POST /listing-tasks/batch-update-accounts。
+ * field: account_ids-采集账号，order_account_ids-下单账号。
+ */
+export async function batchUpdateMonitorAccounts(
+  ids: number[],
+  field: 'account_ids' | 'order_account_ids',
+  accountIds: string[],
+): Promise<BatchResult> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    '/api/v1/product-monitor/listing-tasks/batch-update-accounts',
+    { body: { ids, field, account_ids: accountIds } },
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  return toBatchResult(data, ids.length);
+}
+
+/** 批量修改监控任务分类：POST /listing-tasks/batch-update-category */
+export async function batchUpdateMonitorCategory(
+  ids: number[],
+  categoryId: number,
+): Promise<BatchResult> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    '/api/v1/product-monitor/listing-tasks/batch-update-category',
+    { body: { ids, category_id: categoryId } },
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  return toBatchResult(data, ids.length);
+}
+
+/** 批量修改监控任务私信内容：POST /listing-tasks/batch-update-dm-content */
+export async function batchUpdateMonitorDmContent(
+  ids: number[],
+  dmContent: string,
+): Promise<BatchResult> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    '/api/v1/product-monitor/listing-tasks/batch-update-dm-content',
+    { body: { ids, dm_content: dmContent } },
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  return toBatchResult(data, ids.length);
+}
+
+// ---------------------------------------------------------------------------
+// 采集商品（/product-monitor/listing-tasks/items）
+// ---------------------------------------------------------------------------
+
+/** 采集商品（后端 _item_to_dict 全字段，详情接口额外含 detail_json/raw_json） */
+export interface MonitorItem {
+  id: number;
+  monitor_task_id: number | null;
+  monitor_task_keyword: string | null;
+  item_id: string;
+  title: string;
+  price: string;
+  area: string;
+  pic_url: string;
+  seller_id: string;
+  seller_user_id: string;
+  seller_nick: string;
+  want_count: number;
+  tags: string;
+  publish_time: string | null;
+  target_url: string;
+  has_detail: boolean;
+  /** filled/pending/failed */
+  seller_fill_status: string;
+  seller_fill_fail_reason: string;
+  is_dm_sent: boolean;
+  dm_account_id: string;
+  dm_chat_id: string;
+  /** not_sent/waiting/pending/success/failed */
+  dm_status: string;
+  dm_fail_reason: string;
+  dm_attempts: number;
+  is_ordered: boolean;
+  order_id: string;
+  order_account_id: string;
+  /** not_ordered/ordered/failed/no_account/duplicate */
+  order_status: string;
+  order_fail_reason: string;
+  order_attempts: number;
+  ordered_at: string | null;
+  last_seen_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/** 采集商品列表筛选（字段见后端 GET /items Query 参数） */
+export interface MonitorItemQuery {
+  page: number;
+  pageSize: number;
+  monitorTaskId?: number;
+  /** 商品标题关键字 */
+  keyword?: string;
+  area?: string;
+  sellerNick?: string;
+  /** 商品ID精确筛选 */
+  itemId?: string;
+  sellerFill?: string;
+  /** 是否已获取详情 */
+  hasDetail?: boolean;
+  /** 私信状态：not_sent/waiting/pending/success/failed */
+  dmState?: string;
+  /** 下单状态：not_ordered/ordered/failed/no_account/duplicate */
+  orderState?: string;
+  /** 采集时间区间（北京时间 YYYY-MM-DDTHH:mm） */
+  createdStart?: string;
+  createdEnd?: string;
+}
+
+function normalizeItem(raw: Record<string, unknown>): MonitorItem {
+  return {
+    id: num(raw.id),
+    monitor_task_id: raw.monitor_task_id != null ? num(raw.monitor_task_id) : null,
+    monitor_task_keyword: str(raw.monitor_task_keyword) || null,
+    item_id: str(raw.item_id),
+    title: str(raw.title),
+    price: str(raw.price, '0'),
+    area: str(raw.area),
+    pic_url: str(raw.pic_url),
+    seller_id: str(raw.seller_id),
+    seller_user_id: str(raw.seller_user_id),
+    seller_nick: str(raw.seller_nick),
+    want_count: num(raw.want_count),
+    tags: str(raw.tags),
+    publish_time: str(raw.publish_time) || null,
+    target_url: str(raw.target_url),
+    has_detail: Boolean(raw.has_detail),
+    seller_fill_status: str(raw.seller_fill_status),
+    seller_fill_fail_reason: str(raw.seller_fill_fail_reason),
+    is_dm_sent: Boolean(raw.is_dm_sent),
+    dm_account_id: str(raw.dm_account_id),
+    dm_chat_id: str(raw.dm_chat_id),
+    dm_status: str(raw.dm_status, 'not_sent'),
+    dm_fail_reason: str(raw.dm_fail_reason),
+    dm_attempts: num(raw.dm_attempts),
+    is_ordered: Boolean(raw.is_ordered),
+    order_id: str(raw.order_id),
+    order_account_id: str(raw.order_account_id),
+    order_status: str(raw.order_status, 'not_ordered'),
+    order_fail_reason: str(raw.order_fail_reason),
+    order_attempts: num(raw.order_attempts),
+    ordered_at: str(raw.ordered_at) || null,
+    last_seen_at: str(raw.last_seen_at) || null,
+    created_at: str(raw.created_at) || null,
+    updated_at: str(raw.updated_at) || null,
+  };
+}
+
+/** 分页查询采集商品：GET /listing-tasks/items，data 为 { list, total, ... } */
+export async function getMonitorItems(
+  query: MonitorItemQuery,
+): Promise<{ list: MonitorItem[]; total: number }> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(
+    '/api/v1/product-monitor/listing-tasks/items',
+    {
+      params: {
+        query: {
+          page: query.page,
+          page_size: query.pageSize,
+          ...(query.monitorTaskId != null
+            ? { monitor_task_id: query.monitorTaskId }
+            : {}),
+          ...(query.keyword ? { keyword: query.keyword } : {}),
+          ...(query.area ? { area: query.area } : {}),
+          ...(query.sellerNick ? { seller_nick: query.sellerNick } : {}),
+          ...(query.itemId ? { item_id: query.itemId } : {}),
+          ...(query.sellerFill ? { seller_fill: query.sellerFill } : {}),
+          ...(query.hasDetail != null ? { has_detail: query.hasDetail } : {}),
+          ...(query.dmState ? { dm_state: query.dmState } : {}),
+          ...(query.orderState ? { order_state: query.orderState } : {}),
+          ...(query.createdStart ? { created_start: query.createdStart } : {}),
+          ...(query.createdEnd ? { created_end: query.createdEnd } : {}),
+        },
+      },
+    },
+  )) as { data?: unknown; error?: unknown };
+  const inner = unwrapData<Record<string, unknown>>(data);
+  const obj = inner && typeof inner === 'object' ? inner : {};
+  const rawList = Array.isArray(obj.list)
+    ? obj.list
+    : Array.isArray(inner)
+      ? (inner as unknown[])
+      : [];
+  return {
+    list: rawList.map((raw) =>
+      normalizeItem((raw ?? {}) as Record<string, unknown>),
+    ),
+    total: num(obj.total, rawList.length),
+  };
+}
+
+/** 批量重置「私信失败」采集商品为未私信：POST /listing-tasks/items/reset-dm */
+export async function resetMonitorItemsDm(ids: number[]): Promise<BatchResult> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    '/api/v1/product-monitor/listing-tasks/items/reset-dm',
+    { body: { ids } },
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  return toBatchResult(data, ids.length);
+}
+
+/**
+ * 查询单条采集商品完整信息：GET /listing-tasks/items/{pk}，data 为 { item }。
+ * 业务失败（不存在）抛错。
+ */
+export async function getMonitorItemDetail(pk: number): Promise<MonitorItem> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(
+    `/api/v1/product-monitor/listing-tasks/items/${pk}`,
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  const inner = unwrapData<Record<string, unknown>>(data);
+  const item =
+    inner && typeof inner === 'object'
+      ? (inner as Record<string, unknown>).item
+      : null;
+  if (!item || typeof item !== 'object') {
+    throw new Error('采集商品不存在');
+  }
+  return normalizeItem(item as Record<string, unknown>);
+}
+
+// ---------------------------------------------------------------------------
+// 监控日志复制账号Cookies（POST /listing-tasks/logs/copy-cookies）
+// ---------------------------------------------------------------------------
+
+/** 复制Cookies返回的单条账号信息（account_id/cookies/secret_key） */
+export interface MonitorLogCookie {
+  account_id: string;
+  cookies: string;
+  secret_key: string;
+}
+
+/**
+ * 汇总选中监控日志涉及账号（去重）的 Cookie 与分销秘钥：
+ * POST /listing-tasks/logs/copy-cookies，body { ids }，data 为 { list }。
+ * 返回空数组表示选中日志没有可复制的账号。
+ */
+export async function copyMonitorLogCookies(
+  ids: number[],
+): Promise<MonitorLogCookie[]> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(
+    '/api/v1/product-monitor/listing-tasks/logs/copy-cookies',
+    { body: { ids } },
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  const inner = unwrapData<unknown>(data);
+  let arr: unknown[] = [];
+  if (Array.isArray(inner)) arr = inner;
+  else if (inner && typeof inner === 'object' && Array.isArray((inner as Record<string, unknown>).list)) {
+    arr = (inner as Record<string, unknown>).list as unknown[];
+  }
+  return arr.map((raw) => {
+    const o = (raw ?? {}) as Record<string, unknown>;
+    return {
+      account_id: str(o.account_id),
+      cookies: str(o.cookies),
+      secret_key: str(o.secret_key),
+    };
+  });
+}

--- a/xianyu-mobile/api/wrappers/notifications.ts
+++ b/xianyu-mobile/api/wrappers/notifications.ts
@@ -124,23 +124,35 @@ export interface MessageNotificationBinding {
   enabled: boolean;
 }
 
-/** 获取消息通知绑定列表 */
+/**
+ * 获取消息通知绑定列表。
+ * 后端 GET /message-notifications 返回以 cookie_id 为键的字典：
+ * `{ [cookie_id]: [{ id, channel_id, enabled, channel_name, channel_type, channel_config }] }`，
+ * cookie_id 只存在于外层键，需在展开时写入每条绑定的 account_id。
+ */
 export async function getMessageNotifications(): Promise<MessageNotificationBinding[]> {
   const client = await getApiClient();
-  const { data } = (await (client.GET as any)('/api/v1/message-notifications', {
-    params: { query: { page: 1, page_size: 200 } },
-  })) as { data?: unknown; error?: unknown };
-  return extractArray<MessageNotificationBinding>(
-    data,
-    (raw) =>
-      ({
-        id: Number(raw.id ?? 0),
-        account_id: String(raw.account_id ?? raw.cookie_id ?? ''),
-        channel_id: Number(raw.channel_id ?? 0),
-        channel_name: raw.channel_name != null ? String(raw.channel_name) : undefined,
-        enabled: Boolean(raw.enabled ?? true),
-      }) as MessageNotificationBinding,
-  );
+  const { data } = (await (client.GET as any)('/api/v1/message-notifications')) as {
+    data?: unknown;
+    error?: unknown;
+  };
+  const body = unwrap<Record<string, unknown>>(data);
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return [];
+  const result: MessageNotificationBinding[] = [];
+  for (const [cookieId, group] of Object.entries(body)) {
+    if (!Array.isArray(group)) continue;
+    for (const raw of group) {
+      const r = (raw ?? {}) as Record<string, unknown>;
+      result.push({
+        id: Number(r.id ?? 0),
+        account_id: String(r.account_id ?? cookieId),
+        channel_id: Number(r.channel_id ?? 0),
+        channel_name: r.channel_name != null ? String(r.channel_name) : undefined,
+        enabled: Boolean(r.enabled ?? true),
+      });
+    }
+  }
+  return result;
 }
 
 /** 新建消息通知绑定 */
@@ -166,13 +178,23 @@ export async function createMessageNotification(
   return null;
 }
 
-/** 更新绑定（启停） */
-export async function updateMessageNotification(
-  id: number,
+/**
+ * 新增/更新消息通知绑定（upsert 语义）。
+ * 后端无 PUT /message-notifications/{id}（405），
+ * 统一用 POST /message-notifications/{cookie_id}，body `{ channel_id, enabled }`：
+ * 已存在同账号同渠道的绑定时更新 enabled，否则新建（notifications.py set_message_notification）。
+ */
+export async function upsertMessageNotification(
+  cookieId: string,
+  channelId: number,
   enabled: boolean,
 ): Promise<void> {
   const client = await getApiClient();
-  await (client.PUT as any)(`/api/v1/message-notifications/${id}`, { body: { enabled } });
+  const { error } = (await (client.POST as any)(
+    `/api/v1/message-notifications/${cookieId}`,
+    { body: { channel_id: channelId, enabled } },
+  )) as { data?: unknown; error?: unknown };
+  if (error) throw await extractError(error);
 }
 
 /** 删除绑定 */

--- a/xianyu-mobile/api/wrappers/orders-tab.ts
+++ b/xianyu-mobile/api/wrappers/orders-tab.ts
@@ -151,18 +151,69 @@ function mapOrderDetail(raw: Record<string, unknown>): OrderDetail {
 }
 
 /**
- * 分页获取订单列表。
+ * 订单列表服务端筛选参数（与后端 GET /api/v1/orders 的 Query 参数一一对应，
+ * 见 backend-web app/api/routes/orders.py list_orders）。
+ * 除 page/pageSize 外均为可选；空字符串/undefined 不会拼进 query。
+ */
+export interface OrderListFilters {
+  /** 账号 cookie_id */
+  cookieId?: string;
+  /** 细粒度订单状态（pending_ship/shipped/completed/refunded 等，后端精确匹配） */
+  status?: string;
+  /** 搜索关键词：订单号 / 商品ID / 买家ID */
+  search?: string;
+  /** 发货方式：manual/auto/scheduled/none */
+  deliveryMethod?: string;
+  /** 是否小刀 */
+  isBargain?: boolean;
+  /** 是否已评价 */
+  isRated?: boolean;
+  /** 开始日期，格式 YYYY-MM-DD */
+  startDate?: string;
+  /** 结束日期，格式 YYYY-MM-DD */
+  endDate?: string;
+  /** 关联消息发送状态：success/failed/unknown/timeout */
+  deliverySendStatus?: string;
+}
+
+/** YYYY-MM-DD 严格校验：不合法的日期不发给后端（避免半输入状态触发 500） */
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * 分页获取订单列表（支持服务端多条件筛选）。
  *
- * 后端响应约定为 `{ data: Order[], total }`，但也可能包一层 `{ success, data }`
- * 或直接返回裸数组，三种形态均兼容。
+ * 后端响应约定为 `{ success, data: Order[], total }`，但也可能裸返回数组，
+ * 多种形态均兼容。
  */
 export async function getOrders(
   page: number,
   pageSize: number,
+  filters?: OrderListFilters,
 ): Promise<{ data: Order[]; total: number }> {
   const client = await getApiClient();
+  const query: Record<string, string | number | boolean> = {
+    page,
+    page_size: pageSize,
+  };
+  if (filters) {
+    if (filters.cookieId) query.cookie_id = filters.cookieId;
+    if (filters.status) query.status = filters.status;
+    if (filters.search) query.search = filters.search;
+    if (filters.deliveryMethod) query.delivery_method = filters.deliveryMethod;
+    if (filters.isBargain != null) query.is_bargain = filters.isBargain;
+    if (filters.isRated != null) query.is_rated = filters.isRated;
+    if (filters.startDate && DATE_RE.test(filters.startDate)) {
+      query.start_date = filters.startDate;
+    }
+    if (filters.endDate && DATE_RE.test(filters.endDate)) {
+      query.end_date = filters.endDate;
+    }
+    if (filters.deliverySendStatus) {
+      query.delivery_send_status = filters.deliverySendStatus;
+    }
+  }
   const { data } = (await (client.GET as any)('/api/v1/orders', {
-    params: { query: { page, page_size: pageSize } },
+    params: { query },
   })) as { data?: unknown; error?: unknown };
 
   const body = data;
@@ -243,17 +294,120 @@ export async function deleteOrder(id: string): Promise<void> {
 // 同步闲鱼订单
 // ---------------------------------------------------------------------------
 
+/** 同步闲鱼订单的统计结果（后端 fetch-xianyu 的 data 字段） */
+export interface FetchXianyuStats {
+  /** 从闲鱼获取到的订单条数 */
+  total_fetched: number;
+  /** 新插入数据库条数 */
+  new_inserted: number;
+  /** 更新条数 */
+  updated: number;
+  /** 失败条数 */
+  failed: number;
+  /** 处理的账号数（同步全部时 > 1） */
+  accounts_processed: number;
+  /** 失败账号与原因，格式 "账号ID: 原因" */
+  errors: string[];
+}
+
+function emptyStats(): FetchXianyuStats {
+  return {
+    total_fetched: 0,
+    new_inserted: 0,
+    updated: 0,
+    failed: 0,
+    accounts_processed: 0,
+    errors: [],
+  };
+}
+
 /**
  * 同步闲鱼订单到数据库。
  *
- * 注意：请求体字段为 `cookie_id`（与后端 FetchXianyuOrdersRequest schema 一致，
- * 而非 account_id）。该接口可能耗时较长，通过 AbortController 设置 10 分钟超时。
+ * 请求体字段为 `cookie_id`（与后端 FetchXianyuOrdersRequest schema 一致）：
+ * - 传具体账号 ID → 只同步该账号；
+ * - 传 undefined/null → 同步全部账号（后端会跳过 inactive/disabled 等状态）。
+ *
+ * 返回获取/新增/更新统计与失败账号列表。该接口可能耗时较长，
+ * 调用方应通过 AbortController/withTimeout 自行控制超时
+ * （单账号建议 120s，全部账号建议 600s）。
  */
-export async function fetchXianyuOrders(cookieId: string): Promise<void> {
+export async function fetchXianyuOrders(
+  cookieId?: string | null,
+): Promise<FetchXianyuStats> {
   const client = await getApiClient();
-  await (client.POST as any)('/api/v1/orders/fetch-xianyu', {
-    body: { cookie_id: cookieId },
-  });
+  const { data } = (await (client.POST as any)('/api/v1/orders/fetch-xianyu', {
+    body: { cookie_id: cookieId ?? null },
+  })) as { data?: unknown; error?: unknown };
+
+  const body = (data ?? {}) as Record<string, unknown>;
+  if (body.success === false) {
+    throw new Error(
+      typeof body.message === 'string' && body.message
+        ? body.message
+        : '同步闲鱼订单失败',
+    );
+  }
+  const stats = unwrap(body) as Record<string, unknown> | null;
+  if (!stats || typeof stats !== 'object') return emptyStats();
+  return {
+    total_fetched: Number(stats.total_fetched ?? 0) || 0,
+    new_inserted: Number(stats.new_inserted ?? 0) || 0,
+    updated: Number(stats.updated ?? 0) || 0,
+    failed: Number(stats.failed ?? 0) || 0,
+    accounts_processed: Number(stats.accounts_processed ?? 0) || 0,
+    errors: Array.isArray(stats.errors) ? stats.errors.map(String) : [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 批量删除
+// ---------------------------------------------------------------------------
+
+/** 批量删除结果（后端 batch-delete 的 message 与 data 字段） */
+export interface BatchDeleteResult {
+  /** 后端提示消息，如「删除完成，成功3条，失败1条」 */
+  message: string;
+  /** 成功删除条数 */
+  deleted: number;
+  /** 失败条数 */
+  failed: number;
+}
+
+/**
+ * 批量删除订单。
+ *
+ * 后端 POST /api/v1/orders/batch-delete 的 body 为 `{ ids: number[] }`
+ * （数据库主键）。Order.id 是字符串化的主键，这里转回数字。
+ */
+export async function batchDeleteOrders(
+  ids: string[],
+): Promise<BatchDeleteResult> {
+  const numericIds = ids
+    .map((id) => Number(id))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  if (numericIds.length === 0) {
+    throw new Error('请选择要删除的订单');
+  }
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)('/api/v1/orders/batch-delete', {
+    body: { ids: numericIds },
+  })) as { data?: unknown; error?: unknown };
+
+  const body = (data ?? {}) as Record<string, unknown>;
+  if (body.success === false) {
+    throw new Error(
+      typeof body.message === 'string' && body.message
+        ? body.message
+        : '批量删除失败',
+    );
+  }
+  const inner = unwrap(body) as Record<string, unknown> | null;
+  return {
+    message: typeof body.message === 'string' ? body.message : '',
+    deleted: Number(inner?.deleted ?? 0) || 0,
+    failed: Number(inner?.failed ?? 0) || 0,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/xianyu-mobile/api/wrappers/popup-announcements.ts
+++ b/xianyu-mobile/api/wrappers/popup-announcements.ts
@@ -1,0 +1,162 @@
+import { getApiClient } from './client';
+
+// ---------------------------------------------------------------------------
+// 弹窗公告管理（管理员）
+// 后端路由前缀: /api/v1/popup-announcements
+//（backend-web/app/api/routes/popup_announcements.py，软删除，字段 is_enabled）
+// ---------------------------------------------------------------------------
+
+const PREFIX = '/api/v1/popup-announcements';
+
+/** 弹窗公告（GET 列表 items 的元素） */
+export interface PopupAnnouncement {
+  id: number;
+  title: string;
+  content: string;
+  /** 跳转链接，可为空 */
+  link: string | null;
+  is_enabled: boolean;
+  /** 来源：local=本机 / remote=远程官方服务器同步 */
+  source?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** 新增/更新入参（对齐后端 PopupAnnouncementCreate/Update） */
+export interface PopupAnnouncementInput {
+  title: string;
+  content: string;
+  /** 可选跳转链接，空串按无链接处理 */
+  link?: string;
+  is_enabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// 通用解析工具（与 card-relation.ts 的 unwrapData/assertOk 保持一致）
+// ---------------------------------------------------------------------------
+
+/** 取出 `{ success, data }` 包裹的内部 data；未包裹则原样返回 */
+function unwrapData<T>(body: unknown): T {
+  if (
+    body &&
+    typeof body === 'object' &&
+    'success' in (body as Record<string, unknown>) &&
+    'data' in (body as Record<string, unknown>)
+  ) {
+    const inner = (body as { data: unknown }).data;
+    if (inner != null) return inner as T;
+  }
+  return body as T;
+}
+
+/** 断言业务成功：body.success === false 时抛出 message */
+function assertOk(body: unknown, fallback = '操作失败'): void {
+  if (
+    body &&
+    typeof body === 'object' &&
+    (body as Record<string, unknown>).success === false
+  ) {
+    const msg = (body as Record<string, unknown>).message;
+    throw new Error((typeof msg === 'string' && msg) || fallback);
+  }
+}
+
+function str(val: unknown, fallback = ''): string {
+  if (val == null) return fallback;
+  const s = String(val);
+  return s === 'undefined' || s === 'null' ? fallback : s;
+}
+
+function num(val: unknown, fallback = 0): number {
+  if (val == null || val === '') return fallback;
+  const n = Number(val);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizeItem(raw: Record<string, unknown>): PopupAnnouncement {
+  return {
+    id: num(raw.id),
+    title: str(raw.title),
+    content: str(raw.content),
+    link: raw.link != null && str(raw.link) !== '' ? str(raw.link) : null,
+    is_enabled: Boolean(raw.is_enabled),
+    source: raw.source != null ? str(raw.source) : undefined,
+    created_at: raw.created_at != null ? str(raw.created_at) : undefined,
+    updated_at: raw.updated_at != null ? str(raw.updated_at) : undefined,
+  };
+}
+
+/**
+ * 弹窗公告列表（管理员，按创建时间倒序）。
+ * GET ?page&page_size → data: { items, total, page, page_size }
+ */
+export async function getPopupAnnouncements(
+  page = 1,
+  pageSize = 50,
+): Promise<PopupAnnouncement[]> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(PREFIX, {
+    params: { query: { page, page_size: pageSize } },
+  })) as { data?: unknown; error?: unknown };
+  assertOk(data, '获取弹窗公告失败');
+  const inner = unwrapData<unknown>(data);
+  let arr: unknown[] = [];
+  if (Array.isArray(inner)) arr = inner;
+  else if (inner && typeof inner === 'object') {
+    const obj = inner as Record<string, unknown>;
+    if (Array.isArray(obj.items)) arr = obj.items;
+    else if (Array.isArray(obj.list)) arr = obj.list;
+    else if (Array.isArray(obj.data)) arr = obj.data;
+  }
+  return arr.map((it) => normalizeItem((it ?? {}) as Record<string, unknown>));
+}
+
+/** 新增弹窗公告：POST ''，body { title, content, link?, is_enabled } */
+export async function createPopupAnnouncement(
+  input: PopupAnnouncementInput,
+): Promise<void> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(PREFIX, { body: input })) as {
+    data?: unknown;
+    error?: unknown;
+  };
+  assertOk(data, '发布失败');
+}
+
+/** 更新弹窗公告：PUT /{id}，body { title, content, link?, is_enabled } */
+export async function updatePopupAnnouncement(
+  id: number,
+  input: PopupAnnouncementInput,
+): Promise<void> {
+  const client = await getApiClient();
+  const { data } = (await (client.PUT as any)(`${PREFIX}/${id}`, {
+    body: input,
+  })) as { data?: unknown; error?: unknown };
+  assertOk(data, '更新失败');
+}
+
+/**
+ * 启用/停用弹窗公告：PUT /{id}/toggle（后端取反当前状态）。
+ * 返回切换后的 is_enabled。
+ */
+export async function togglePopupAnnouncement(id: number): Promise<boolean> {
+  const client = await getApiClient();
+  const { data } = (await (client.PUT as any)(`${PREFIX}/${id}/toggle`)) as {
+    data?: unknown;
+    error?: unknown;
+  };
+  assertOk(data, '操作失败');
+  const inner = unwrapData<Record<string, unknown>>(data);
+  const body = (inner && typeof inner === 'object' ? inner : {}) as Record<string, unknown>;
+  return Boolean(body.is_enabled);
+}
+
+/** 删除弹窗公告（软删除）：DELETE /{id} */
+export async function deletePopupAnnouncement(id: number): Promise<void> {
+  const client = await getApiClient();
+  const { data } = (await (client.DELETE as any)(`${PREFIX}/${id}`)) as {
+    data?: unknown;
+    error?: unknown;
+  };
+  assertOk(data, '删除失败');
+}

--- a/xianyu-mobile/api/wrappers/product-publish.ts
+++ b/xianyu-mobile/api/wrappers/product-publish.ts
@@ -34,9 +34,9 @@ export interface UploadedImages {
 }
 
 /**
- * 上传商品兜底图片（multipart/form-data，字段名 files，多文件）。
- * 返回 {paths, urls}，提交任务时取 urls 填入 material_defaults.images
- * （与 web AiListingTaskPanel 一致：images 存预览 url）。
+ * 上传商品图片（multipart/form-data，字段名 files，多文件）。
+ * 返回 {paths, urls}：paths 是服务器本地绝对路径（发布时传给闲鱼 Playwright 用），
+ * urls 是静态预览地址（/static/uploads/products/...，相对路径需拼服务器地址）。
  * RN FormData 文件字段需 { uri, name, type }，openapi-fetch 识别 FormData 后交由 fetch 自动设置 boundary。
  */
 export async function uploadProductImages(uris: string[]): Promise<UploadedImages> {
@@ -55,4 +55,296 @@ export async function uploadProductImages(uris: string[]): Promise<UploadedImage
   })) as { data?: unknown };
 
   return unwrapData<UploadedImages>(data);
+}
+
+// ==================== 类型 ====================
+
+/** 素材创建入参（对齐后端 MaterialCreateRequest，只暴露移动端用到的字段） */
+export interface MaterialCreateParams {
+  title: string;
+  description: string;
+  price: number;
+  original_price?: number | null;
+  category?: string | null;
+  /** 服务器本地路径列表（uploadProductImages 返回的 paths），至少 1 张，最多 9 张 */
+  images: string[];
+  quantity?: number;
+  brand?: string | null;
+  condition?: string;
+  delivery_method?: 'express' | 'pickup';
+  shipping_method?: 'free' | 'distance' | 'fixed' | 'template' | 'none';
+  support_pickup?: boolean;
+  postage?: number;
+  address?: string | null;
+  remark?: string | null;
+}
+
+/** 素材（批量发布的数据源） */
+export interface ProductMaterial {
+  id: number;
+  title: string;
+  description: string;
+  price: number;
+  original_price?: number | null;
+  category?: string | null;
+  images: string[];
+  quantity: number;
+  brand?: string | null;
+  condition: string;
+  remark?: string | null;
+  created_at?: string | null;
+}
+
+export interface MaterialsPage {
+  list: ProductMaterial[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
+/** 平台分类路径中的一级分类 */
+export interface CategoryPathItem {
+  id: string;
+  name: string;
+}
+
+/** 类目推荐候选 */
+export interface CategoryCandidate {
+  cat_id?: string | null;
+  cat_name?: string | null;
+  channel_cat_id?: string | null;
+  channel_cat_name?: string | null;
+  leaf_id?: string | null;
+  tb_cat_id?: string | null;
+  score?: number | null;
+  path?: CategoryPathItem[];
+}
+
+export interface CategoryRecommendData {
+  candidates: CategoryCandidate[];
+  account_id?: string;
+}
+
+/** 单品发布入参（对齐后端 PublishSingleRequest） */
+export interface PublishSingleParams {
+  /** 闲鱼账号 ID（cookie_id），必填 */
+  account_id: string;
+  title: string;
+  description: string;
+  price: number;
+  original_price?: number | null;
+  category?: string | null;
+  /** 服务器本地路径列表（uploadProductImages 返回的 paths），至少 1 张 */
+  images: string[];
+  // 类目推荐回填的平台分类字段
+  platform_category_id?: string | null;
+  platform_category_name?: string | null;
+  platform_channel_category_id?: string | null;
+  platform_channel_category_name?: string | null;
+  platform_leaf_id?: string | null;
+  platform_tb_category_id?: string | null;
+  platform_category_path?: CategoryPathItem[];
+  category_source?: 'manual' | 'recommendation';
+  category_confidence?: number | null;
+  quantity?: number;
+  stock?: number | null;
+  address?: string | null;
+  delivery_method?: 'express' | 'pickup';
+  shipping_method?: 'free' | 'distance' | 'fixed' | 'template' | 'none';
+  support_pickup?: boolean;
+  postage?: number;
+  brand?: string | null;
+  condition?: string;
+}
+
+export interface PublishSingleResult {
+  item_url?: string | null;
+  item_id?: string | null;
+  log_id?: number;
+  sync_status?: string;
+  sync_message?: string | null;
+  sync_total_count?: number;
+  sync_saved_count?: number;
+}
+
+/** 批量发布返回 */
+export interface BatchPublishResult {
+  batch_id: string;
+  total: number;
+}
+
+/** 批量进度：单账号维度统计 */
+export interface BatchAccountStatus {
+  account_id: string;
+  total: number;
+  success: number;
+  failed: number;
+  publishing: number;
+  pending: number;
+  sync_status: 'pending' | 'running' | 'success' | 'failed' | 'skipped' | 'unknown';
+  sync_message: string;
+  sync_total_count: number;
+  sync_saved_count: number;
+}
+
+/** 批量进度状态（GET /publish/batch/{id}/status） */
+export interface BatchStatus {
+  batch_id: string;
+  total: number;
+  success: number;
+  failed: number;
+  publishing: number;
+  pending: number;
+  finished: boolean;
+  account_statuses: BatchAccountStatus[];
+}
+
+/** 发布日志条目 */
+export interface PublishLogItem {
+  id: number;
+  account_id: string;
+  title: string;
+  price?: string | null;
+  material_id?: number | null;
+  batch_id?: string | null;
+  status: 'pending' | 'publishing' | 'success' | 'failed';
+  item_id?: string | null;
+  item_url?: string | null;
+  error_message?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PublishLogsPage {
+  list: PublishLogItem[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
+// ==================== 发布接口 ====================
+
+/** 单品发布（同步调用闲鱼发布接口，耗时较长） */
+export async function publishSingle(params: PublishSingleParams): Promise<PublishSingleResult> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(`${PREFIX}/publish/single`, {
+    body: params,
+  })) as { data?: unknown };
+  return unwrapData<PublishSingleResult>(data);
+}
+
+/** 批量发布（后台异步执行，立即返回 batch_id 供轮询进度） */
+export async function publishBatch(
+  accountIds: string[],
+  materialIds: number[],
+): Promise<BatchPublishResult> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(`${PREFIX}/publish/batch`, {
+    body: { account_ids: accountIds, material_ids: materialIds },
+  })) as { data?: unknown };
+  return unwrapData<BatchPublishResult>(data);
+}
+
+/**
+ * 查询批量发布进度（5 秒轮询直到 finished）。
+ * 任务不存在或状态已失效时后端返回 success=false，unwrapData 会 throw。
+ */
+export async function getBatchStatus(batchId: string): Promise<BatchStatus> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(
+    `${PREFIX}/publish/batch/${encodeURIComponent(batchId)}/status`,
+  )) as { data?: unknown };
+  return unwrapData<BatchStatus>(data);
+}
+
+// ==================== 发布日志 ====================
+
+/** 分页查询发布日志（可按账号/状态过滤：pending/publishing/success/failed） */
+export async function getPublishLogs(
+  page: number = 1,
+  pageSize: number = 20,
+  accountId?: string,
+  status?: string,
+): Promise<PublishLogsPage> {
+  const client = await getApiClient();
+  const query: Record<string, string | number> = { page, page_size: pageSize };
+  if (accountId) query.account_id = accountId;
+  if (status) query.status = status;
+
+  const { data } = (await (client.GET as any)(`${PREFIX}/logs`, {
+    params: { query },
+  })) as { data?: unknown };
+
+  const body = unwrapData<Record<string, unknown>>(data);
+  const rawList = Array.isArray(body.list) ? (body.list as PublishLogItem[]) : [];
+  return {
+    list: rawList,
+    total: typeof body.total === 'number' ? body.total : rawList.length,
+    page: typeof body.page === 'number' ? body.page : page,
+    page_size: typeof body.page_size === 'number' ? body.page_size : pageSize,
+    total_pages: typeof body.total_pages === 'number' ? body.total_pages : 0,
+  };
+}
+
+// ==================== 素材库 ====================
+
+/** 分页查询素材列表（可按标题模糊搜索） */
+export async function listMaterials(
+  page: number = 1,
+  pageSize: number = 20,
+  title?: string,
+): Promise<MaterialsPage> {
+  const client = await getApiClient();
+  const query: Record<string, string | number> = { page, page_size: pageSize };
+  if (title) query.title = title;
+
+  const { data } = (await (client.GET as any)(`${PREFIX}/materials`, {
+    params: { query },
+  })) as { data?: unknown };
+
+  const body = unwrapData<Record<string, unknown>>(data);
+  const rawList = Array.isArray(body.list) ? (body.list as ProductMaterial[]) : [];
+  return {
+    list: rawList,
+    total: typeof body.total === 'number' ? body.total : rawList.length,
+    page: typeof body.page === 'number' ? body.page : page,
+    page_size: typeof body.page_size === 'number' ? body.page_size : pageSize,
+    total_pages: typeof body.total_pages === 'number' ? body.total_pages : 0,
+  };
+}
+
+/** 创建素材，返回新素材 ID */
+export async function createMaterial(params: MaterialCreateParams): Promise<{ id: number }> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(`${PREFIX}/materials`, {
+    body: params,
+  })) as { data?: unknown };
+  return unwrapData<{ id: number }>(data);
+}
+
+/** 删除素材 */
+export async function deleteMaterial(id: number): Promise<void> {
+  const client = await getApiClient();
+  await (client.DELETE as any)(`${PREFIX}/materials/${id}`);
+}
+
+// ==================== 类目推荐 ====================
+
+/** 按标题和描述推荐闲鱼平台分类（可指定账号，缺省由后端自动轮换） */
+export async function recommendCategory(params: {
+  title: string;
+  description: string;
+  account_id?: string;
+}): Promise<CategoryRecommendData> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(`${PREFIX}/category/recommend`, {
+    body: params,
+  })) as { data?: unknown };
+  const body = unwrapData<Record<string, unknown>>(data);
+  return {
+    candidates: Array.isArray(body.candidates) ? (body.candidates as CategoryCandidate[]) : [],
+    account_id: typeof body.account_id === 'string' ? body.account_id : undefined,
+  };
 }

--- a/xianyu-mobile/api/wrappers/products.ts
+++ b/xianyu-mobile/api/wrappers/products.ts
@@ -1,4 +1,6 @@
 import { getApiClient, extractError } from './client';
+// 仅类型引用（复用 XianyuItem 行结构），不改动 items.ts（归属其他模块）
+import type { XianyuItem, XianyuItemsPage } from './items';
 
 // ---------------------------------------------------------------------------
 // 类型定义（与任务规格保持一致）
@@ -658,6 +660,126 @@ export async function deleteCard(cardId: number): Promise<void> {
   await (client.DELETE as any)(`/api/v1/cards/${cardId}`);
 }
 
+/** 批量删除结果（对齐后端 POST /cards/batch-delete 返回的 data） */
+export interface BatchDeleteResult {
+  success_count: number;
+  total_count: number;
+}
+
+/**
+ * 批量删除卡券
+ *
+ * POST /api/v1/cards/batch-delete，body { ids: number[] }。
+ * 后端返回 ApiResponse 包裹的 { success_count, total_count }。
+ */
+export async function batchDeleteCards(
+  cardIds: number[],
+): Promise<BatchDeleteResult> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)('/api/v1/cards/batch-delete', {
+    body: { ids: cardIds },
+  })) as { data?: unknown; error?: unknown };
+  assertOk(data);
+  const inner = unwrapData<Record<string, unknown>>(data);
+  const obj = inner && typeof inner === 'object' ? inner : {};
+  return {
+    success_count: num(obj.success_count, 0),
+    total_count: num(obj.total_count, cardIds.length),
+  };
+}
+
+/**
+ * 获取单个卡券详情（全量字段，含 text_content / data_content / api_config /
+ * image_urls / description 等列表轻量模式剔除的大字段）。
+ *
+ * GET /api/v1/cards/{card_id}。配合 getCardsPaged({ lite: true }) 使用：
+ * 列表走轻量接口，编辑 / 详情时按需拉取全量补全。
+ */
+export async function getCard(cardId: number): Promise<Card> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(
+    `/api/v1/cards/${cardId}`,
+  )) as { data?: unknown; error?: unknown };
+  const inner = unwrapData<unknown>(data);
+  if (inner && typeof inner === 'object' && !Array.isArray(inner)) {
+    return normalizeCard(inner as Record<string, unknown>);
+  }
+  throw new Error('卡券不存在或已删除');
+}
+
+/** 卡券分页结果 */
+export interface CardsPage {
+  list: Card[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
+export interface GetCardsPagedOptions {
+  /** 搜索关键词（后端匹配名称/描述） */
+  search?: string;
+  /** 卡券类型过滤（text/data/api/image） */
+  type?: CardKind;
+  /** 轻量模式：剔除 text_content/data_content/api_config/image_urls 等大字段 */
+  lite?: boolean;
+}
+
+/**
+ * 分页获取卡券列表（服务端搜索 + 类型过滤 + 可选轻量模式）。
+ *
+ * GET /api/v1/cards?page&page_size&search&type&lite。
+ * 后端返回裸分页对象 { list, total, page, page_size, total_pages }，
+ * 可能被 ApiResponse 包一层，统一兼容。
+ * lite=true 时列表项不含大字段，编辑/详情用 getCard(cardId) 按需补全。
+ */
+export async function getCardsPaged(
+  page: number = 1,
+  pageSize: number = 20,
+  opts: GetCardsPagedOptions = {},
+): Promise<CardsPage> {
+  const client = await getApiClient();
+  const query: Record<string, string | number | boolean> = {
+    page,
+    page_size: pageSize,
+  };
+  if (opts.search) query.search = opts.search;
+  if (opts.type) query.type = opts.type;
+  if (opts.lite) query.lite = 1;
+  const { data } = (await (client.GET as any)('/api/v1/cards', {
+    params: { query },
+  })) as { data?: unknown; error?: unknown };
+  const inner = unwrapData<unknown>(data);
+  const obj =
+    inner && typeof inner === 'object' && !Array.isArray(inner)
+      ? (inner as Record<string, unknown>)
+      : {};
+  const rawList: unknown[] = Array.isArray(inner)
+    ? inner
+    : Array.isArray(obj.list)
+      ? obj.list
+      : Array.isArray(obj.data)
+        ? obj.data
+        : Array.isArray(obj.items)
+          ? obj.items
+          : [];
+  const total = typeof obj.total === 'number' ? obj.total : rawList.length;
+  return {
+    list: rawList.map((it) =>
+      normalizeCard((it ?? {}) as Record<string, unknown>),
+    ),
+    total,
+    page: typeof obj.page === 'number' ? obj.page : page,
+    page_size: typeof obj.page_size === 'number' ? obj.page_size : pageSize,
+    total_pages:
+      typeof obj.total_pages === 'number'
+        ? obj.total_pages
+        : total > 0
+          ? Math.ceil(total / pageSize)
+          : 0,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // 商品列表（分页）
 // ---------------------------------------------------------------------------
@@ -707,6 +829,89 @@ export async function getProductItems(
       normalizeProductItem((item ?? {}) as Record<string, unknown>),
     ),
     total,
+  };
+}
+
+/** 从 item_detail（平台商品 JSON）解析主图，逻辑对齐 items.ts 的 extractImage */
+function extractItemImage(itemDetail: unknown): string | null {
+  if (typeof itemDetail !== 'string' || !itemDetail) return null;
+  try {
+    const parsed = JSON.parse(itemDetail) as { imageInfoDOList?: unknown };
+    const list = parsed.imageInfoDOList;
+    if (!Array.isArray(list)) return null;
+    const entries = list as Array<Record<string, unknown>>;
+    const major = entries.find(
+      (e) =>
+        typeof e === 'object' &&
+        e &&
+        String(e.major).toLowerCase() === 'true' &&
+        e.url,
+    );
+    const anyImg = entries.find((e) => typeof e === 'object' && e && e.url);
+    return ((major || anyImg)?.url as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** 行结构对齐 items.ts 的 mapItem（此处独立实现，避免改动 items.ts） */
+function mapXianyuItem(raw: Record<string, unknown>): XianyuItem {
+  return {
+    id: raw.id as string | number,
+    cookie_id: (raw.cookie_id as string) ?? '',
+    item_id: (raw.item_id as string) ?? '',
+    title: (raw.item_title as string) || (raw.title as string) || '',
+    price: (raw.item_price as string) || (raw.price as string) || '',
+    status: (raw.item_status_desc as string) ?? '',
+    quantity: (raw.item_quantity ?? null) as string | number | null,
+    image: extractItemImage(raw.item_detail),
+    is_seller_item: Boolean(raw.is_seller_item),
+    created_at: raw.created_at as string | undefined,
+  };
+}
+
+/**
+ * 分页搜索闲鱼已发布商品（支持关键词 + 账号过滤）。
+ *
+ * GET /api/v1/items/paginated?page&page_size&cookie_id&keyword。
+ * 与 items.ts 的 getXianyuItems 同端点，但卡券关联商品页需要 keyword
+ * 搜索参数，而 items.ts 归属其他模块不可改动，故在此独立封装；
+ * 行结构直接复用 XianyuItem / XianyuItemsPage（仅类型引用）。
+ */
+export async function searchXianyuItems(
+  page: number = 1,
+  pageSize: number = 20,
+  opts?: { cookieId?: string; keyword?: string },
+): Promise<XianyuItemsPage> {
+  const client = await getApiClient();
+  const query: Record<string, string | number> = { page, page_size: pageSize };
+  if (opts?.cookieId) query.cookie_id = opts.cookieId;
+  if (opts?.keyword) query.keyword = opts.keyword;
+  const { data } = (await (client.GET as any)('/api/v1/items/paginated', {
+    params: { query },
+  })) as { data?: unknown; error?: unknown };
+  const body = (data ?? {}) as Record<string, unknown>;
+  const rawList = Array.isArray(body.data)
+    ? (body.data as Record<string, unknown>[])
+    : Array.isArray(body)
+      ? (body as unknown as Record<string, unknown>[])
+      : Array.isArray(body.items)
+        ? (body.items as Record<string, unknown>[])
+        : [];
+  const total = typeof body.total === 'number' ? body.total : rawList.length;
+  return {
+    items: rawList.map((it) =>
+      mapXianyuItem((it ?? {}) as Record<string, unknown>),
+    ),
+    total,
+    page: typeof body.page === 'number' ? body.page : page,
+    page_size: typeof body.page_size === 'number' ? body.page_size : pageSize,
+    total_pages:
+      typeof body.total_pages === 'number'
+        ? body.total_pages
+        : total > 0
+          ? Math.ceil(total / pageSize)
+          : 0,
   };
 }
 

--- a/xianyu-mobile/api/wrappers/shared-scan.ts
+++ b/xianyu-mobile/api/wrappers/shared-scan.ts
@@ -1,0 +1,185 @@
+import { getApiClient } from './client';
+
+// ---------------------------------------------------------------------------
+// 共享多人扫码登录（管理端）
+// 后端路由前缀: /api/v1/shared-scan（backend-web/app/api/routes/shared_scan.py）
+// 管理员创建会话 → 生成分享链接 → 兼职通过链接各自扫码 → 管理端实时查看状态。
+// ---------------------------------------------------------------------------
+
+const PREFIX = '/api/v1/shared-scan';
+
+/** 共享会话（GET /list 的 list 项） */
+export interface SharedScanSession {
+  session_id: string;
+  status: string;
+  /** 兼职端分享链接（后端按请求来源拼接：{frontend_url}/shared-scan-page?session_id=...） */
+  share_url: string;
+  expires_at: string;
+  created_at: string;
+  /** 会话下兼职数量 */
+  worker_count: number;
+  /** 已扫码成功的兼职数量 */
+  success_count: number;
+}
+
+/** 创建会话结果（POST /create 的 data） */
+export interface SharedScanSessionCreated {
+  session_id: string;
+  share_url: string;
+  expires_at: string;
+}
+
+/** 单个兼职的实时扫码状态（GET /status → part_time_workers 的 list 项） */
+export interface SharedScanWorkerInfo {
+  sub_session_id: string;
+  status: string;
+  account_id: string | null;
+  cookie_saved: boolean;
+  /** 加入时间（Unix 秒时间戳） */
+  joined_at: number;
+}
+
+/** 会话下所有兼职的实时状态（GET /status?session_id=... 的 data） */
+export interface SharedSessionStatus {
+  session_id: string;
+  session_status: string;
+  part_time_workers: SharedScanWorkerInfo[];
+}
+
+// ---------------------------------------------------------------------------
+// 通用解析工具（与 card-relation.ts 的 unwrapData/assertOk 保持一致）
+// ---------------------------------------------------------------------------
+
+/** 取出 `{ success, data }` 包裹的内部 data；未包裹则原样返回 */
+function unwrapData<T>(body: unknown): T {
+  if (
+    body &&
+    typeof body === 'object' &&
+    'success' in (body as Record<string, unknown>) &&
+    'data' in (body as Record<string, unknown>)
+  ) {
+    const inner = (body as { data: unknown }).data;
+    if (inner != null) return inner as T;
+  }
+  return body as T;
+}
+
+/** 断言业务成功：body.success === false 时抛出 message */
+function assertOk(body: unknown, fallback = '操作失败'): void {
+  if (
+    body &&
+    typeof body === 'object' &&
+    (body as Record<string, unknown>).success === false
+  ) {
+    const msg = (body as Record<string, unknown>).message;
+    throw new Error(
+      (typeof msg === 'string' && msg) || fallback,
+    );
+  }
+}
+
+function str(val: unknown, fallback = ''): string {
+  if (val == null) return fallback;
+  const s = String(val);
+  return s === 'undefined' || s === 'null' ? fallback : s;
+}
+
+function num(val: unknown, fallback = 0): number {
+  if (val == null || val === '') return fallback;
+  const n = Number(val);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function nullableStr(val: unknown): string | null {
+  const s = str(val);
+  return s === '' ? null : s;
+}
+
+function normalizeSession(raw: Record<string, unknown>): SharedScanSession {
+  return {
+    session_id: str(raw.session_id),
+    status: str(raw.status, 'active'),
+    share_url: str(raw.share_url),
+    expires_at: str(raw.expires_at),
+    created_at: str(raw.created_at),
+    worker_count: num(raw.worker_count, 0),
+    success_count: num(raw.success_count, 0),
+  };
+}
+
+function normalizeWorker(raw: Record<string, unknown>): SharedScanWorkerInfo {
+  return {
+    sub_session_id: str(raw.sub_session_id),
+    status: str(raw.status, 'qrcode_ready'),
+    account_id: nullableStr(raw.account_id),
+    cookie_saved: Boolean(raw.cookie_saved),
+    joined_at: num(raw.joined_at, 0),
+  };
+}
+
+/** 创建共享会话：POST /create（无需 body），返回会话与分享链接 */
+export async function createSharedSession(): Promise<SharedScanSessionCreated> {
+  const client = await getApiClient();
+  const { data } = (await (client.POST as any)(`${PREFIX}/create`)) as {
+    data?: unknown;
+    error?: unknown;
+  };
+  assertOk(data, '创建失败');
+  const inner = unwrapData<Record<string, unknown>>(data);
+  const body = (inner && typeof inner === 'object' ? inner : {}) as Record<string, unknown>;
+  return {
+    session_id: str(body.session_id),
+    share_url: str(body.share_url),
+    expires_at: str(body.expires_at),
+  };
+}
+
+/** 会话列表（含兼职统计）：GET /list → data.sessions */
+export async function listSharedSessions(): Promise<SharedScanSession[]> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(`${PREFIX}/list`)) as {
+    data?: unknown;
+    error?: unknown;
+  };
+  assertOk(data, '获取会话列表失败');
+  const inner = unwrapData<unknown>(data);
+  let arr: unknown[] = [];
+  if (Array.isArray(inner)) arr = inner;
+  else if (inner && typeof inner === 'object') {
+    const obj = inner as Record<string, unknown>;
+    if (Array.isArray(obj.sessions)) arr = obj.sessions;
+    else if (Array.isArray(obj.list)) arr = obj.list;
+    else if (Array.isArray(obj.data)) arr = obj.data;
+  }
+  return arr.map((it) => normalizeSession((it ?? {}) as Record<string, unknown>));
+}
+
+/** 查询会话下所有兼职实时状态：GET /status?session_id=... */
+export async function getSharedSessionStatus(
+  sessionId: string,
+): Promise<SharedSessionStatus> {
+  const client = await getApiClient();
+  const { data } = (await (client.GET as any)(`${PREFIX}/status`, {
+    params: { query: { session_id: sessionId } },
+  })) as { data?: unknown; error?: unknown };
+  assertOk(data, '获取兼职状态失败');
+  const inner = unwrapData<Record<string, unknown>>(data);
+  const body = (inner && typeof inner === 'object' ? inner : {}) as Record<string, unknown>;
+  const workers = Array.isArray(body.part_time_workers) ? body.part_time_workers : [];
+  return {
+    session_id: str(body.session_id, sessionId),
+    session_status: str(body.session_status),
+    part_time_workers: workers.map((it) =>
+      normalizeWorker((it ?? {}) as Record<string, unknown>),
+    ),
+  };
+}
+
+/** 删除会话（连同兼职记录）：DELETE /{session_id} */
+export async function deleteSharedSession(sessionId: string): Promise<void> {
+  const client = await getApiClient();
+  const { data } = (await (client.DELETE as any)(
+    `${PREFIX}/${sessionId}`,
+  )) as { data?: unknown; error?: unknown };
+  assertOk(data, '删除失败');
+}

--- a/xianyu-mobile/api/wrappers/users-self.ts
+++ b/xianyu-mobile/api/wrappers/users-self.ts
@@ -1,0 +1,86 @@
+import { getApiClient, extractError } from './client';
+import { ApiError } from './errors';
+
+// ---------------------------------------------------------------------------
+// 当前用户凭证：对接码 / 分销 API 秘钥
+// 后端路由前缀: /api/v1/users（users.py）
+// 注意：GET 接口为直返信封 { success, dock_code | secret_key }（无 data 包裹），
+// 且首次调用时后端会自动生成并持久化凭证，可安全重复调用。
+// ---------------------------------------------------------------------------
+
+/** 从后端直返信封中宽松取字符串字段 */
+function pickString(data: unknown, key: string): string | null {
+  if (data && typeof data === 'object') {
+    const v = (data as Record<string, unknown>)[key];
+    if (v != null && v !== '') return String(v);
+  }
+  return null;
+}
+
+/** 获取当前用户对接码（8 位大写字母+数字，无则自动生成） */
+export async function getDockCode(): Promise<string> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.GET as any)(
+    '/api/v1/users/dock-code',
+  )) as { data?: unknown; error?: unknown };
+  if (error) throw await extractError(error);
+  const code = pickString(data, 'dock_code');
+  if (!code) throw new ApiError('未获取到对接码', 0);
+  return code;
+}
+
+/** 重置对接码（旧码立即失效，并清除所有已绑定分销商与对接记录） */
+export async function resetDockCode(): Promise<{
+  success: boolean;
+  message?: string;
+}> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.POST as any)(
+    '/api/v1/users/dock-code/reset',
+  )) as {
+    data?: { success?: boolean; message?: string };
+    error?: unknown;
+  };
+  if (error) throw await extractError(error);
+  return { success: data?.success ?? true, message: data?.message };
+}
+
+/** 获取当前用户分销秘钥（32 位随机字符，无则自动生成） */
+export async function getSecretKey(): Promise<string> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.GET as any)(
+    '/api/v1/users/secret-key',
+  )) as { data?: unknown; error?: unknown };
+  if (error) throw await extractError(error);
+  const key = pickString(data, 'secret_key');
+  if (!key) throw new ApiError('未获取到分销秘钥', 0);
+  return key;
+}
+
+/** 更换分销秘钥（旧秘钥立即失效），后端在 data 中直接返回新秘钥 */
+export async function resetSecretKey(): Promise<{
+  success: boolean;
+  message?: string;
+  secret_key?: string;
+}> {
+  const client = await getApiClient();
+  const { data, error } = (await (client.POST as any)(
+    '/api/v1/users/secret-key/reset',
+  )) as {
+    data?: {
+      success?: boolean;
+      message?: string;
+      data?: { secret_key?: string } | null;
+    };
+    error?: unknown;
+  };
+  if (error) throw await extractError(error);
+  const inner = data?.data;
+  return {
+    success: data?.success ?? true,
+    message: data?.message,
+    secret_key:
+      pickString(inner, 'secret_key') ?? pickString(data, 'secret_key') ??
+      undefined,
+  };
+}

--- a/xianyu-mobile/app.json
+++ b/xianyu-mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "闲鱼管家",
     "slug": "xianyu-mobile",
-    "version": "1.0.6",
+    "version": "1.0.8",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/xianyu-mobile/app/(tabs)/_layout.tsx
+++ b/xianyu-mobile/app/(tabs)/_layout.tsx
@@ -1,13 +1,18 @@
 import { Tabs } from 'expo-router';
 import { useColorScheme } from 'react-native';
-// StackActions 未在 expo-router 顶层导出，从其内置 react-navigation routers 取用
-import { StackActions } from 'expo-router/build/react-navigation/routers';
 import { colors, typography } from '@/lib/theme';
 import { MessageCircle, ClipboardList, ShoppingBag, User } from 'lucide-react-native';
 
 export default function TabsLayout() {
   const scheme = useColorScheme();
   const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+
+  // 切 tab 时把该 tab 的内层 Stack 弹回根页。
+  // 不能用 StackActions.popToTop()+target：expo-router 内联 stack router 不响应该 action，
+  // 实测无效；navigate 到栈中必然存在的根路由 'index' 会触发回退（pop）到它。
+  const popTabToRoot = (navigation: { navigate: (name: string, params: object) => void }) => (name: string) => {
+    (navigation as unknown as { navigate: (name: string, params: object) => void }).navigate(name, { screen: 'index' });
+  };
 
   return (
     <Tabs
@@ -32,15 +37,8 @@ export default function TabsLayout() {
       <Tabs.Screen
         name="messages"
         options={{ title: '消息', tabBarIcon: ({ color }) => <MessageCircle size={22} stroke={color} /> }}
-        // 切到"消息"tab 时把内层 messages Stack 弹回根(会话列表)，避免停在某个聊天详情
-        listeners={({ navigation }: { navigation: { getState: () => { routes: { name: string; state?: { key?: string } }[] }; dispatch: (a: unknown) => void } }) => ({
-          tabPress: () => {
-            const route = navigation.getState().routes.find((r) => r.name === 'messages');
-            const nestedKey = route?.state?.key;
-            if (nestedKey) {
-              navigation.dispatch({ ...StackActions.popToTop(), target: nestedKey });
-            }
-          },
+        listeners={({ navigation }) => ({
+          tabPress: () => popTabToRoot(navigation as never)('messages'),
         })}
       />
       <Tabs.Screen
@@ -55,16 +53,7 @@ export default function TabsLayout() {
         name="mine"
         options={{ title: '我的', tabBarIcon: ({ color }) => <User size={22} stroke={color} /> }}
         listeners={({ navigation }) => ({
-          tabPress: () => {
-            // 切到"我的"tab 时把内层 mine Stack 弹回根(菜单)，避免停在子页显示其他页面
-            const mineRoute = navigation
-              .getState()
-              .routes.find((r: { name: string; state?: { key?: string } }) => r.name === 'mine');
-            const nestedKey = mineRoute?.state?.key;
-            if (nestedKey) {
-              navigation.dispatch({ ...StackActions.popToTop(), target: nestedKey });
-            }
-          },
+          tabPress: () => popTabToRoot(navigation as never)('mine'),
         })}
       />
     </Tabs>

--- a/xianyu-mobile/app/(tabs)/mine/_layout.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/_layout.tsx
@@ -35,7 +35,9 @@ export default function MineStackLayout() {
       <Stack.Screen name="listing-monitor" options={{ title: '上新监控' }} />
       <Stack.Screen name="monitor-categories" options={{ title: '监控分类' }} />
       <Stack.Screen name="monitor-logs" options={{ title: '监控日志' }} />
+      <Stack.Screen name="monitor-items" options={{ title: '采集商品' }} />
       <Stack.Screen name="monitor-fallback" options={{ title: '兜底账号' }} />
+      <Stack.Screen name="popup-announcements" options={{ title: '弹窗公告' }} />
       <Stack.Screen name="product-publish" options={{ title: '商品发布' }} />
       <Stack.Screen name="items" options={{ title: '商品管理' }} />
       <Stack.Screen name="item-edit" options={{ title: '编辑商品' }} />

--- a/xianyu-mobile/app/(tabs)/mine/accounts.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/accounts.tsx
@@ -21,6 +21,8 @@ import { Trash2, Eye, EyeOff } from 'lucide-react-native';
 import { PasswordLoginModal } from '@/components/PasswordLoginModal';
 import * as DocumentPicker from 'expo-document-picker';
 import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system/legacy';
+import * as Sharing from 'expo-sharing';
 import { colors, spacing, typography, radius } from '@/lib/theme';
 import {
   getAccountDetailsPaginated,
@@ -32,6 +34,9 @@ import {
   batchRenewLogin,
   exportAccounts,
   importAccounts,
+  createAccountByCookie,
+  fetchAiModels,
+  type AiModelOption,
   updateAccountRemark,
   updateAccountCookie,
   updateAccountPauseDuration,
@@ -91,6 +96,9 @@ import {
 
 const PAGE_SIZE = 20;
 const POLL_INTERVAL = 2000;
+/** xlsx 导出文件的 MIME 类型 */
+const XLSX_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
 /** 顶部筛选 tab：全部 / 在线 / 离线 / 已禁用（客户端过滤已加载列表） */
 type AccountFilter = 'all' | 'online' | 'offline' | 'disabled';
@@ -386,6 +394,15 @@ export default function AccountsScreen() {
   const [batchLoading, setBatchLoading] = useState(false);
   const [pwdLoginAccount, setPwdLoginAccount] = useState<AccountDetail | null>(null);
 
+  // 手动粘贴 Cookie 添加账号
+  const [manualVisible, setManualVisible] = useState(false);
+  const [manualId, setManualId] = useState('');
+  const [manualCookie, setManualCookie] = useState('');
+  const [manualSaving, setManualSaving] = useState(false);
+
+  // 账号导出（写文件 + 系统分享）
+  const [exporting, setExporting] = useState(false);
+
   // 扫码登录状态
   const [qrVisible, setQrVisible] = useState(false);
   const [qrSession, setQrSession] = useState<QrLoginSession | null>(null);
@@ -436,6 +453,10 @@ export default function AccountsScreen() {
   const [aiPrompts, setAiPrompts] = useState('');
   const [aiTimeStart, setAiTimeStart] = useState('');
   const [aiTimeEnd, setAiTimeEnd] = useState('');
+  // AI 模型在线拉取（POST /api/v1/ai-reply-settings/models）
+  const [aiModels, setAiModels] = useState<AiModelOption[]>([]);
+  const [aiModelsLoading, setAiModelsLoading] = useState(false);
+  const [aiModelPickerVisible, setAiModelPickerVisible] = useState(false);
 
   // 默认回复
   const [replyVisible, setReplyVisible] = useState(false);
@@ -670,13 +691,82 @@ export default function AccountsScreen() {
     }
   }
 
+  /** RN Blob 无 arrayBuffer()，用 FileReader.readAsDataURL 取 base64 段 */
+  function blobToBase64(blob: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const s = String(reader.result ?? '');
+        const idx = s.indexOf(',');
+        resolve(idx >= 0 ? s.slice(idx + 1) : s);
+      };
+      reader.onerror = () => reject(new Error('读取导出数据失败'));
+      reader.readAsDataURL(blob);
+    });
+  }
+
   async function handleExport() {
+    if (exporting) return;
     const ids = multiSelect ? Array.from(selectedIds) : undefined;
+    setExporting(true);
     try {
       const blob = await exportAccounts(ids);
-      Alert.alert('导出成功', `已导出 ${blob.size} 字节数据`);
+      const base64 = await blobToBase64(blob);
+      const filename = `账号导出_${new Date().toISOString().slice(0, 10)}.xlsx`;
+      const fileUri = `${FileSystem.cacheDirectory}${filename}`;
+      await FileSystem.writeAsStringAsync(fileUri, base64, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+      // 通过系统分享面板保存到用户可见位置（微信/文件/网盘等）
+      if (await Sharing.isAvailableAsync()) {
+        await Sharing.shareAsync(fileUri, {
+          mimeType: XLSX_MIME,
+          dialogTitle: '保存账号导出文件',
+          UTI: 'com.microsoft.excel',
+        });
+      } else {
+        Alert.alert('导出成功', `已导出 ${blob.size} 字节\n文件位置：${fileUri}`);
+      }
     } catch (e) {
       Alert.alert('导出失败', (e as Error).message);
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  // ---- 手动粘贴 Cookie 添加账号 ----
+  function openManualAdd() {
+    setManualId('');
+    setManualCookie('');
+    setManualVisible(true);
+  }
+
+  async function handleManualAdd() {
+    const accountId = manualId.trim();
+    const cookie = manualCookie.trim();
+    if (!accountId) {
+      Alert.alert('缺少账号ID', '请输入账号ID（闲鱼用户唯一标识）');
+      return;
+    }
+    if (!cookie) {
+      Alert.alert('缺少Cookie', '请粘贴账号 Cookie 文本');
+      return;
+    }
+    setManualSaving(true);
+    try {
+      const res = await createAccountByCookie(accountId, cookie);
+      if (!res.success) {
+        Alert.alert('添加失败', res.message || '账号添加失败');
+        return;
+      }
+      setManualVisible(false);
+      useAccountsStore.getState().invalidate();
+      Alert.alert('成功', '账号已添加');
+      await loadAccounts(true);
+    } catch (e) {
+      Alert.alert('添加失败', (e as Error).message);
+    } finally {
+      setManualSaving(false);
     }
   }
 
@@ -959,6 +1049,9 @@ export default function AccountsScreen() {
     setAiPrompts('');
     setAiTimeStart('');
     setAiTimeEnd('');
+    setAiModels([]);
+    setAiModelsLoading(false);
+    setAiModelPickerVisible(false);
     getAccountAiSettings(account.id)
       .then((s) => {
         if (req !== aiReqRef.current) return;
@@ -997,6 +1090,39 @@ export default function AccountsScreen() {
     const isPrevDefault =
       !aiApiUrl || Object.values(AI_PROVIDER_DEFAULT_BASE_URLS).includes(aiApiUrl);
     if (isPrevDefault) setAiApiUrl(AI_PROVIDER_DEFAULT_BASE_URLS[next]);
+  }
+
+  // ---- AI 模型在线拉取（dashscope_app 不支持，后端也会拒绝）----
+  async function handleFetchAiModels() {
+    if (aiModelsLoading) return;
+    if (aiProvider === 'dashscope_app') {
+      Alert.alert('不支持自动获取', 'DashScope应用API不支持获取模型列表，请手动填写模型名称');
+      return;
+    }
+    if (!aiApiKey.trim()) {
+      Alert.alert('缺少API Key', '请先填写 API Key 再获取模型列表');
+      return;
+    }
+    setAiModelsLoading(true);
+    try {
+      const res = await fetchAiModels({
+        provider_type: aiProvider,
+        base_url: aiApiUrl.trim() || AI_PROVIDER_DEFAULT_BASE_URLS[aiProvider],
+        api_key: aiApiKey.trim(),
+      });
+      if (res.success && res.models.length > 0) {
+        setAiModels(res.models);
+        setAiModelPickerVisible(true);
+      } else {
+        setAiModels([]);
+        Alert.alert('未获取到模型', res.message || '该服务商未返回模型列表，请直接输入模型名称');
+      }
+    } catch (e) {
+      setAiModels([]);
+      Alert.alert('获取失败', (e as Error).message);
+    } finally {
+      setAiModelsLoading(false);
+    }
   }
 
   function buildAiSettings(): AIReplySettings {
@@ -1704,6 +1830,7 @@ export default function AccountsScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
       <View style={styles.header}>
+        <Button label="手动添加" onPress={openManualAdd} variant="secondary" />
         <Button label="导入" onPress={handleImport} variant="secondary" />
       </View>
 
@@ -1733,7 +1860,7 @@ export default function AccountsScreen() {
             <Button label="清Token" onPress={() => handleBatch('clearToken')} variant="secondary" style={styles.batchBtn} />
             <Button label="关通知" onPress={() => handleBatch('closeNotice')} variant="secondary" style={styles.batchBtn} />
             <Button label="续期" onPress={() => handleBatch('renew')} variant="secondary" style={styles.batchBtn} />
-            <Button label="导出" onPress={handleExport} variant="secondary" style={styles.batchBtn} />
+            <Button label="导出" onPress={handleExport} variant="secondary" style={styles.batchBtn} loading={exporting} />
             <Button label="取消" onPress={exitMultiSelect} variant="danger" style={styles.batchBtn} />
           </View>
         </View>
@@ -1853,6 +1980,114 @@ export default function AccountsScreen() {
                 </>
               )}
             </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      {/* 手动添加账号 Modal（粘贴 Cookie） */}
+      <FormModal
+        visible={manualVisible}
+        onClose={() => setManualVisible(false)}
+        title="手动添加账号"
+      >
+        <View style={styles.fieldGroup}>
+          <Text style={[styles.fieldLabel, { color: c.textSecondary }]}>账号ID</Text>
+          <Input
+            value={manualId}
+            onChangeText={setManualId}
+            placeholder="闲鱼账号唯一标识"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+        <View style={styles.fieldGroup}>
+          <Text style={[styles.fieldLabel, { color: c.textSecondary }]}>Cookie</Text>
+          <Input
+            value={manualCookie}
+            onChangeText={setManualCookie}
+            placeholder="粘贴账号 Cookie 文本"
+            multiline
+            autoCapitalize="none"
+            autoCorrect={false}
+            style={[
+              styles.editTextarea,
+              { backgroundColor: c.background, color: c.text, borderColor: c.border },
+            ]}
+          />
+          <Text style={[styles.hintText, { color: c.textMuted }]}>
+            添加后可在账号卡片"编辑"中设置备注；请勿泄露 Cookie 给他人
+          </Text>
+        </View>
+        <View style={styles.modalActions}>
+          <Button
+            label="取消"
+            variant="ghost"
+            onPress={() => setManualVisible(false)}
+            style={styles.modalBtn}
+          />
+          <Button
+            label="添加"
+            onPress={handleManualAdd}
+            loading={manualSaving}
+            disabled={manualSaving}
+            style={styles.modalBtn}
+          />
+        </View>
+      </FormModal>
+
+      {/* AI 模型选择 Modal（在线拉取结果） */}
+      <Modal
+        visible={aiModelPickerVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setAiModelPickerVisible(false)}
+      >
+        <Pressable
+          style={styles.modalOverlay}
+          onPress={() => setAiModelPickerVisible(false)}
+        >
+          <Pressable
+            style={[styles.modalCard, styles.modelPickerCard, { backgroundColor: c.surface }]}
+            onPress={() => {}}
+          >
+            <View style={styles.modalHeader}>
+              <Text style={[styles.modalTitle, { color: c.text }]}>
+                选择模型（共 {aiModels.length} 个）
+              </Text>
+              <Pressable
+                onPress={() => setAiModelPickerVisible(false)}
+                hitSlop={8}
+              >
+                <Text style={[styles.closeBtn, { color: c.textMuted }]}>✕</Text>
+              </Pressable>
+            </View>
+            <FlatList
+              data={aiModels}
+              keyExtractor={(item) => item.id}
+              style={styles.modelList}
+              keyboardShouldPersistTaps="handled"
+              renderItem={({ item }) => (
+                <Pressable
+                  onPress={() => {
+                    setAiModel(item.id);
+                    setAiModelPickerVisible(false);
+                  }}
+                  style={({ pressed }) => [
+                    styles.modelItem,
+                    { borderBottomColor: c.border, opacity: pressed ? 0.6 : 1 },
+                  ]}
+                >
+                  <Text style={[styles.modelName, { color: c.text }]} numberOfLines={1}>
+                    {item.id}
+                  </Text>
+                  {item.name !== item.id ? (
+                    <Text style={[styles.modelAlias, { color: c.textMuted }]} numberOfLines={1}>
+                      {item.name}
+                    </Text>
+                  ) : null}
+                </Pressable>
+              )}
+            />
           </Pressable>
         </Pressable>
       </Modal>
@@ -2162,13 +2397,24 @@ export default function AccountsScreen() {
 
               <View style={styles.fieldGroup}>
                 <Text style={[styles.fieldLabel, { color: c.textSecondary }]}>模型</Text>
-                <Input
-                  value={aiModel}
-                  onChangeText={setAiModel}
-                  placeholder="如 qwen-plus"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                />
+                <View style={styles.modelRow}>
+                  <Input
+                    value={aiModel}
+                    onChangeText={setAiModel}
+                    placeholder="如 qwen-plus"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    style={styles.modelInput}
+                  />
+                  <Button
+                    label="获取模型"
+                    variant="secondary"
+                    onPress={handleFetchAiModels}
+                    loading={aiModelsLoading}
+                    disabled={aiModelsLoading}
+                    style={styles.modelFetchBtn}
+                  />
+                </View>
               </View>
 
               <View style={styles.fieldGroup}>
@@ -3117,4 +3363,17 @@ const styles = StyleSheet.create({
   ruleTitleBox: { flex: 1, marginRight: spacing.sm, gap: spacing.xs },
   ruleName: { ...typography.body, fontWeight: '600' },
   ruleDesc: { ...typography.small },
+  // AI 模型在线拉取
+  modelRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  modelInput: { flex: 1 },
+  modelFetchBtn: { minHeight: 50, paddingHorizontal: spacing.md },
+  modelPickerCard: { maxHeight: '70%', minHeight: 260 },
+  modelList: { flexGrow: 0, marginTop: spacing.sm },
+  modelItem: {
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 2,
+  },
+  modelName: { ...typography.body },
+  modelAlias: { ...typography.small },
 });

--- a/xianyu-mobile/app/(tabs)/mine/admin-users.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/admin-users.tsx
@@ -74,6 +74,10 @@ export default function AdminUsersScreen() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
+  // 用户名搜索（后端 GET /admin/users 支持 username 模糊筛选）
+  const [searchInput, setSearchInput] = useState('');
+  const [searchKeyword, setSearchKeyword] = useState('');
+
   // 新增用户
   const [createVisible, setCreateVisible] = useState(false);
   const [createForm, setCreateForm] = useState({
@@ -108,7 +112,7 @@ export default function AdminUsersScreen() {
   const loadUsers = useCallback(async () => {
     setRefreshing(true);
     try {
-      const list = await getAdminUsers();
+      const list = await getAdminUsers(searchKeyword || undefined);
       setUsers(list);
     } catch (e) {
       Alert.alert('加载失败', (e as Error).message);
@@ -116,11 +120,21 @@ export default function AdminUsersScreen() {
       setLoading(false);
       setRefreshing(false);
     }
-  }, []);
+  }, [searchKeyword]);
 
   useEffect(() => {
     loadUsers();
   }, [loadUsers]);
+
+  /** 应用搜索框关键词；为空则取消筛选（loadUsers 依赖 searchKeyword 自动重查） */
+  function handleSearch() {
+    setSearchKeyword(searchInput.trim());
+  }
+
+  function handleClearSearch() {
+    setSearchInput('');
+    setSearchKeyword('');
+  }
 
   function resetCreateForm() {
     setCreateForm({ username: '', email: '', password: '', role: 'MEMBER' });
@@ -262,6 +276,26 @@ export default function AdminUsersScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
+      <View style={styles.searchRow}>
+        <Input
+          value={searchInput}
+          onChangeText={setSearchInput}
+          placeholder="搜索用户名"
+          autoCapitalize="none"
+          returnKeyType="search"
+          onSubmitEditing={handleSearch}
+          style={styles.searchInput}
+        />
+        <Button label="查询" variant="secondary" onPress={handleSearch} style={styles.searchBtn} />
+      </View>
+      {searchKeyword ? (
+        <Pressable style={styles.searchHint} onPress={handleClearSearch} hitSlop={6}>
+          <Text style={[styles.searchHintText, { color: c.primary }]}>
+            筛选：{searchKeyword}（点击取消）
+          </Text>
+        </Pressable>
+      ) : null}
+
       <View style={styles.header}>
         <Button label="新增用户" onPress={() => setCreateVisible(true)} variant="secondary" />
       </View>
@@ -643,7 +677,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
   },
-  listContent: { padding: spacing.lg, gap: spacing.md },
+  listContent: { padding: spacing.lg, gap: spacing.md, paddingBottom: 80 },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+  },
+  searchInput: { flex: 1, minHeight: 40 },
+  searchBtn: { minHeight: 40, paddingHorizontal: spacing.lg },
+  searchHint: { paddingHorizontal: spacing.lg, paddingTop: spacing.xs },
+  searchHintText: { ...typography.caption },
   card: { gap: spacing.md },
   cardHeader: {
     flexDirection: 'row',

--- a/xianyu-mobile/app/(tabs)/mine/card-item-relation.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/card-item-relation.tsx
@@ -15,9 +15,10 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { CheckSquare, Square, Package } from 'lucide-react-native';
-import { EmptyState, Button, Loading } from '@/components/ui';
+import { EmptyState, Button, Loading, Input } from '@/components/ui';
 import { colors, spacing, typography, radius } from '@/lib/theme';
-import { getXianyuItems, type XianyuItem } from '@/api/wrappers/items';
+import type { XianyuItem } from '@/api/wrappers/items';
+import { searchXianyuItems } from '@/api/wrappers/products';
 import { getAccountOptions, type AccountOption } from '@/api/wrappers/accounts';
 import {
   getCardItemIds,
@@ -49,6 +50,10 @@ export default function CardItemRelationScreen() {
   // 选中态以 getCardItemIds 为准（含已删除商品的孤儿关联），保存时不丢失
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
+  // 商品标题搜索（服务端 keyword，500ms 防抖）
+  const [searchText, setSearchText] = useState('');
+  const [keyword, setKeyword] = useState('');
+
   // 切换账号/分页会触发重复请求，用序号丢弃过期响应
   const reqSeqRef = useRef(0);
 
@@ -72,14 +77,21 @@ export default function CardItemRelationScreen() {
   }, [cardId]);
 
   const loadItems = useCallback(
-    async (accountId: string, opts?: { append?: boolean; fromPage?: number }) => {
+    async (
+      accountId: string,
+      opts?: { append?: boolean; fromPage?: number; keyword?: string },
+    ) => {
       const append = opts?.append ?? false;
       const targetPage = opts?.fromPage ?? 1;
+      const kw = opts?.keyword ?? keyword;
       const seq = ++reqSeqRef.current;
       if (append) setLoadingMore(true);
       else if (opts?.fromPage == null) setRefreshing(true);
       try {
-        const res = await getXianyuItems(targetPage, PAGE_SIZE, accountId || undefined);
+        const res = await searchXianyuItems(targetPage, PAGE_SIZE, {
+          cookieId: accountId || undefined,
+          keyword: kw || undefined,
+        });
         if (seq !== reqSeqRef.current) return;
         setItems((prev) => (append ? [...prev, ...res.items] : res.items));
         setPage(res.page);
@@ -95,7 +107,7 @@ export default function CardItemRelationScreen() {
         setLoading(false);
       }
     },
-    [],
+    [keyword],
   );
 
   useEffect(() => {
@@ -104,14 +116,20 @@ export default function CardItemRelationScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // 标题搜索防抖 500ms（与账号切换一样重置到第一页）
+  useEffect(() => {
+    const t = setTimeout(() => setKeyword(searchText.trim()), 500);
+    return () => clearTimeout(t);
+  }, [searchText]);
+
   useEffect(() => {
     setLoading(true);
-    loadItems(selectedAccountId);
-  }, [selectedAccountId, loadItems]);
+    loadItems(selectedAccountId, { keyword });
+  }, [selectedAccountId, keyword, loadItems]);
 
   const handleRefresh = useCallback(() => {
-    loadItems(selectedAccountId);
-  }, [selectedAccountId, loadItems]);
+    loadItems(selectedAccountId, { keyword });
+  }, [selectedAccountId, keyword, loadItems]);
 
   const handleLoadMore = useCallback(() => {
     if (loadingMore || refreshing || loading) return;
@@ -246,6 +264,17 @@ export default function CardItemRelationScreen() {
         </ScrollView>
       </View>
 
+      {/* 商品标题搜索（服务端 keyword） */}
+      <View style={[styles.searchWrap, { backgroundColor: c.surface, borderColor: c.border }]}>
+        <Input
+          value={searchText}
+          onChangeText={setSearchText}
+          placeholder="搜索商品标题"
+          style={styles.searchInput}
+          returnKeyType="search"
+        />
+      </View>
+
       {/* 工具栏：标题 + 全选 + 计数 */}
       <View style={[styles.toolbar, { borderBottomColor: c.borderLight, backgroundColor: c.surfaceAlt }]}>
         <View style={styles.toolbarLeft}>
@@ -287,7 +316,13 @@ export default function CardItemRelationScreen() {
           <EmptyState
             icon={Package}
             title="暂无商品"
-            message={selectedAccountId ? '该账号暂无已发布商品' : '暂无已发布商品'}
+            message={
+              keyword
+                ? '没有匹配的商品'
+                : selectedAccountId
+                  ? '该账号暂无已发布商品'
+                  : '暂无已发布商品'
+            }
           />
         }
         ListFooterComponent={
@@ -323,6 +358,14 @@ export default function CardItemRelationScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   accountBar: { borderBottomWidth: 1, paddingBottom: spacing.sm },
+  searchWrap: {
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+    borderRadius: radius.md,
+    borderWidth: 1,
+  },
+  searchInput: { minHeight: 40, borderWidth: 0, borderRadius: 0 },
   chipRowScroll: { gap: spacing.sm, paddingHorizontal: spacing.lg, paddingVertical: 2 },
   chip: {
     paddingHorizontal: spacing.md,

--- a/xianyu-mobile/app/(tabs)/mine/cards.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/cards.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   View,
   Text,
@@ -13,19 +13,34 @@ import {
   KeyboardAvoidingView,
   Platform,
   Image,
+  ActivityIndicator,
   type TextStyle,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useColorScheme } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import { Card, Button, Input, Loading, EmptyState, Badge, FilterTabs } from '@/components/ui';
-import { Ticket, Plus, X } from 'lucide-react-native';
+import { useRouter } from 'expo-router';
+import { Card, Button, Input, Loading, EmptyState, Badge, FilterTabs, DetailRow } from '@/components/ui';
+import {
+  Ticket,
+  Plus,
+  X,
+  Eye,
+  Pencil,
+  Link2,
+  Copy,
+  CheckSquare,
+  Square,
+  Trash2,
+} from 'lucide-react-native';
 import { colors, spacing, typography, radius } from '@/lib/theme';
 import {
-  getCards,
+  getCardsPaged,
+  getCard,
   createCard,
   updateCard,
   deleteCard,
+  batchDeleteCards,
   uploadCardImage,
   type Card as CardType,
   type CardKind,
@@ -35,6 +50,18 @@ import {
 // ---------------------------------------------------------------------------
 // 常量与映射
 // ---------------------------------------------------------------------------
+
+/** 列表分页大小（服务端分页 + onEndReached 增量加载） */
+const PAGE_SIZE = 20;
+
+/** 类型筛选 tab（筛选条件传给服务端 type 参数，不再做客户端计数） */
+const FILTER_TABS: { key: string; label: string }[] = [
+  { key: 'all', label: '全部' },
+  { key: 'text', label: '固定文字' },
+  { key: 'data', label: '批量数据' },
+  { key: 'api', label: 'API' },
+  { key: 'image', label: '图片' },
+];
 
 const TYPE_OPTIONS: { key: CardKind; label: string }[] = [
   { key: 'text', label: '固定文字' },
@@ -252,12 +279,21 @@ function validateForm(f: CardFormState): string {
 export default function CardsScreen() {
   const scheme = useColorScheme();
   const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+  const router = useRouter();
 
+  // 列表：服务端分页 + 搜索 + 类型过滤（lite 轻量字段，编辑/详情按需补全）
   const [cards, setCards] = useState<CardType[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState<string>('all');
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
+  const [total, setTotal] = useState(0);
+  // 搜索/筛选/翻页并发请求用序号丢弃过期响应
+  const reqSeqRef = useRef(0);
 
   const [modalVisible, setModalVisible] = useState(false);
   const [editing, setEditing] = useState<CardType | null>(null);
@@ -266,54 +302,68 @@ export default function CardsScreen() {
   const [uploading, setUploading] = useState(false);
   const [dockOpen, setDockOpen] = useState(false);
   const [specOpen, setSpecOpen] = useState(false);
+  // lite 列表项缺大字段，编辑/复制前按需拉全量时的加载态
+  const [formLoading, setFormLoading] = useState(false);
 
-  const loadCards = useCallback(async () => {
-    try {
-      setRefreshing(true);
-      const list = await getCards();
-      setCards(list);
-    } catch (e) {
-      Alert.alert('加载失败', (e as Error).message);
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  }, []);
+  // 长按操作菜单
+  const [menuCard, setMenuCard] = useState<CardType | null>(null);
+  // 批量删除多选模式
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [batchDeleting, setBatchDeleting] = useState(false);
+  // 只读详情
+  const [detail, setDetail] = useState<CardType | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
 
-  useEffect(() => {
-    loadCards();
-  }, [loadCards]);
-
-  // 客户端过滤（已一次性拉取全部卡券）
-  const filtered = useMemo(() => {
-    const kw = search.trim().toLowerCase();
-    return cards.filter((card) => {
-      if (typeFilter !== 'all' && card.type !== typeFilter) return false;
-      if (!kw) return true;
-      const hay = `${card.name ?? ''} ${card.description ?? ''}`.toLowerCase();
-      return hay.includes(kw);
-    });
-  }, [cards, search, typeFilter]);
-
-  // 各类型计数（基于全量，不受搜索影响）
-  const typeCounts = useMemo(() => {
-    const map: Record<string, number> = { text: 0, data: 0, api: 0, image: 0 };
-    for (const card of cards) {
-      if (card.type && map[card.type] != null) map[card.type]++;
-    }
-    return map;
-  }, [cards]);
-
-  const filterTabs = useMemo(
-    () => [
-      { key: 'all', label: '全部', count: cards.length },
-      { key: 'text', label: '固定文字', count: typeCounts.text },
-      { key: 'data', label: '批量数据', count: typeCounts.data },
-      { key: 'api', label: 'API', count: typeCounts.api },
-      { key: 'image', label: '图片', count: typeCounts.image },
-    ],
-    [cards.length, typeCounts],
+  const fetchPage = useCallback(
+    async (targetPage: number, mode: 'reset' | 'append') => {
+      const seq = ++reqSeqRef.current;
+      if (mode === 'append') setLoadingMore(true);
+      else setRefreshing(true);
+      try {
+        const res = await getCardsPaged(targetPage, PAGE_SIZE, {
+          search: debouncedSearch,
+          type: typeFilter === 'all' ? undefined : (typeFilter as CardKind),
+          lite: true,
+        });
+        if (seq !== reqSeqRef.current) return;
+        setCards((prev) =>
+          mode === 'append' ? [...prev, ...res.list] : res.list,
+        );
+        setPage(res.page);
+        setTotalPages(res.total_pages);
+        setTotal(res.total);
+      } catch (e) {
+        if (seq !== reqSeqRef.current) return;
+        Alert.alert('加载失败', (e as Error).message);
+      } finally {
+        if (seq !== reqSeqRef.current) return;
+        setRefreshing(false);
+        setLoadingMore(false);
+        setLoading(false);
+      }
+    },
+    [debouncedSearch, typeFilter],
   );
+
+  // 首次加载 + 关键词（防抖后）/类型筛选变化时重置到第一页
+  useEffect(() => {
+    fetchPage(1, 'reset');
+  }, [fetchPage]);
+
+  // 搜索防抖 500ms，走服务端 search
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search.trim()), 500);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const loadCards = useCallback(() => fetchPage(1, 'reset'), [fetchPage]);
+
+  const loadMore = useCallback(() => {
+    if (loadingMore || refreshing) return;
+    if (totalPages > 0 && page >= totalPages) return;
+    return fetchPage(page + 1, 'append');
+  }, [loadingMore, refreshing, totalPages, page, fetchPage]);
 
   function openCreate() {
     setEditing(null);
@@ -323,12 +373,136 @@ export default function CardsScreen() {
     setModalVisible(true);
   }
 
-  function openEdit(card: CardType) {
-    setEditing(card);
-    setForm(cardToForm(card));
-    setDockOpen(card.is_dockable ?? false);
-    setSpecOpen(card.is_multi_spec ?? false);
-    setModalVisible(true);
+  /** lite 列表项缺 text/data/api_config/图片等大字段，编辑前按需拉全量 */
+  async function openEdit(card: CardType) {
+    setMenuCard(null);
+    setFormLoading(true);
+    try {
+      const full = await getCard(card.id);
+      setEditing(full);
+      setForm(cardToForm(full));
+      setDockOpen(full.is_dockable ?? false);
+      setSpecOpen(full.is_multi_spec ?? false);
+      setModalVisible(true);
+    } catch (e) {
+      Alert.alert('加载卡券失败', (e as Error).message);
+    } finally {
+      setFormLoading(false);
+    }
+  }
+
+  /** 复制卡券：以现有卡券预填表单并清空名称，保存时走新建（createCard） */
+  async function copyCard(card: CardType) {
+    setMenuCard(null);
+    setFormLoading(true);
+    try {
+      const full = await getCard(card.id);
+      const next = cardToForm(full);
+      next.name = '';
+      setEditing(null);
+      setForm(next);
+      setDockOpen(next.isDockable);
+      setSpecOpen(next.isMultiSpec);
+      setModalVisible(true);
+    } catch (e) {
+      Alert.alert('加载卡券失败', (e as Error).message);
+    } finally {
+      setFormLoading(false);
+    }
+  }
+
+  /** 查看详情：先展示列表轻量信息，再用全量接口替换 */
+  async function openDetail(card: CardType) {
+    setMenuCard(null);
+    setDetail(card);
+    setDetailLoading(true);
+    try {
+      const full = await getCard(card.id);
+      setDetail(full);
+    } catch (e) {
+      Alert.alert('加载详情失败', (e as Error).message);
+      setDetail(null);
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  /** 跳转卡券→商品关联页（mine Stack 已注册 card-item-relation） */
+  function openRelation(card: CardType) {
+    setMenuCard(null);
+    router.push({
+      pathname: '/(tabs)/mine/card-item-relation',
+      params: {
+        cardId: String(card.id),
+        cardName: card.name || card.remark || `卡券 #${card.id}`,
+      },
+    });
+  }
+
+  // ------------------------- 批量删除（多选模式） -------------------------
+
+  function enterSelectMode(card: CardType) {
+    setMenuCard(null);
+    setSelectMode(true);
+    setSelectedIds(new Set([card.id]));
+  }
+
+  function exitSelectMode() {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }
+
+  function toggleSelect(id: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const allLoadedSelected =
+    cards.length > 0 && cards.every((x) => selectedIds.has(x.id));
+
+  /** 全选/取消全选：作用于当前已加载的卡券 */
+  function toggleSelectAll() {
+    setSelectedIds((prev) => {
+      if (allLoadedSelected) return new Set();
+      return new Set(cards.map((x) => x.id));
+    });
+  }
+
+  function confirmBatchDelete() {
+    if (selectedIds.size === 0) {
+      Alert.alert('提示', '请先选择要删除的卡券');
+      return;
+    }
+    Alert.alert(
+      '批量删除',
+      `确定删除选中的 ${selectedIds.size} 张卡券吗？此操作不可恢复。`,
+      [
+        { text: '取消', style: 'cancel' },
+        { text: '删除', style: 'destructive', onPress: () => void doBatchDelete() },
+      ],
+      { cancelable: true },
+    );
+  }
+
+  async function doBatchDelete() {
+    setBatchDeleting(true);
+    try {
+      const res = await batchDeleteCards(Array.from(selectedIds));
+      exitSelectMode();
+      Alert.alert(
+        '删除完成',
+        `成功删除 ${res.success_count}/${res.total_count} 张卡券`,
+      );
+      await loadCards();
+    } catch (e) {
+      Alert.alert('删除失败', (e as Error).message);
+    } finally {
+      setBatchDeleting(false);
+    }
   }
 
   function closeModal() {
@@ -425,12 +599,13 @@ export default function CardsScreen() {
   }
 
   function confirmDelete(card: CardType) {
+    setMenuCard(null);
     Alert.alert(
       '删除卡券',
       `确定删除「${card.name || card.remark || '此卡券'}」吗？此操作不可恢复。`,
       [
         { text: '取消', style: 'cancel' },
-        { text: '删除', style: 'destructive', onPress: () => doDelete(card) },
+        { text: '删除', style: 'destructive', onPress: () => void doDelete(card) },
       ],
       { cancelable: true },
     );
@@ -440,17 +615,10 @@ export default function CardsScreen() {
     try {
       await deleteCard(card.id);
       setCards((prev) => prev.filter((x) => x.id !== card.id));
+      setTotal((t) => Math.max(0, t - 1));
     } catch (e) {
       Alert.alert('删除失败', (e as Error).message);
     }
-  }
-
-  function handleLongPress(card: CardType) {
-    Alert.alert(card.name || card.remark || '卡券', undefined, [
-      { text: '编辑', onPress: () => openEdit(card) },
-      { text: '删除', style: 'destructive', onPress: () => confirmDelete(card) },
-      { text: '取消', style: 'cancel' },
-    ]);
   }
 
   if (loading) {
@@ -463,9 +631,37 @@ export default function CardsScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
-      <View style={styles.header}>
-        <Button label="+ 新建" onPress={openCreate} variant="secondary" />
-      </View>
+      {selectMode ? (
+        <View style={[styles.header, styles.selectHeader, { borderBottomColor: c.border }]}>
+          <Pressable onPress={toggleSelectAll} style={styles.selectAllBtn} hitSlop={4}>
+            {allLoadedSelected ? (
+              <CheckSquare size={16} color={c.primary} />
+            ) : (
+              <Square size={16} color={c.textMuted} />
+            )}
+            <Text style={[styles.selectAllText, { color: c.textSecondary }]}>全选</Text>
+          </Pressable>
+          <Text style={[styles.selectCount, { color: c.text }]}>
+            已选 {selectedIds.size} / {total}
+          </Text>
+          <View style={styles.selectActions}>
+            <Button
+              label="删除"
+              variant="danger"
+              onPress={confirmBatchDelete}
+              loading={batchDeleting}
+              disabled={batchDeleting}
+              style={styles.selectBtn}
+            />
+            <Button label="取消" variant="ghost" onPress={exitSelectMode} style={styles.selectBtn} />
+          </View>
+        </View>
+      ) : (
+        <View style={styles.header}>
+          <Text style={[styles.headerTitle, { color: c.text }]}>共 {total} 张</Text>
+          <Button label="+ 新建" onPress={openCreate} variant="secondary" />
+        </View>
+      )}
 
       <View style={[styles.searchWrap, { backgroundColor: c.surface, borderColor: c.border }]}>
         <Input
@@ -477,46 +673,68 @@ export default function CardsScreen() {
         />
       </View>
 
-      <FilterTabs tabs={filterTabs} active={typeFilter} onChange={setTypeFilter} />
+      <FilterTabs tabs={FILTER_TABS} active={typeFilter} onChange={setTypeFilter} />
 
       <FlatList
-        data={filtered}
+        data={cards}
         keyExtractor={(item) => String(item.id)}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={loadCards} />}
-        renderItem={({ item }) => (
-          <Pressable onPress={() => openEdit(item)} onLongPress={() => handleLongPress(item)}>
-            <Card style={styles.cardItem}>
-              <View style={styles.cardTop}>
-                <View style={styles.cardTitleRow}>
-                  <Text style={[styles.cardName, { color: c.text }]} numberOfLines={1}>
-                    {item.name || '未命名卡券'}
-                  </Text>
-                  <Badge label={typeLabel(item.type)} variant={typeBadgeVariant(item.type)} />
+        onEndReached={loadMore}
+        onEndReachedThreshold={0.3}
+        renderItem={({ item }) => {
+          const checked = selectedIds.has(item.id);
+          return (
+            <Pressable
+              onPress={() => (selectMode ? toggleSelect(item.id) : openEdit(item))}
+              onLongPress={() => (selectMode ? undefined : setMenuCard(item))}
+            >
+              <Card
+                style={[styles.cardItem, selectMode && checked && { borderColor: c.primary }]}
+              >
+                <View style={styles.cardTop}>
+                  <View style={styles.cardTitleRow}>
+                    {selectMode ? (
+                      checked ? (
+                        <CheckSquare size={18} color={c.primary} />
+                      ) : (
+                        <Square size={18} color={c.textMuted} />
+                      )
+                    ) : null}
+                    <Text style={[styles.cardName, { color: c.text }]} numberOfLines={1}>
+                      {item.name || '未命名卡券'}
+                    </Text>
+                    <Badge label={typeLabel(item.type)} variant={typeBadgeVariant(item.type)} />
+                  </View>
+                  {!selectMode ? (
+                    <Switch
+                      value={item.enabled ?? true}
+                      onValueChange={(v) => toggleEnabled(item, v)}
+                      trackColor={{ false: c.border, true: c.primary }}
+                    />
+                  ) : null}
                 </View>
-                <Switch
-                  value={item.enabled ?? true}
-                  onValueChange={(v) => toggleEnabled(item, v)}
-                  trackColor={{ false: c.border, true: c.primary }}
-                />
-              </View>
-              {item.description ? (
-                <Text style={[styles.cardDesc, { color: c.textMuted }]} numberOfLines={1}>
-                  {item.description.slice(0, 40)}
-                </Text>
-              ) : null}
-              <View style={styles.cardMeta}>
-                {item.is_dockable ? (
-                  <Badge label={`对接 ¥${item.price || '-'}`} variant="info" />
+                {item.description ? (
+                  <Text style={[styles.cardDesc, { color: c.textMuted }]} numberOfLines={1}>
+                    {item.description.slice(0, 40)}
+                  </Text>
                 ) : null}
-                {item.is_multi_spec ? (
-                  <Badge label={`${item.spec_name || ''}:${item.spec_value || ''}`} variant="warning" />
-                ) : null}
-                {item.use_no_logistics_form ? <Badge label="无物流" variant="gray" /> : null}
-                {item.delay_seconds ? <Badge label={`延时${item.delay_seconds}s`} variant="gray" /> : null}
-              </View>
-            </Card>
-          </Pressable>
-        )}
+                <View style={styles.cardMeta}>
+                  {item.is_dockable ? (
+                    <Badge label={`对接 ¥${item.price || '-'}`} variant="info" />
+                  ) : null}
+                  {item.is_multi_spec ? (
+                    <Badge label={`${item.spec_name || ''}:${item.spec_value || ''}`} variant="warning" />
+                  ) : null}
+                  {item.use_no_logistics_form ? <Badge label="无物流" variant="gray" /> : null}
+                  {item.delay_seconds ? <Badge label={`延时${item.delay_seconds}s`} variant="gray" /> : null}
+                  {item.delivery_count ? (
+                    <Badge label={`已发货 ${item.delivery_count} 次`} variant="gray" />
+                  ) : null}
+                </View>
+              </Card>
+            </Pressable>
+          );
+        }}
         ListEmptyComponent={
           <EmptyState
             icon={Ticket}
@@ -525,6 +743,15 @@ export default function CardsScreen() {
             actionLabel="添加卡券"
             onAction={openCreate}
           />
+        }
+        ListFooterComponent={
+          loadingMore ? (
+            <View style={styles.footer}>
+              <ActivityIndicator size="small" color={c.primary} />
+            </View>
+          ) : cards.length > 0 && totalPages > 0 && page >= totalPages ? (
+            <Text style={[styles.footerText, { color: c.textMuted }]}>没有更多了</Text>
+          ) : null
         }
         contentContainerStyle={styles.list}
       />
@@ -944,15 +1171,183 @@ export default function CardsScreen() {
               <Button
                 label="保存"
                 onPress={save}
-                loading={saving}
-                disabled={saving}
+                loading={saving || formLoading}
+                disabled={saving || formLoading}
                 style={styles.modalBtn}
               />
             </View>
           </View>
         </KeyboardAvoidingView>
       </Modal>
+
+      {/* 长按操作菜单 */}
+      <Modal
+        visible={menuCard !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setMenuCard(null)}
+      >
+        <Pressable style={styles.menuBackdrop} onPress={() => setMenuCard(null)}>
+          <View style={[styles.menuSheet, { backgroundColor: c.surface }]}>
+            <Text style={[styles.menuTitle, { color: c.text }]} numberOfLines={1}>
+              {menuCard?.name || menuCard?.remark || '卡券'}
+            </Text>
+            <MenuItem icon={Eye} label="查看详情" onPress={() => menuCard && void openDetail(menuCard)} />
+            <MenuItem icon={Pencil} label="编辑" onPress={() => menuCard && void openEdit(menuCard)} />
+            <MenuItem icon={Link2} label="关联商品" onPress={() => menuCard && openRelation(menuCard)} />
+            <MenuItem icon={Copy} label="复制" onPress={() => menuCard && void copyCard(menuCard)} />
+            <MenuItem
+              icon={CheckSquare}
+              label="批量删除（多选）"
+              onPress={() => menuCard && enterSelectMode(menuCard)}
+            />
+            <MenuItem icon={Trash2} label="删除" danger onPress={() => menuCard && confirmDelete(menuCard)} />
+            <MenuItem icon={X} label="取消" onPress={() => setMenuCard(null)} />
+          </View>
+        </Pressable>
+      </Modal>
+
+      {/* 卡券详情（只读） */}
+      <Modal
+        visible={detail !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setDetail(null)}
+      >
+        <Pressable style={styles.menuBackdrop} onPress={() => setDetail(null)}>
+          <Pressable
+            style={[styles.detailSheet, { backgroundColor: c.surface }]}
+            onPress={() => {}}
+          >
+            <View style={[styles.modalHeader, { paddingHorizontal: spacing.lg }]}>
+              <Text style={[styles.modalTitle, { color: c.text }]} numberOfLines={1}>
+                {detail?.name || '卡券详情'}
+              </Text>
+              <Pressable onPress={() => setDetail(null)} hitSlop={8}>
+                <Text style={[styles.modalClose, { color: c.textMuted }]}>✕</Text>
+              </Pressable>
+            </View>
+            {detail && !detailLoading ? (
+              <ScrollView style={styles.detailScroll} contentContainerStyle={styles.detailBody}>
+                <View style={styles.detailBadges}>
+                  <Badge label={typeLabel(detail.type)} variant={typeBadgeVariant(detail.type)} />
+                  <Badge
+                    label={detail.enabled ? '已启用' : '已停用'}
+                    variant={detail.enabled ? 'success' : 'gray'}
+                  />
+                  {detail.is_dockable ? (
+                    <Badge label={`对接 ¥${detail.price || '-'}`} variant="info" />
+                  ) : null}
+                  {detail.is_multi_spec ? (
+                    <Badge
+                      label={`${detail.spec_name || ''}:${detail.spec_value || ''}`}
+                      variant="warning"
+                    />
+                  ) : null}
+                  {detail.use_no_logistics_form ? <Badge label="无物流" variant="gray" /> : null}
+                  {detail.delay_seconds ? (
+                    <Badge label={`延时${detail.delay_seconds}s`} variant="gray" />
+                  ) : null}
+                  {detail.delivery_count ? (
+                    <Badge label={`已发货 ${detail.delivery_count} 次`} variant="gray" />
+                  ) : null}
+                </View>
+
+                <DetailRow label="名称" value={detail.name || '未命名卡券'} c={c} />
+                <DetailRow label="ID" value={String(detail.id)} c={c} />
+                {detail.description ? (
+                  <DetailRow label="备注" value={detail.description} c={c} />
+                ) : null}
+
+                {detail.type === 'text' ? (
+                  <DetailRow label="文字内容" value={detail.text_content || '（空）'} c={c} />
+                ) : null}
+
+                {detail.type === 'data' ? (
+                  <>
+                    <DetailRow
+                      label="数据条数"
+                      value={`${countDataLines(detail.data_content)} 条`}
+                      c={c}
+                    />
+                    <DetailRow label="数据内容" value={detail.data_content || '（空）'} c={c} />
+                  </>
+                ) : null}
+
+                {detail.type === 'api' && detail.api_config ? (
+                  <>
+                    <DetailRow label="接口地址" value={detail.api_config.url || '（空）'} c={c} />
+                    <DetailRow label="请求方法" value={detail.api_config.method || 'GET'} c={c} />
+                    <DetailRow
+                      label="超时时间"
+                      value={`${detail.api_config.timeout ?? 60} 秒`}
+                      c={c}
+                    />
+                    {detail.api_config.headers ? (
+                      <DetailRow label="请求头" value={detail.api_config.headers} c={c} />
+                    ) : null}
+                    {detail.api_config.params ? (
+                      <DetailRow label="请求参数" value={detail.api_config.params} c={c} />
+                    ) : null}
+                    {detail.api_config.response_field ? (
+                      <DetailRow label="取值字段" value={detail.api_config.response_field} c={c} />
+                    ) : null}
+                  </>
+                ) : null}
+
+                {detail.type === 'image' ? (
+                  <View style={styles.detailImages}>
+                    {detail.image_urls.length > 0 ? (
+                      detail.image_urls.map((url) => (
+                        <Image key={url} source={{ uri: url }} style={styles.detailImage} />
+                      ))
+                    ) : (
+                      <Text style={[styles.detailHint, { color: c.textMuted }]}>暂无图片</Text>
+                    )}
+                  </View>
+                ) : null}
+              </ScrollView>
+            ) : (
+              <View style={styles.detailLoading}>
+                <ActivityIndicator color={c.primary} />
+                <Text style={[styles.detailHint, { color: c.textMuted }]}>加载详情...</Text>
+              </View>
+            )}
+          </Pressable>
+        </Pressable>
+      </Modal>
     </SafeAreaView>
+  );
+}
+
+/** 批量数据条数：按行拆分并过滤空行 */
+function countDataLines(content?: string): number {
+  if (!content) return 0;
+  return content.split('\n').map((s) => s.trim()).filter(Boolean).length;
+}
+
+/** 长按菜单项 */
+function MenuItem({
+  icon: Icon,
+  label,
+  onPress,
+  danger,
+}: {
+  icon: React.ComponentType<{ color?: string; size?: number }>;
+  label: string;
+  onPress: () => void;
+  danger?: boolean;
+}) {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.menuItem, pressed && { opacity: 0.6 }]}
+    >
+      <Icon color={danger ? c.error : c.textSecondary} size={18} />
+      <Text style={[styles.menuItemText, { color: danger ? c.error : c.text }]}>{label}</Text>
+    </Pressable>
   );
 }
 
@@ -1193,4 +1588,52 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   imageAddText: { ...typography.small, marginTop: 2 },
+
+  // 分页 footer
+  footer: { paddingVertical: spacing.lg, alignItems: 'center' },
+  footerText: { ...typography.small, textAlign: 'center', paddingVertical: spacing.md },
+
+  // 批量删除选择态顶栏
+  selectHeader: { borderBottomWidth: StyleSheet.hairlineWidth },
+  selectAllBtn: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  selectAllText: { ...typography.small, fontWeight: '600' },
+  selectCount: { ...typography.caption, flex: 1, textAlign: 'center' },
+  selectActions: { flexDirection: 'row', gap: spacing.sm },
+  selectBtn: { minHeight: 40, paddingHorizontal: spacing.md },
+
+  // 长按操作菜单
+  menuBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.xl,
+  },
+  menuSheet: {
+    width: '100%',
+    maxWidth: 320,
+    borderRadius: radius.lg,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+  },
+  menuTitle: { ...typography.caption, fontWeight: '600', paddingVertical: spacing.sm },
+  menuItem: { flexDirection: 'row', alignItems: 'center', gap: spacing.md, paddingVertical: 11 },
+  menuItemText: { ...typography.body },
+
+  // 卡券详情（只读）
+  detailSheet: {
+    width: '100%',
+    maxWidth: 480,
+    maxHeight: '80%',
+    borderRadius: radius.lg,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+  },
+  detailScroll: { paddingHorizontal: spacing.lg },
+  detailBody: { gap: spacing.sm, paddingTop: spacing.sm },
+  detailBadges: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.xs },
+  detailImages: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+  detailImage: { width: 96, height: 96, borderRadius: radius.md },
+  detailLoading: { alignItems: 'center', gap: spacing.sm, paddingVertical: spacing.xl },
+  detailHint: { ...typography.small },
 });

--- a/xianyu-mobile/app/(tabs)/mine/crawler.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/crawler.tsx
@@ -1,47 +1,87 @@
-import { useState, useCallback, useEffect } from 'react';
-import { View, Text, StyleSheet, FlatList, Pressable, RefreshControl, Alert } from 'react-native';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  Alert,
+  Switch,
+  ScrollView,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useColorScheme } from 'react-native';
-import { Card, Button, Loading } from '@/components/ui';
+import { Plus } from 'lucide-react-native';
+import { Card, Button, Input, Loading, EmptyState, FormModal } from '@/components/ui';
 import { colors, spacing, typography, radius } from '@/lib/theme';
+import { getAccountOptions, type AccountOption } from '@/api/wrappers/accounts';
 import {
   getCrawlerJobs,
-  getCrawlerItems,
-  startCrawler,
-  stopCrawler,
+  getCrawlerJobItems,
+  createCrawlerJob,
+  deleteCrawlerJob,
+  startCrawlerJob,
+  stopCrawlerJob,
+  runCrawlerJobOnce,
   type CrawlerJob,
   type CrawlerItem,
-} from '@/api/wrappers/distribution';
+} from '@/api/wrappers/crawler';
 
-/** 运行中状态：可停止、不可再次启动 */
-function isRunning(status: string): boolean {
-  const s = status.toLowerCase();
-  return ['running', 'active', 'started', 'ongoing', 'processing'].some((k) =>
-    s.includes(k),
-  );
+/** ISO/字符串时间 → 简洁可读形式，失败则原样返回 */
+function formatTime(raw: string | null): string {
+  if (!raw) return '';
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-/** 由状态文案派生标签颜色 */
-function statusColor(status: string, c: { success: string; warning: string; error: string; textMuted: string }): string {
-  const s = status.toLowerCase();
-  if (['fail', 'error', 'stopped', 'cancel', 'timeout'].some((k) => s.includes(k)))
-    return c.error;
-  if (isRunning(status)) return c.success;
-  if (['pending', 'waiting', 'queued'].some((k) => s.includes(k))) return c.warning;
-  return c.textMuted;
+/** 数值输入兜底：非法输入回退默认值并夹紧范围 */
+function clampInt(raw: string, fallback: number, min: number, max: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, Math.round(n)));
 }
+
+const FORM_DEFAULTS = {
+  keyword: '',
+  intervalSeconds: '900',
+  startPage: '1',
+  pages: '1',
+  pageSize: '20',
+  detailLimit: '20',
+  fetchDetail: true,
+  enabled: true,
+};
 
 export default function CrawlerScreen() {
   const scheme = useColorScheme();
   const c = colors[scheme === 'dark' ? 'dark' : 'light'];
 
   const [jobs, setJobs] = useState<CrawlerJob[]>([]);
+  const [accounts, setAccounts] = useState<AccountOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [itemsMap, setItemsMap] = useState<Record<number, CrawlerItem[]>>({});
   const [itemsLoading, setItemsLoading] = useState<Record<number, boolean>>({});
+  /** 启停/删除/立即执行的按任务加载态 */
   const [actionLoading, setActionLoading] = useState<Record<number, boolean>>({});
+
+  // 新建任务表单
+  const [formVisible, setFormVisible] = useState(false);
+  const [cookieId, setCookieId] = useState('');
+  const [keyword, setKeyword] = useState(FORM_DEFAULTS.keyword);
+  const [intervalSeconds, setIntervalSeconds] = useState(FORM_DEFAULTS.intervalSeconds);
+  const [startPage, setStartPage] = useState(FORM_DEFAULTS.startPage);
+  const [pages, setPages] = useState(FORM_DEFAULTS.pages);
+  const [pageSize, setPageSize] = useState(FORM_DEFAULTS.pageSize);
+  const [detailLimit, setDetailLimit] = useState(FORM_DEFAULTS.detailLimit);
+  const [fetchDetail, setFetchDetail] = useState(FORM_DEFAULTS.fetchDetail);
+  const [enabled, setEnabled] = useState(FORM_DEFAULTS.enabled);
+  const [creating, setCreating] = useState(false);
+  const loadedAccounts = useRef(false);
 
   const loadJobs = useCallback(async () => {
     setRefreshing(true);
@@ -55,9 +95,21 @@ export default function CrawlerScreen() {
     }
   }, []);
 
+  const loadAccounts = useCallback(async (force = false) => {
+    if (loadedAccounts.current && !force) return;
+    try {
+      const list = await getAccountOptions();
+      setAccounts(list);
+      loadedAccounts.current = true;
+    } catch {
+      // 账号列表加载失败不阻塞任务列表，创建时再校验
+    }
+  }, []);
+
   useEffect(() => {
     loadJobs();
-  }, [loadJobs]);
+    loadAccounts();
+  }, [loadJobs, loadAccounts]);
 
   const toggleExpand = useCallback(
     async (job: CrawlerJob) => {
@@ -70,7 +122,7 @@ export default function CrawlerScreen() {
       if (itemsMap[job.id]) return;
       setItemsLoading((prev) => ({ ...prev, [job.id]: true }));
       try {
-        const items = await getCrawlerItems(job.id);
+        const items = await getCrawlerJobItems(job.id);
         setItemsMap((prev) => ({ ...prev, [job.id]: items }));
       } catch (e) {
         Alert.alert('加载商品失败', (e as Error).message);
@@ -81,35 +133,139 @@ export default function CrawlerScreen() {
     [expandedId, itemsMap],
   );
 
-  const handleStart = useCallback(
-    async (jobId: number) => {
+  const withAction = useCallback(
+    async (jobId: number, fn: () => Promise<void>) => {
       setActionLoading((prev) => ({ ...prev, [jobId]: true }));
       try {
-        await startCrawler(jobId);
-        await loadJobs();
-      } catch (e) {
-        Alert.alert('启动失败', (e as Error).message);
+        await fn();
       } finally {
         setActionLoading((prev) => ({ ...prev, [jobId]: false }));
       }
     },
-    [loadJobs],
+    [],
+  );
+
+  const handleStart = useCallback(
+    (jobId: number) =>
+      withAction(jobId, async () => {
+        try {
+          await startCrawlerJob(jobId);
+          await loadJobs();
+        } catch (e) {
+          Alert.alert('启动失败', (e as Error).message);
+        }
+      }),
+    [withAction, loadJobs],
   );
 
   const handleStop = useCallback(
-    async (jobId: number) => {
-      setActionLoading((prev) => ({ ...prev, [jobId]: true }));
-      try {
-        await stopCrawler(jobId);
-        await loadJobs();
-      } catch (e) {
-        Alert.alert('停止失败', (e as Error).message);
-      } finally {
-        setActionLoading((prev) => ({ ...prev, [jobId]: false }));
-      }
-    },
-    [loadJobs],
+    (jobId: number) =>
+      withAction(jobId, async () => {
+        try {
+          await stopCrawlerJob(jobId);
+          await loadJobs();
+        } catch (e) {
+          Alert.alert('停止失败', (e as Error).message);
+        }
+      }),
+    [withAction, loadJobs],
   );
+
+  /** 立即执行一次：后端同步采集，可能耗时较长 */
+  const handleRunOnce = useCallback(
+    (job: CrawlerJob) =>
+      withAction(job.id, async () => {
+        try {
+          const res = await runCrawlerJobOnce(job.id);
+          if (res.success) {
+            Alert.alert('执行完成', `写入 ${res.upserted} 条（共抓到 ${res.total} 条）`);
+          } else {
+            Alert.alert('执行失败', res.error || '采集服务返回失败');
+          }
+          setItemsMap((prev) => {
+            const next = { ...prev };
+            delete next[job.id]; // 重新展开时拉取最新结果
+            return next;
+          });
+          await loadJobs();
+        } catch (e) {
+          Alert.alert('执行失败', (e as Error).message);
+        }
+      }),
+    [withAction, loadJobs],
+  );
+
+  const confirmDeleteJob = useCallback(
+    (job: CrawlerJob) => {
+      Alert.alert(
+        '确认删除',
+        `删除任务「${job.keyword}」（#${job.id}）？采集到的 ${job.item_count} 件商品记录将一并删除，不可恢复。`,
+        [
+          { text: '取消', style: 'cancel' },
+          {
+            text: '删除',
+            style: 'destructive',
+            onPress: () =>
+              withAction(job.id, async () => {
+                try {
+                  await deleteCrawlerJob(job.id);
+                  if (expandedId === job.id) setExpandedId(null);
+                  await loadJobs();
+                } catch (e) {
+                  Alert.alert('删除失败', (e as Error).message);
+                }
+              }),
+          },
+        ],
+      );
+    },
+    [withAction, loadJobs, expandedId],
+  );
+
+  /** 长按菜单：删除/立即执行入口 */
+  function handleLongPress(job: CrawlerJob) {
+    Alert.alert(`任务 #${job.id}`, `关键词：${job.keyword}\n账号：${job.cookie_id}`, [
+      { text: '立即执行一次', onPress: () => handleRunOnce(job) },
+      { text: '删除任务', style: 'destructive', onPress: () => confirmDeleteJob(job) },
+      { text: '取消', style: 'cancel' },
+    ]);
+  }
+
+  function openCreate() {
+    loadAccounts();
+    if (!cookieId && accounts.length > 0) setCookieId(accounts[0].id);
+    setFormVisible(true);
+  }
+
+  async function handleCreate() {
+    const kw = keyword.trim();
+    if (!cookieId) { Alert.alert('提示', '请先选择采集账号'); return; }
+    if (!kw) { Alert.alert('提示', '请填写搜索关键词'); return; }
+    const interval = clampInt(intervalSeconds, 900, 60, 86400);
+    if (Number(intervalSeconds) < 60) { Alert.alert('提示', '执行间隔至少 60 秒'); return; }
+    setCreating(true);
+    try {
+      const jobId = await createCrawlerJob({
+        cookie_id: cookieId,
+        keyword: kw,
+        interval_seconds: interval,
+        start_page: clampInt(startPage, 1, 1, 50),
+        pages: clampInt(pages, 1, 1, 10),
+        page_size: clampInt(pageSize, 20, 1, 50),
+        fetch_detail: fetchDetail,
+        detail_limit: clampInt(detailLimit, 20, 0, 50),
+        enabled,
+      });
+      setFormVisible(false);
+      setKeyword(FORM_DEFAULTS.keyword);
+      Alert.alert('创建成功', jobId != null ? `任务 #${jobId} 已创建` : '任务已创建');
+      await loadJobs();
+    } catch (e) {
+      Alert.alert('创建失败', (e as Error).message);
+    } finally {
+      setCreating(false);
+    }
+  }
 
   if (loading) {
     return (
@@ -121,117 +277,213 @@ export default function CrawlerScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
+      <View style={styles.header}>
+        <Text style={[styles.headerHint, { color: c.textMuted }]}>长按任务可立即执行或删除</Text>
+        <Pressable onPress={openCreate} style={[styles.addBtn, { backgroundColor: c.primary }]} hitSlop={8}>
+          <Plus size={20} color="#FFF" />
+        </Pressable>
+      </View>
+
       <FlatList
         data={jobs}
         keyExtractor={(item) => String(item.id)}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={loadJobs} />}
         contentContainerStyle={styles.list}
         ListEmptyComponent={
-          <View style={styles.empty}>
-            <Text style={[styles.emptyText, { color: c.textMuted }]}>暂无爬虫任务</Text>
-          </View>
+          <EmptyState
+            icon={Plus}
+            title="暂无爬虫任务"
+            message="创建定时采集任务，按关键词自动抓取闲鱼商品"
+            actionLabel="新建任务"
+            onAction={openCreate}
+          />
         }
         renderItem={({ item }) => {
           const expanded = expandedId === item.id;
-          const running = isRunning(item.status);
-          const items = itemsMap[item.id];
           const busy = !!actionLoading[item.id];
+          const items = itemsMap[item.id];
           return (
-            <Card style={styles.card}>
-              <Pressable
-                onPress={() => toggleExpand(item)}
-                style={styles.jobHeader}
-              >
-                <View style={styles.jobInfo}>
-                  <Text style={[styles.jobName, { color: c.text }]} numberOfLines={1}>
-                    {item.name}
-                  </Text>
-                  <View style={styles.jobMeta}>
-                    <View
-                      style={[styles.badge, { backgroundColor: statusColor(item.status, c) }]}
-                    >
-                      <Text style={styles.badgeText}>{item.status}</Text>
-                    </View>
-                    {item.items_count != null && (
-                      <Text style={[styles.count, { color: c.textMuted }]}>
-                        {item.items_count} 件商品
-                      </Text>
-                    )}
-                  </View>
-                </View>
-                <Text style={[styles.chevron, { color: c.textMuted }]}>
-                  {expanded ? '▲' : '▼'}
-                </Text>
-              </Pressable>
-
-              <View style={styles.jobActions}>
-                <Button
-                  label="启动"
-                  variant={running ? 'ghost' : 'primary'}
-                  onPress={() => handleStart(item.id)}
-                  loading={busy}
-                  disabled={running || busy}
-                  style={styles.actionBtn}
-                />
-                <Button
-                  label="停止"
-                  variant="danger"
-                  onPress={() => handleStop(item.id)}
-                  loading={busy}
-                  disabled={!running || busy}
-                  style={styles.actionBtn}
-                />
-              </View>
-
-              {expanded && (
-                <View
-                  style={[styles.itemsWrap, { borderTopColor: c.border, borderTopWidth: 1 }]}
-                >
-                  {itemsLoading[item.id] ? (
-                    <Text style={[styles.hint, { color: c.textMuted }]}>
-                      加载商品中...
+            <Pressable onLongPress={() => handleLongPress(item)} delayLongPress={400}>
+              <Card style={styles.card}>
+                <Pressable onPress={() => toggleExpand(item)} style={styles.jobHeader}>
+                  <View style={styles.jobInfo}>
+                    <Text style={[styles.jobName, { color: c.text }]} numberOfLines={1}>
+                      {item.keyword}
                     </Text>
-                  ) : items && items.length > 0 ? (
-                    items.map((it) => (
-                      <View
-                        key={it.item_id}
-                        style={[styles.itemRow, { borderBottomColor: c.border }]}
-                      >
-                        <Text
-                          style={[styles.itemTitle, { color: c.text }]}
-                          numberOfLines={1}
-                        >
-                          {it.title}
-                        </Text>
-                        <Text style={[styles.itemPrice, { color: c.primary }]}>
-                          ¥{it.price}
-                        </Text>
+                    <Text style={[styles.jobAccount, { color: c.textMuted }]} numberOfLines={1}>
+                      #{item.id} · {item.cookie_id}
+                    </Text>
+                    <View style={styles.jobMeta}>
+                      <View style={[styles.badge, { backgroundColor: item.running ? c.success : item.enabled ? c.info : c.textMuted }]}>
+                        <Text style={styles.badgeText}>{item.running ? '运行中' : item.enabled ? '已启用' : '已停止'}</Text>
                       </View>
-                    ))
+                      <Text style={[styles.count, { color: c.textMuted }]}>{item.item_count} 件商品</Text>
+                      {item.last_run_at ? (
+                        <Text style={[styles.count, { color: c.textMuted }]} numberOfLines={1}>
+                          上次 {formatTime(item.last_run_at)}
+                        </Text>
+                      ) : null}
+                    </View>
+                    {item.last_error ? (
+                      <Text style={[styles.lastError, { color: c.error }]} numberOfLines={2}>
+                        {item.last_error}
+                      </Text>
+                    ) : null}
+                  </View>
+                  <Text style={[styles.chevron, { color: c.textMuted }]}>{expanded ? '▲' : '▼'}</Text>
+                </Pressable>
+
+                <View style={styles.jobActions}>
+                  <Button
+                    label="立即执行"
+                    variant="primary"
+                    onPress={() => handleRunOnce(item)}
+                    loading={busy}
+                    style={styles.actionBtn}
+                  />
+                  {item.running || item.enabled ? (
+                    <Button
+                      label="停止"
+                      variant="danger"
+                      onPress={() => handleStop(item.id)}
+                      loading={busy}
+                      style={styles.actionBtn}
+                    />
                   ) : (
-                    <Text style={[styles.hint, { color: c.textMuted }]}>暂无商品</Text>
+                    <Button
+                      label="启动"
+                      variant="secondary"
+                      onPress={() => handleStart(item.id)}
+                      loading={busy}
+                      style={styles.actionBtn}
+                    />
                   )}
                 </View>
-              )}
-            </Card>
+
+                {expanded && (
+                  <View style={[styles.itemsWrap, { borderTopColor: c.border, borderTopWidth: 1 }]}>
+                    {itemsLoading[item.id] ? (
+                      <Text style={[styles.hint, { color: c.textMuted }]}>加载商品中...</Text>
+                    ) : items && items.length > 0 ? (
+                      items.map((it) => (
+                        <View key={it.item_id} style={[styles.itemRow, { borderBottomColor: c.border }]}>
+                          <View style={styles.itemTexts}>
+                            <Text style={[styles.itemTitle, { color: c.text }]} numberOfLines={1}>
+                              {it.title || it.item_id}
+                            </Text>
+                            {(it.area || it.seller_name) && (
+                              <Text style={[styles.itemSub, { color: c.textMuted }]} numberOfLines={1}>
+                                {[it.area, it.seller_name].filter(Boolean).join(' · ')}
+                              </Text>
+                            )}
+                          </View>
+                          <Text style={[styles.itemPrice, { color: c.primary }]}>¥{it.price}</Text>
+                        </View>
+                      ))
+                    ) : (
+                      <Text style={[styles.hint, { color: c.textMuted }]}>暂无商品，可点击「立即执行」抓取</Text>
+                    )}
+                  </View>
+                )}
+              </Card>
+            </Pressable>
           );
         }}
       />
+
+      <FormModal visible={formVisible} onClose={() => setFormVisible(false)} title="新建采集任务">
+        <ScrollView nestedScrollEnabled style={styles.formScroll} contentContainerStyle={styles.formContent}>
+          <Text style={[styles.label, { color: c.textSecondary }]}>采集账号</Text>
+          {accounts.length === 0 ? (
+            <Text style={[styles.hint, { color: c.error }]}>暂无可用账号，请先在「账号管理」登录</Text>
+          ) : (
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.accountSelector} contentContainerStyle={styles.accountSelectorContent}>
+              {accounts.map((a) => (
+                <Pressable
+                  key={a.id}
+                  onPress={() => setCookieId(a.id)}
+                  style={[styles.accountOption, { backgroundColor: cookieId === a.id ? c.primary : c.background, borderColor: cookieId === a.id ? c.primary : c.border }]}
+                >
+                  <Text style={[styles.typeOptionText, { color: cookieId === a.id ? '#FFF' : c.text }]} numberOfLines={1}>
+                    {a.remark || a.id}
+                  </Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          )}
+
+          <Text style={[styles.label, { color: c.textSecondary }]}>搜索关键词</Text>
+          <Input value={keyword} onChangeText={setKeyword} placeholder="如：iPhone 数据线" style={styles.input} />
+
+          <View style={styles.gridRow}>
+            <View style={styles.gridItem}>
+              <Text style={[styles.label, { color: c.textSecondary }]}>间隔（秒，≥60）</Text>
+              <Input value={intervalSeconds} onChangeText={setIntervalSeconds} keyboardType="number-pad" style={styles.input} />
+            </View>
+            <View style={styles.gridItem}>
+              <Text style={[styles.label, { color: c.textSecondary }]}>起始页</Text>
+              <Input value={startPage} onChangeText={setStartPage} keyboardType="number-pad" style={styles.input} />
+            </View>
+          </View>
+          <View style={styles.gridRow}>
+            <View style={styles.gridItem}>
+              <Text style={[styles.label, { color: c.textSecondary }]}>抓取页数（≤10）</Text>
+              <Input value={pages} onChangeText={setPages} keyboardType="number-pad" style={styles.input} />
+            </View>
+            <View style={styles.gridItem}>
+              <Text style={[styles.label, { color: c.textSecondary }]}>每页条数（≤50）</Text>
+              <Input value={pageSize} onChangeText={setPageSize} keyboardType="number-pad" style={styles.input} />
+            </View>
+          </View>
+
+          <View style={styles.switchRow}>
+            <View style={styles.switchTexts}>
+              <Text style={[styles.label, { color: c.text }]}>抓取商品详情</Text>
+              <Text style={[styles.hint, { color: c.textMuted }]}>包含描述、浏览/想要数等详情字段</Text>
+            </View>
+            <Switch value={fetchDetail} onValueChange={setFetchDetail} trackColor={{ false: c.border, true: c.primary }} />
+          </View>
+          {fetchDetail && (
+            <View>
+              <Text style={[styles.label, { color: c.textSecondary }]}>详情抓取上限（≤50）</Text>
+              <Input value={detailLimit} onChangeText={setDetailLimit} keyboardType="number-pad" style={styles.input} />
+            </View>
+          )}
+
+          <View style={styles.switchRow}>
+            <View style={styles.switchTexts}>
+              <Text style={[styles.label, { color: c.text }]}>创建后立即启用</Text>
+              <Text style={[styles.hint, { color: c.textMuted }]}>按设定间隔自动执行采集</Text>
+            </View>
+            <Switch value={enabled} onValueChange={setEnabled} trackColor={{ false: c.border, true: c.primary }} />
+          </View>
+        </ScrollView>
+
+        <View style={styles.sheetActions}>
+          <Button label="取消" variant="secondary" onPress={() => setFormVisible(false)} style={styles.sheetBtn} />
+          <Button label="创建任务" onPress={handleCreate} loading={creating} style={styles.sheetBtn} />
+        </View>
+      </FormModal>
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  list: { padding: spacing.lg, gap: spacing.md },
+  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: spacing.lg, paddingVertical: spacing.md },
+  headerHint: { ...typography.small, flex: 1, marginRight: spacing.md },
+  addBtn: { width: 32, height: 32, borderRadius: radius.full, alignItems: 'center', justifyContent: 'center' },
+  list: { padding: spacing.lg, paddingTop: 0, gap: spacing.md, paddingBottom: 80 },
   card: { gap: spacing.sm },
   jobHeader: { flexDirection: 'row', alignItems: 'center' },
   jobInfo: { flex: 1, marginRight: spacing.sm, gap: spacing.xs },
   jobName: { ...typography.body, fontWeight: '600' },
-  jobMeta: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  jobAccount: { ...typography.small },
+  jobMeta: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm, flexWrap: 'wrap' },
   badge: { paddingHorizontal: spacing.sm, paddingVertical: 2, borderRadius: radius.sm },
   badgeText: { ...typography.small, fontWeight: '600', color: '#FFF' },
   count: { ...typography.small },
+  lastError: { ...typography.small },
   chevron: { fontSize: 12, fontWeight: '600' },
   jobActions: { flexDirection: 'row', gap: spacing.sm },
   actionBtn: { flex: 1, minHeight: 40 },
@@ -243,9 +495,24 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.sm,
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  itemTitle: { ...typography.caption, flex: 1, marginRight: spacing.sm },
+  itemTexts: { flex: 1, marginRight: spacing.sm, gap: 2 },
+  itemTitle: { ...typography.caption, fontWeight: '600' },
+  itemSub: { ...typography.small },
   itemPrice: { ...typography.caption, fontWeight: '600' },
   hint: { ...typography.small, paddingVertical: spacing.sm },
-  empty: { alignItems: 'center', paddingVertical: 28 },
-  emptyText: { ...typography.body },
+  // 新建表单
+  formScroll: { flexGrow: 0 },
+  formContent: { gap: spacing.xs, paddingBottom: spacing.sm },
+  label: { ...typography.caption },
+  accountSelector: { flexGrow: 0 },
+  accountSelectorContent: { gap: spacing.sm, paddingVertical: spacing.xs },
+  accountOption: { maxWidth: 160, paddingHorizontal: spacing.md, paddingVertical: spacing.sm, borderRadius: radius.sm, borderWidth: 1 },
+  typeOptionText: { ...typography.caption },
+  input: { marginTop: spacing.xs },
+  gridRow: { flexDirection: 'row', gap: spacing.sm },
+  gridItem: { flex: 1 },
+  switchRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginTop: spacing.sm },
+  switchTexts: { flex: 1, marginRight: spacing.md, gap: 2 },
+  sheetActions: { flexDirection: 'row', gap: spacing.sm, marginTop: spacing.sm },
+  sheetBtn: { flex: 1 },
 });

--- a/xianyu-mobile/app/(tabs)/mine/dashboard.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/dashboard.tsx
@@ -8,33 +8,33 @@ import {
   ShoppingBag,
   Wifi,
   Users,
-  ListTodo,
+  TrendingUp,
 } from 'lucide-react-native';
 import { Card, StatCard, Loading } from '@/components/ui';
 import { colors, spacing, typography } from '@/lib/theme';
-import { getBrowseSummary, type DashboardStats } from '@/api/wrappers/dashboard';
+import {
+  getCookieStats,
+  getOrderTrend,
+  type CookieStats,
+  type OrderTrendPoint,
+} from '@/api/wrappers/dashboard';
 import { useAccountsStore } from '@/stores/accounts';
 
-/** YYYY-MM-DD 格式化 */
-function formatDate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
+const EMPTY_STATS: CookieStats = {
+  total_accounts: 0,
+  active_accounts: 0,
+  total_keywords: 0,
+  total_orders: 0,
+  today_reply_count: 0,
+  yesterday_reply_count: 0,
+  account_limit: null,
+  used_account_count: 0,
+  remaining_account_count: null,
+};
 
-/** 从统计结果中按候选字段名提取数字，缺失时返回 undefined */
-function maybeNumber(
-  obj: Record<string, unknown>,
-  keys: string[],
-): number | undefined {
-  for (const k of keys) {
-    if (k in obj && obj[k] != null && obj[k] !== '') {
-      const n = Number(obj[k]);
-      if (Number.isFinite(n)) return n;
-    }
-  }
-  return undefined;
+/** 金额展示：0 显示 0，保留两位小数 */
+function formatAmount(n: number): string {
+  return `¥${n.toFixed(2)}`;
 }
 
 export default function DashboardScreen() {
@@ -44,12 +44,9 @@ export default function DashboardScreen() {
 
   const accounts = useAccountsStore((s) => s.options);
   const loadAccounts = useAccountsStore((s) => s.load);
-  const [stats, setStats] = useState<DashboardStats>({
-    total_accounts: 0,
-    active_accounts: 0,
-    today_replies: 0,
-    total_orders: 0,
-  });
+  // 真实数据源：GET /api/v1/cookies/stats + /api/v1/cookies/stats/order-trend
+  const [stats, setStats] = useState<CookieStats>(EMPTY_STATS);
+  const [trend, setTrend] = useState<OrderTrendPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
@@ -58,40 +55,13 @@ export default function DashboardScreen() {
     setRefreshing(true);
     try {
       await loadAccounts(force);
-      const accs = useAccountsStore.getState().options;
-
-      // 用今天日期范围调用浏览概要；接口需要账号，取第一个账号的 pk
-      if (accs.length > 0) {
-        const today = formatDate(new Date());
-        const result = await getBrowseSummary(String(accs[0].pk), today, today);
-        const totalAccounts =
-          maybeNumber(result, ['total_accounts', 'account_count', 'accounts']) ??
-          accs.length;
-        const activeAccounts =
-          maybeNumber(result, ['active_accounts', 'active_count']) ??
-          accs.filter((a) => a.enabled).length;
-        const todayReplies =
-          maybeNumber(result, [
-            'today_replies',
-            'today_reply_count',
-            'replies',
-          ]) ?? 0;
-        const totalOrders =
-          maybeNumber(result, ['total_orders', 'orders', 'order_count']) ?? 0;
-        setStats({
-          total_accounts: totalAccounts,
-          active_accounts: activeAccounts,
-          today_replies: todayReplies,
-          total_orders: totalOrders,
-        });
-      } else {
-        setStats({
-          total_accounts: 0,
-          active_accounts: 0,
-          today_replies: 0,
-          total_orders: 0,
-        });
-      }
+      // 趋势失败不阻断统计卡展示
+      const [statsRes, trendRes] = await Promise.all([
+        getCookieStats(),
+        getOrderTrend(7).catch(() => [] as OrderTrendPoint[]),
+      ]);
+      setStats(statsRes);
+      setTrend(trendRes);
     } catch (e) {
       console.error('加载仪表盘失败', e);
       Alert.alert('加载失败', (e as Error).message);
@@ -114,7 +84,6 @@ export default function DashboardScreen() {
   }
 
   // 上方统计卡只放可操作的高价值指标；账号明细见下方"账号概览"卡。
-  // 近7日趋势暂无数据源，该位按约定回退为"账号总数"。
   const statCards: {
     label: string;
     value: number;
@@ -124,7 +93,7 @@ export default function DashboardScreen() {
   }[] = [
     {
       label: '今日回复',
-      value: stats.today_replies,
+      value: stats.today_reply_count,
       icon: MessageCircle,
       accent: c.info,
       onPress: () => router.push('/(tabs)/messages'),
@@ -137,7 +106,7 @@ export default function DashboardScreen() {
       onPress: () => router.push('/(tabs)/orders'),
     },
     {
-      label: '在线账号',
+      label: '启用账号',
       value: stats.active_accounts,
       icon: Wifi,
       accent: c.success,
@@ -151,6 +120,11 @@ export default function DashboardScreen() {
       onPress: () => router.push('/(tabs)/mine/accounts'),
     },
   ];
+
+  // 近7日趋势条形图（横向，参考 data-analysis 分布条画法）
+  const maxAmount = trend.reduce((m, p) => Math.max(m, p.amount), 0);
+  const trendTotalCount = trend.reduce((sum, p) => sum + p.count, 0);
+  const trendTotalAmount = trend.reduce((sum, p) => sum + p.amount, 0);
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
@@ -184,7 +158,7 @@ export default function DashboardScreen() {
               账号总数
             </Text>
             <Text style={[styles.infoValue, { color: c.text }]}>
-              {accounts.length}
+              {stats.total_accounts}
             </Text>
           </View>
           <View
@@ -194,7 +168,7 @@ export default function DashboardScreen() {
               启用账号
             </Text>
             <Text style={[styles.infoValue, { color: c.success }]}>
-              {accounts.filter((a) => a.enabled).length}
+              {stats.active_accounts}
             </Text>
           </View>
           <View
@@ -204,19 +178,90 @@ export default function DashboardScreen() {
               停用账号
             </Text>
             <Text style={[styles.infoValue, { color: c.textMuted }]}>
-              {accounts.filter((a) => !a.enabled).length}
+              {Math.max(0, stats.total_accounts - stats.active_accounts)}
+            </Text>
+          </View>
+          <View
+            style={[styles.infoRow, { borderTopColor: c.border, borderTopWidth: 1 }]}
+          >
+            <Text style={[styles.infoLabel, { color: c.textSecondary }]}>
+              关键词总数
+            </Text>
+            <Text style={[styles.infoValue, { color: c.text }]}>
+              {stats.total_keywords}
+            </Text>
+          </View>
+          <View
+            style={[styles.infoRow, { borderTopColor: c.border, borderTopWidth: 1 }]}
+          >
+            <Text style={[styles.infoLabel, { color: c.textSecondary }]}>
+              昨日回复
+            </Text>
+            <Text style={[styles.infoValue, { color: c.text }]}>
+              {stats.yesterday_reply_count}
+            </Text>
+          </View>
+          <View
+            style={[styles.infoRow, { borderTopColor: c.border, borderTopWidth: 1 }]}
+          >
+            <Text style={[styles.infoLabel, { color: c.textSecondary }]}>
+              剩余额度
+            </Text>
+            <Text style={[styles.infoValue, { color: c.text }]}>
+              {stats.remaining_account_count == null
+                ? '不限'
+                : `${stats.remaining_account_count} / 限 ${stats.account_limit ?? '—'}`}
             </Text>
           </View>
         </Card>
 
-        <Card style={styles.todoCard}>
-          <View style={styles.todoHeader}>
-            <ListTodo size={16} stroke={c.primary} />
-            <Text style={[styles.todoTitle, { color: c.text }]}>今日待办</Text>
+        {/* 近7日订单趋势（真实数据源 order-trend；无数据源支撑的"今日待办"卡已移除） */}
+        <Card style={styles.trendCard}>
+          <View style={styles.trendHeader}>
+            <TrendingUp size={16} stroke={c.primary} />
+            <Text style={[styles.infoTitle, { color: c.text }]}>近7日订单</Text>
           </View>
-          <Text style={[styles.todoEmpty, { color: c.textMuted }]}>
-            暂无待办事项
-          </Text>
+          {trend.length === 0 ? (
+            <Text style={[styles.trendEmpty, { color: c.textMuted }]}>
+              暂无订单数据
+            </Text>
+          ) : (
+            <>
+              <Text style={[styles.trendSummary, { color: c.textSecondary }]}>
+                合计 {trendTotalCount} 单 · {formatAmount(trendTotalAmount)}
+              </Text>
+              {trend.map((p, idx) => {
+                const widthPct =
+                  maxAmount > 0 ? (p.amount / maxAmount) * 100 : 0;
+                return (
+                  <View key={`${p.date}-${idx}`} style={styles.trendRow}>
+                    <Text
+                      style={[styles.trendLabel, { color: c.textSecondary }]}
+                      numberOfLines={1}
+                    >
+                      {p.date}
+                    </Text>
+                    <View
+                      style={[styles.trendTrack, { backgroundColor: c.surfaceAlt }]}
+                    >
+                      <View
+                        style={[
+                          styles.trendFill,
+                          { width: `${widthPct}%`, backgroundColor: c.primary },
+                        ]}
+                      />
+                    </View>
+                    <Text
+                      style={[styles.trendValue, { color: c.primary }]}
+                      numberOfLines={1}
+                    >
+                      {p.amount > 0 ? formatAmount(p.amount) : '0'} · {p.count}单
+                    </Text>
+                  </View>
+                );
+              })}
+            </>
+          )}
         </Card>
 
         {accounts.length === 0 && (
@@ -244,9 +289,20 @@ const styles = StyleSheet.create({
   },
   infoLabel: { ...typography.body },
   infoValue: { ...typography.body, fontWeight: '600' },
-  todoCard: { gap: spacing.sm },
-  todoHeader: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
-  todoTitle: { ...typography.heading },
-  todoEmpty: { ...typography.caption },
+  // 近7日订单趋势
+  trendCard: { gap: spacing.sm },
+  trendHeader: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  trendSummary: { ...typography.caption },
+  trendRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  trendLabel: { ...typography.small, width: 42 },
+  trendTrack: {
+    flex: 1,
+    height: 8,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  trendFill: { height: '100%', borderRadius: 4 },
+  trendValue: { ...typography.small, width: 110, textAlign: 'right' },
+  trendEmpty: { ...typography.caption },
   hint: { ...typography.caption, textAlign: 'center', paddingVertical: spacing.md },
 });

--- a/xianyu-mobile/app/(tabs)/mine/data-management.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/data-management.tsx
@@ -1,17 +1,17 @@
 import { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, Pressable, Alert, RefreshControl, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, FlatList, Alert, RefreshControl, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useColorScheme } from 'react-native';
-import { Card, Loading, Badge, FilterTabs } from '@/components/ui';
-import { colors, spacing, typography, radius } from '@/lib/theme';
-import { getTableData, clearTableData } from '@/api/wrappers/admin';
+import { Card, Loading, FilterTabs } from '@/components/ui';
+import { colors, spacing, typography } from '@/lib/theme';
+import { getTableData } from '@/api/wrappers/admin';
 
+// 后端 TABLE_MAP（admin.py:45-55）：orders 需用 xy_orders，cards 表未注册（后端未开放）
 const TABLE_OPTIONS = [
   { key: 'default_replies', label: '默认回复' },
   { key: 'keywords', label: '关键词' },
   { key: 'cookies', label: '账号' },
-  { key: 'cards', label: '卡券' },
-  { key: 'orders', label: '订单' },
+  { key: 'xy_orders', label: '订单' },
   { key: 'item_info', label: '商品信息' },
   { key: 'notification_channels', label: '通知渠道' },
   { key: 'risk_control_logs', label: '风控日志' },
@@ -25,7 +25,6 @@ export default function DataManagementScreen() {
   const [columns, setColumns] = useState<string[]>([]);
   const [count, setCount] = useState(0);
   const [loading, setLoading] = useState(false);
-  const [clearing, setClearing] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -38,26 +37,11 @@ export default function DataManagementScreen() {
 
   useEffect(() => { load(); }, [load]);
 
-  async function handleClear() {
-    Alert.alert('确认清空', `确定清空 ${TABLE_OPTIONS.find(t => t.key === selectedTable)?.label} 表？（前 100 条预览，清空删除全部数据，不可恢复）`, [
-      { text: '取消' },
-      { text: '清空', style: 'destructive', onPress: async () => {
-        setClearing(true);
-        try { await clearTableData(selectedTable); Alert.alert('已清空', `${selectedTable} 表已清空`); load(); }
-        catch (e) { Alert.alert('清空失败', (e as Error).message); }
-        finally { setClearing(false); }
-      }},
-    ]);
-  }
-
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left','right','bottom']}>
       <FilterTabs tabs={TABLE_OPTIONS} active={selectedTable} onChange={setSelectedTable} />
       <View style={styles.toolbar}>
         <Text style={[styles.count, { color: c.textMuted }]}>共 {count} 条</Text>
-        <Pressable onPress={handleClear} disabled={clearing} style={({ pressed }) => [styles.clearBtn, { opacity: pressed ? 0.7 : 1, borderColor: c.error }]}>
-          <Text style={[styles.clearText, { color: c.error }]}>{clearing ? '清空中...' : '清空表'}</Text>
-        </Pressable>
       </View>
       {loading ? (
         <Loading label="加载数据..." />
@@ -96,8 +80,6 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   toolbar: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: spacing.lg, paddingVertical: spacing.sm },
   count: { ...typography.small },
-  clearBtn: { paddingHorizontal: spacing.md, paddingVertical: spacing.xs, borderRadius: radius.sm, borderWidth: 1 },
-  clearText: { ...typography.small, fontWeight: '600' },
   tableScroll: { flex: 1 },
   table: { minWidth: 600 },
   tableHeader: { flexDirection: 'row', borderBottomWidth: 1 },

--- a/xianyu-mobile/app/(tabs)/mine/index.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/index.tsx
@@ -45,6 +45,8 @@ import {
   SlidersHorizontal,
   Clock,
   Database,
+  BellRing,
+  ScanSearch,
 } from 'lucide-react-native';
 
 type MenuItem = { label: string; icon: typeof User; onPress: () => void; adminOnly?: boolean };
@@ -89,6 +91,7 @@ export default function MineScreen() {
       title: '运营',
       items: [
         { label: '公告', icon: Megaphone, onPress: () => router.push('/(tabs)/mine/announcements') },
+        { label: '弹窗公告', icon: BellRing, onPress: () => router.push('/(tabs)/mine/popup-announcements'), adminOnly: true },
         { label: '数据分析', icon: BarChart3, onPress: () => router.push('/(tabs)/mine/data-analysis') },
         { label: '风控日志', icon: Shield, onPress: () => router.push('/(tabs)/mine/risk-logs') },
         { label: '反馈', icon: MessageCircle, onPress: () => router.push('/(tabs)/mine/feedback') },
@@ -103,6 +106,7 @@ export default function MineScreen() {
         { label: '上新监控', icon: Radar, onPress: () => router.push('/(tabs)/mine/listing-monitor') },
         { label: '监控分类', icon: FolderTree, onPress: () => router.push('/(tabs)/mine/monitor-categories') },
         { label: '监控日志', icon: ScrollText, onPress: () => router.push('/(tabs)/mine/monitor-logs') },
+        { label: '采集商品', icon: ScanSearch, onPress: () => router.push('/(tabs)/mine/monitor-items') },
         { label: '兜底账号', icon: Users, onPress: () => router.push('/(tabs)/mine/monitor-fallback') },
         { label: '商品发布', icon: ShoppingCart, onPress: () => router.push('/(tabs)/mine/product-publish') },
         { label: '商品管理', icon: Package, onPress: () => router.push('/(tabs)/mine/items') },

--- a/xianyu-mobile/app/(tabs)/mine/item-edit.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/item-edit.tsx
@@ -17,8 +17,15 @@ import { colors, spacing, typography, radius } from '@/lib/theme';
 import {
   getSellerItemDetail,
   updateSellerItem,
+  updateItemPrice,
   type SellerItemForm,
 } from '@/api/wrappers/item-edit';
+import {
+  getXianyuItemDetail,
+  setItemMultiSpec,
+  setItemMultiQuantityDelivery,
+  type XianyuItemSku,
+} from '@/api/wrappers/items';
 
 // seller-detail 可能回填 'template'，表单仅支持四种；回填为 template 时不选中任何 chip，保存时回退为原值
 type ShippingMethod = NonNullable<SellerItemForm['shipping_method']>;
@@ -53,6 +60,16 @@ export default function ItemEditScreen() {
   const [postage, setPostage] = useState('');
   const [supportPickup, setSupportPickup] = useState(false);
 
+  // 快捷改价：多规格行（来自本地库 item_sku_list，含 sku_id 供回传）
+  const [priceSkus, setPriceSkus] = useState<
+    Array<{ skuId: string; label: string; price: string; quantity: string }>
+  >([]);
+  const [isMultiSpecItem, setIsMultiSpecItem] = useState(false);
+  const [priceSaving, setPriceSaving] = useState(false);
+  // 商品标记（本地库标记，供商品列表筛选）
+  const [flagMultiSpec, setFlagMultiSpec] = useState(false);
+  const [flagMultiQty, setFlagMultiQty] = useState(false);
+
   const paramsReady = Boolean(cookieId && itemId);
 
   const load = useCallback(async () => {
@@ -76,6 +93,32 @@ export default function ItemEditScreen() {
       }
       setPostage(form.postage != null ? String(form.postage) : '');
       setSupportPickup(Boolean(form.support_pickup));
+      // 本地库详情：取多规格明细（含 sku_id）与列表筛选标记；失败不阻塞编辑表单
+      try {
+        const { item } = await getXianyuItemDetail(cookieId, itemId);
+        const skus = item.item_sku_list ?? [];
+        if (skus.length > 0) {
+          setIsMultiSpecItem(true);
+          setPriceSkus(
+            skus.map((sku: XianyuItemSku) => ({
+              skuId: sku.sku_id,
+              label:
+                (sku.specs ?? []).map((s) => `${s.name}：${s.value}`).join('，') || sku.sku_id,
+              price: sku.price != null ? String(sku.price) : '',
+              quantity: sku.quantity != null ? String(sku.quantity) : '',
+            })),
+          );
+        } else {
+          setIsMultiSpecItem(false);
+          setPriceSkus([]);
+        }
+        setFlagMultiSpec(Boolean(item.is_multi_spec));
+        setFlagMultiQty(Boolean(item.multi_quantity_delivery));
+      } catch {
+        // 本地详情缺失时退化为单规格快捷改价（用表单价格/库存）
+        setIsMultiSpecItem(false);
+        setPriceSkus([]);
+      }
     } catch (e) {
       setLoadError((e as Error).message || '加载商品详情失败');
     } finally {
@@ -140,6 +183,92 @@ export default function ItemEditScreen() {
       Alert.alert('保存失败', `${(e as Error).message || '未知错误'}\n${BACKEND_VERSION_HINT}`);
     } finally {
       setSaving(false);
+    }
+  }
+
+  const updateSkuRow = (idx: number, field: 'price' | 'quantity', value: string) => {
+    setPriceSkus((prev) => prev.map((row, i) => (i === idx ? { ...row, [field]: value } : row)));
+  };
+
+  /** 单规格快捷改价：仅提交价格与库存（PUT /items/{cookie_id}/{item_id}/price） */
+  async function handleQuickPriceSave() {
+    if (!cookieId || !itemId || priceSaving) return;
+    const priceNum = parseFloat(price);
+    if (!price.trim() || Number.isNaN(priceNum) || priceNum <= 0) {
+      Alert.alert('提示', '价格需大于0');
+      return;
+    }
+    const quantityNum = parseInt(quantity, 10);
+    if (!quantity.trim() || Number.isNaN(quantityNum) || quantityNum < 0) {
+      Alert.alert('提示', '库存不能为负数');
+      return;
+    }
+    setPriceSaving(true);
+    try {
+      const res = await updateItemPrice(cookieId, itemId, {
+        price: priceNum,
+        quantity: quantityNum,
+      });
+      if (!res.success) {
+        Alert.alert('改价失败', res.message || '未知错误');
+        return;
+      }
+      Alert.alert('改价成功', res.message || '价格与库存已更新');
+    } catch (e) {
+      Alert.alert('改价失败', `${(e as Error).message || '未知错误'}\n${BACKEND_VERSION_HINT}`);
+    } finally {
+      setPriceSaving(false);
+    }
+  }
+
+  /** 多规格快捷改价：提交每个 SKU 的价格与库存 */
+  async function handleSkuPriceSave() {
+    if (!cookieId || !itemId || priceSaving) return;
+    for (const sku of priceSkus) {
+      const p = parseFloat(sku.price);
+      if (!sku.price || Number.isNaN(p) || p <= 0) {
+        Alert.alert('提示', `规格「${sku.label}」价格需大于0`);
+        return;
+      }
+      const q = parseInt(sku.quantity, 10);
+      if (!sku.quantity || Number.isNaN(q) || q < 0) {
+        Alert.alert('提示', `规格「${sku.label}」库存不能为负数`);
+        return;
+      }
+    }
+    setPriceSaving(true);
+    try {
+      const res = await updateItemPrice(cookieId, itemId, {
+        skus: priceSkus.map((sku) => ({
+          sku_id: sku.skuId,
+          price: parseFloat(sku.price),
+          quantity: parseInt(sku.quantity, 10),
+        })),
+      });
+      if (!res.success) {
+        Alert.alert('改价失败', res.message || '未知错误');
+        return;
+      }
+      Alert.alert('改价成功', res.message || '规格价格与库存已更新');
+    } catch (e) {
+      Alert.alert('改价失败', `${(e as Error).message || '未知错误'}\n${BACKEND_VERSION_HINT}`);
+    } finally {
+      setPriceSaving(false);
+    }
+  }
+
+  /** 切换本地"多规格 / 多数量发货"标记（供商品列表筛选） */
+  async function handleToggleFlag(kind: 'spec' | 'qty', value: boolean) {
+    if (!cookieId || !itemId) return;
+    const setter = kind === 'spec' ? setFlagMultiSpec : setFlagMultiQty;
+    const prev = kind === 'spec' ? flagMultiSpec : flagMultiQty;
+    setter(value);
+    try {
+      if (kind === 'spec') await setItemMultiSpec(cookieId, itemId, value);
+      else await setItemMultiQuantityDelivery(cookieId, itemId, value);
+    } catch (e) {
+      setter(prev);
+      Alert.alert('操作失败', (e as Error).message || '未知错误');
     }
   }
 
@@ -225,7 +354,55 @@ export default function ItemEditScreen() {
             keyboardType="number-pad"
             placeholder="1"
           />
+
+          {!isMultiSpecItem ? (
+            <Button
+              label="仅保存价格与库存（快捷改价）"
+              variant="secondary"
+              onPress={handleQuickPriceSave}
+              loading={priceSaving}
+              style={styles.quickPriceBtn}
+            />
+          ) : null}
         </Card>
+
+        {isMultiSpecItem ? (
+          <Card style={styles.section}>
+            <Text style={[styles.label, { color: c.textSecondary }]}>改价（多规格）</Text>
+            <Text style={[styles.hintText, { color: c.textMuted }]}>
+              逐个规格设置价格与库存，保存后立即生效
+            </Text>
+            {priceSkus.map((sku, idx) => (
+              <View key={sku.skuId || idx} style={styles.skuRow}>
+                <Text style={[styles.skuLabel, { color: c.text }]} numberOfLines={2}>
+                  {sku.label}
+                </Text>
+                <View style={styles.skuInputs}>
+                  <Input
+                    value={sku.price}
+                    onChangeText={(v) => updateSkuRow(idx, 'price', v)}
+                    keyboardType="decimal-pad"
+                    placeholder="价格"
+                    style={styles.skuInput}
+                  />
+                  <Input
+                    value={sku.quantity}
+                    onChangeText={(v) => updateSkuRow(idx, 'quantity', v)}
+                    keyboardType="number-pad"
+                    placeholder="库存"
+                    style={styles.skuInput}
+                  />
+                </View>
+              </View>
+            ))}
+            <Button
+              label="保存全部规格价格"
+              onPress={handleSkuPriceSave}
+              loading={priceSaving}
+              style={styles.quickPriceBtn}
+            />
+          </Card>
+        ) : null}
 
         <Card style={styles.section}>
           <Text style={[styles.label, { color: c.textSecondary }]}>商品图片</Text>
@@ -295,6 +472,29 @@ export default function ItemEditScreen() {
           </View>
         </Card>
 
+        <Card style={styles.section}>
+          <Text style={[styles.label, { color: c.textSecondary }]}>商品标记</Text>
+          <View style={[styles.switchRow, { borderBottomColor: c.borderLight }]}>
+            <Text style={[styles.switchLabel, { color: c.text }]}>多规格</Text>
+            <Switch
+              value={flagMultiSpec}
+              onValueChange={(v) => handleToggleFlag('spec', v)}
+              trackColor={{ false: c.border, true: c.primary }}
+            />
+          </View>
+          <View style={[styles.switchRow, { borderBottomColor: c.borderLight }]}>
+            <Text style={[styles.switchLabel, { color: c.text }]}>多数量发货</Text>
+            <Switch
+              value={flagMultiQty}
+              onValueChange={(v) => handleToggleFlag('qty', v)}
+              trackColor={{ false: c.border, true: c.primary }}
+            />
+          </View>
+          <Text style={[styles.hintText, { color: c.textMuted }]}>
+            标记仅用于商品列表筛选，不影响闲鱼平台商品
+          </Text>
+        </Card>
+
         <Button
           label="保存修改"
           onPress={handleSave}
@@ -332,6 +532,12 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
   },
   switchLabel: { ...typography.body },
+  hintText: { ...typography.small, paddingVertical: spacing.xs },
+  quickPriceBtn: { marginTop: spacing.md },
+  skuRow: { marginTop: spacing.sm, gap: spacing.xs },
+  skuLabel: { ...typography.small, fontWeight: '600' },
+  skuInputs: { flexDirection: 'row', gap: spacing.sm },
+  skuInput: { flex: 1 },
   saveBtn: { marginTop: spacing.sm },
   errorWrap: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.xl, gap: spacing.sm },
   errorTitle: { ...typography.heading },

--- a/xianyu-mobile/app/(tabs)/mine/items.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/items.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   Alert,
   View,
@@ -14,15 +14,41 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { Card, EmptyState, Badge, Loading } from '@/components/ui';
-import { Package, Ticket } from 'lucide-react-native';
+import { Card, EmptyState, Badge, Loading, Input } from '@/components/ui';
+import {
+  Package,
+  Ticket,
+  Search,
+  X,
+  CheckCircle2,
+  Circle,
+} from 'lucide-react-native';
 import { colors, spacing, typography, radius } from '@/lib/theme';
-import { getXianyuItems, type XianyuItem } from '@/api/wrappers/items';
+import {
+  getXianyuItems,
+  syncXianyuItemsFromAccount,
+  batchOfflineXianyuItems,
+  batchDeleteItemRecords,
+  type XianyuItem,
+} from '@/api/wrappers/items';
 import { batchDeleteItems } from '@/api/wrappers/item-edit';
+import { batchClearItemRelations } from '@/api/wrappers/card-relation';
 import { getAccountOptions, type AccountOption } from '@/api/wrappers/accounts';
 import { ItemCardRelationModal } from '@/components/card-relation/ItemCardRelationModal';
 
 const PAGE_SIZE = 20;
+
+/** 列表筛选 chips 定义（对应 GET /paginated 的布尔筛选参数） */
+const FILTER_CHIPS: Array<{
+  key: 'polished' | 'multiSpec' | 'multiQty';
+  label: string;
+}> = [
+  { key: 'polished', label: '已擦亮' },
+  { key: 'multiSpec', label: '多规格' },
+  { key: 'multiQty', label: '多数量发货' },
+];
+
+type BatchAction = '' | 'offline' | 'delete' | 'clear';
 
 export default function ItemsScreen() {
   const scheme = useColorScheme();
@@ -44,9 +70,39 @@ export default function ItemsScreen() {
   // 关联卡券弹窗：当前正在关联卡券的商品，非空即表示弹窗打开
   const [relationItem, setRelationItem] = useState<XianyuItem | null>(null);
 
+  // 搜索与筛选（keyword 输入防抖后生效）
+  const [keywordInput, setKeywordInput] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [filterPolished, setFilterPolished] = useState(false);
+  const [filterMultiSpec, setFilterMultiSpec] = useState(false);
+  const [filterMultiQty, setFilterMultiQty] = useState(false);
+
+  // 批量选择模式：selectedKeys 以 cookie_id::item_id 为键
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [batchBusy, setBatchBusy] = useState<BatchAction>('');
+
+  // 商品同步：'one'=当前选中账号，'all'=全部账号
+  const [syncing, setSyncing] = useState<'' | 'one' | 'all'>('');
+
   // 切换账号会触发两次 loadItems（useEffect 依赖变更 + selectedAccountId 传入），
   // 用 ref 记录最新请求序号，丢弃过期响应
   const reqSeqRef = useRef(0);
+
+  // loadItems 通过 ref 读取最新筛选条件，避免筛选状态变化时重建回调导致拉取中断
+  const filtersRef = useRef({ keyword: '', polished: false, multiSpec: false, multiQty: false });
+  filtersRef.current = {
+    keyword,
+    polished: filterPolished,
+    multiSpec: filterMultiSpec,
+    multiQty: filterMultiQty,
+  };
+
+  // 搜索关键字 500ms 防抖
+  useEffect(() => {
+    const t = setTimeout(() => setKeyword(keywordInput.trim()), 500);
+    return () => clearTimeout(t);
+  }, [keywordInput]);
 
   const loadAccounts = useCallback(async () => {
     try {
@@ -62,6 +118,7 @@ export default function ItemsScreen() {
       const append = opts?.append ?? false;
       const targetPage = opts?.fromPage ?? 1;
       const seq = ++reqSeqRef.current;
+      const f = filtersRef.current;
 
       if (append) {
         setLoadingMore(true);
@@ -70,7 +127,12 @@ export default function ItemsScreen() {
       }
       setError(null);
       try {
-        const res = await getXianyuItems(targetPage, PAGE_SIZE, accountId || undefined);
+        const res = await getXianyuItems(targetPage, PAGE_SIZE, accountId || undefined, {
+          keyword: f.keyword || undefined,
+          isPolished: f.polished || undefined,
+          isMultiSpec: f.multiSpec || undefined,
+          multiQuantityDelivery: f.multiQty || undefined,
+        });
         if (seq !== reqSeqRef.current) return; // 已被后续请求覆盖
         console.log('[ITEMS] API返回', res.items.length, '条, item_ids:', res.items.map(i => i.item_id));
         setItems((prev) => {
@@ -112,7 +174,7 @@ export default function ItemsScreen() {
   useEffect(() => {
     setLoading(true);
     loadItems(selectedAccountId);
-  }, [selectedAccountId, loadItems]);
+  }, [selectedAccountId, keyword, filterPolished, filterMultiSpec, filterMultiQty, loadItems]);
 
   const handleRefresh = useCallback(() => {
     loadItems(selectedAccountId);
@@ -123,6 +185,87 @@ export default function ItemsScreen() {
     if (totalPages > 0 && page >= totalPages) return;
     loadItems(selectedAccountId, { append: true, fromPage: page + 1 });
   }, [loadingMore, refreshing, loading, totalPages, page, selectedAccountId, loadItems]);
+
+  // ==================== 商品同步 ====================
+
+  const handleSync = useCallback(
+    async (scope: 'one' | 'all') => {
+      if (syncing) return;
+      if (scope === 'one' && !selectedAccountId) {
+        Alert.alert('提示', '请先在顶部选择要同步的账号');
+        return;
+      }
+      setSyncing(scope);
+      try {
+        const res = await syncXianyuItemsFromAccount(scope === 'one' ? selectedAccountId : undefined);
+        const failed = res.failed_accounts ?? [];
+        const lines: string[] = [`获取 ${res.total_count} 件商品，新增/更新 ${res.saved_count} 件`];
+        if (scope === 'all' && res.account_count != null) {
+          lines.push(
+            `账号：成功 ${res.success_account_count ?? 0}/${res.account_count} 个`,
+          );
+        }
+        if (failed.length > 0) {
+          const preview = failed.slice(0, 5).join('\n');
+          lines.push(
+            `失败账号 ${failed.length} 个：\n${preview}${failed.length > 5 ? `\n...等共 ${failed.length} 个` : ''}`,
+          );
+        }
+        Alert.alert('同步完成', lines.join('\n'));
+        loadItems(selectedAccountId);
+      } catch (e) {
+        Alert.alert('同步失败', (e as Error).message || '未知错误');
+      } finally {
+        setSyncing('');
+      }
+    },
+    [syncing, selectedAccountId, loadItems],
+  );
+
+  // ==================== 批量选择 ====================
+
+  const itemKey = useCallback(
+    (it: XianyuItem) => `${it.cookie_id}::${it.item_id}`,
+    [],
+  );
+
+  const selectedItems = useMemo(
+    () => items.filter((it) => selectedKeys.has(itemKey(it))),
+    [items, selectedKeys, itemKey],
+  );
+
+  const allSelected = items.length > 0 && selectedItems.length === items.length;
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelectedKeys(new Set());
+  }, []);
+
+  const toggleSelectMode = useCallback(() => {
+    if (selectMode) exitSelectMode();
+    else setSelectMode(true);
+  }, [selectMode, exitSelectMode]);
+
+  const toggleItem = useCallback((it: XianyuItem) => {
+    setSelectedKeys((prev) => {
+      const key = `${it.cookie_id}::${it.item_id}`;
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const enterSelectWith = useCallback((it: XianyuItem) => {
+    setSelectMode(true);
+    setSelectedKeys(new Set([`${it.cookie_id}::${it.item_id}`]));
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedKeys(
+      allSelected ? new Set() : new Set(items.map((it) => `${it.cookie_id}::${it.item_id}`)),
+    );
+  }, [allSelected, items]);
 
   const handleEdit = useCallback(
     (item: XianyuItem) => {
@@ -164,65 +307,242 @@ export default function ItemsScreen() {
       Alert.alert(item.title || '无标题', undefined, [
         { text: '编辑', onPress: () => handleEdit(item) },
         { text: '删除', style: 'destructive', onPress: () => handleDelete(item) },
+        { text: '批量选择', onPress: () => enterSelectWith(item) },
         { text: '取消', style: 'cancel' },
       ]);
     },
-    [handleEdit, handleDelete],
+    [handleEdit, handleDelete, enterSelectWith],
   );
+
+  // ==================== 批量操作 ====================
+
+  /** 批量下架：按归属账号分组，逐账号用其 Cookie 调闲鱼接口 */
+  const handleBatchOffline = useCallback(() => {
+    const targets = selectedItems;
+    if (targets.length === 0 || batchBusy) return;
+    const groups = new Map<string, string[]>();
+    let orphan = 0;
+    for (const it of targets) {
+      if (!it.cookie_id) {
+        orphan += 1;
+        continue;
+      }
+      const arr = groups.get(it.cookie_id);
+      if (arr) arr.push(it.item_id);
+      else groups.set(it.cookie_id, [it.item_id]);
+    }
+    Alert.alert(
+      '批量下架',
+      `将通过各账号 Cookie 下架选中的 ${targets.length} 件商品（涉及 ${groups.size} 个账号）${orphan ? `，${orphan} 件未指定账号无法下架` : ''}。下架不会删除本地记录，确定继续吗？`,
+      [
+        { text: '取消', style: 'cancel' },
+        {
+          text: '下架',
+          style: 'destructive',
+          onPress: async () => {
+            setBatchBusy('offline');
+            try {
+              let suc = 0;
+              let fail = 0;
+              const failedIds: string[] = [];
+              const errors: string[] = [];
+              for (const [cookieId, ids] of groups) {
+                try {
+                  const r = await batchOfflineXianyuItems(cookieId, ids);
+                  suc += r.suc_count;
+                  fail += r.fail_count;
+                  failedIds.push(...r.failed_item_ids);
+                } catch (e) {
+                  errors.push(`账号 ${cookieId}：${(e as Error).message || '下架失败'}`);
+                }
+              }
+              const lines = [`成功下架 ${suc} 件${fail ? `，失败 ${fail} 件` : ''}`];
+              if (orphan) lines.push(`已跳过 ${orphan} 件未指定账号的商品`);
+              if (failedIds.length > 0) {
+                lines.push(
+                  `失败商品：${failedIds.slice(0, 5).join('、')}${failedIds.length > 5 ? ` 等共 ${failedIds.length} 个` : ''}`,
+                );
+              }
+              if (errors.length > 0) lines.push(errors.slice(0, 3).join('\n'));
+              Alert.alert(suc > 0 ? '下架完成' : '下架失败', lines.join('\n'));
+              setSelectedKeys(new Set());
+              loadItems(selectedAccountId);
+            } finally {
+              setBatchBusy('');
+            }
+          },
+        },
+      ],
+    );
+  }, [selectedItems, batchBusy, selectedAccountId, loadItems]);
+
+  /** 批量删除本地记录（不影响闲鱼平台） */
+  const handleBatchDeleteRecords = useCallback(() => {
+    const targets = selectedItems;
+    if (targets.length === 0 || batchBusy) return;
+    Alert.alert(
+      '批量删除本地记录',
+      `将删除选中的 ${targets.length} 件商品的本地记录（不影响闲鱼平台在售商品），确定继续吗？`,
+      [
+        { text: '取消', style: 'cancel' },
+        {
+          text: '删除',
+          style: 'destructive',
+          onPress: async () => {
+            setBatchBusy('delete');
+            try {
+              const res = await batchDeleteItemRecords(
+                targets.map((it) => ({ cookie_id: it.cookie_id || null, item_id: it.item_id })),
+              );
+              Alert.alert('删除完成', res.message || `已删除 ${targets.length} 条本地记录`);
+              setSelectedKeys(new Set());
+              loadItems(selectedAccountId);
+            } catch (e) {
+              Alert.alert('删除失败', (e as Error).message || '未知错误');
+            } finally {
+              setBatchBusy('');
+            }
+          },
+        },
+      ],
+    );
+  }, [selectedItems, batchBusy, selectedAccountId, loadItems]);
+
+  /** 批量清空选中商品的卡券关联（不删除卡券本身） */
+  const handleBatchClearRelations = useCallback(() => {
+    const targets = selectedItems;
+    if (targets.length === 0 || batchBusy) return;
+    const itemIds = Array.from(new Set(targets.map((it) => it.item_id)));
+    Alert.alert(
+      '批量清空关联卡券',
+      `将清空选中 ${targets.length} 件商品的卡券关联（不删除卡券本身），确定继续吗？`,
+      [
+        { text: '取消', style: 'cancel' },
+        {
+          text: '清空',
+          style: 'destructive',
+          onPress: async () => {
+            setBatchBusy('clear');
+            try {
+              await batchClearItemRelations(itemIds);
+              Alert.alert('操作完成', `已清空 ${targets.length} 件商品的卡券关联`);
+              setSelectedKeys(new Set());
+              loadItems(selectedAccountId);
+            } catch (e) {
+              Alert.alert('操作失败', (e as Error).message || '未知错误');
+            } finally {
+              setBatchBusy('');
+            }
+          },
+        },
+      ],
+    );
+  }, [selectedItems, batchBusy, loadItems, selectedAccountId]);
 
   const accountLabel = (acc: AccountOption) => acc.remark || acc.id;
 
-  const renderItem = ({ item }: { item: XianyuItem }) => (
-    <Pressable
-      onPress={() => handleEdit(item)}
-      onLongPress={() => handleLongPress(item)}
-      style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-    >
-      <Card style={styles.card}>
-        <View style={styles.cardRow}>
-          {item.image ? (
-            <Image
-              source={{ uri: item.image }}
-              style={[styles.thumb, { backgroundColor: c.surfaceAlt }]}
-            />
-          ) : (
-            <View style={[styles.thumb, { backgroundColor: c.surfaceAlt }]}>
-              <Package size={24} stroke={c.textMuted} />
-            </View>
-          )}
-          <View style={styles.body}>
-            <Text
-              style={[styles.title, { color: c.text }]}
-              numberOfLines={2}
-            >
-              {item.title || '无标题'}
-            </Text>
-            <View style={styles.metaRow}>
-              <Text style={[styles.price, { color: c.warning }]} numberOfLines={1}>
-                {item.price ? `¥${item.price}` : '价格未知'}
+  const renderItem = ({ item }: { item: XianyuItem }) => {
+    const key = itemKey(item);
+    const checked = selectedKeys.has(key);
+    return (
+      <Pressable
+        onPress={() => (selectMode ? toggleItem(item) : handleEdit(item))}
+        onLongPress={() => (selectMode ? toggleItem(item) : handleLongPress(item))}
+        style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+      >
+        <Card style={[styles.card, selectMode && checked && { borderColor: c.primary, borderWidth: 1 }]}>
+          <View style={styles.cardRow}>
+            {selectMode ? (
+              <View style={styles.checkWrap}>
+                {checked ? (
+                  <CheckCircle2 size={22} stroke={c.primary} />
+                ) : (
+                  <Circle size={22} stroke={c.border} />
+                )}
+              </View>
+            ) : null}
+            {item.image ? (
+              <Image
+                source={{ uri: item.image }}
+                style={[styles.thumb, { backgroundColor: c.surfaceAlt }]}
+              />
+            ) : (
+              <View style={[styles.thumb, { backgroundColor: c.surfaceAlt }]}>
+                <Package size={24} stroke={c.textMuted} />
+              </View>
+            )}
+            <View style={styles.body}>
+              <Text
+                style={[styles.title, { color: c.text }]}
+                numberOfLines={2}
+              >
+                {item.title || '无标题'}
               </Text>
-              {item.status ? (
-                <Badge label={item.status} variant="info" />
-              ) : null}
-              {item.quantity !== null && item.quantity !== '' && item.quantity !== undefined ? (
-                <Text style={[styles.qty, { color: c.textMuted }]} numberOfLines={1}>
-                  库存 {item.quantity}
+              <View style={styles.metaRow}>
+                <Text style={[styles.price, { color: c.warning }]} numberOfLines={1}>
+                  {item.price ? `¥${item.price}` : '价格未知'}
                 </Text>
-              ) : null}
+                {item.status ? (
+                  <Badge label={item.status} variant="info" />
+                ) : null}
+                {item.quantity !== null && item.quantity !== '' && item.quantity !== undefined ? (
+                  <Text style={[styles.qty, { color: c.textMuted }]} numberOfLines={1}>
+                    库存 {item.quantity}
+                  </Text>
+                ) : null}
+              </View>
             </View>
           </View>
-        </View>
-        <Pressable
-          onPress={() => setRelationItem(item)}
-          style={({ pressed }) => [
-            styles.actionRow,
-            { borderColor: c.borderLight, opacity: pressed ? 0.6 : 1 },
+          {!selectMode ? (
+            <Pressable
+              onPress={() => setRelationItem(item)}
+              style={({ pressed }) => [
+                styles.actionRow,
+                { borderColor: c.borderLight, opacity: pressed ? 0.6 : 1 },
+              ]}
+            >
+              <Ticket size={14} stroke={c.primary} />
+              <Text style={[styles.actionText, { color: c.primary }]}>关联卡券</Text>
+            </Pressable>
+          ) : null}
+        </Card>
+      </Pressable>
+    );
+  };
+
+  /** 顶部工具条小按钮（同步/批量） */
+  const renderToolChip = (opts: {
+    label: string;
+    onPress: () => void;
+    disabled?: boolean;
+    loading?: boolean;
+    active?: boolean;
+  }) => (
+    <Pressable
+      onPress={opts.onPress}
+      disabled={opts.disabled || opts.loading}
+      style={[
+        styles.toolChip,
+        {
+          borderColor: opts.active ? c.primary : c.border,
+          backgroundColor: opts.active ? c.primary : c.surface,
+          opacity: opts.disabled && !opts.loading ? 0.4 : 1,
+        },
+      ]}
+    >
+      {opts.loading ? (
+        <ActivityIndicator size="small" color={opts.active ? '#FFFFFF' : c.primary} />
+      ) : (
+        <Text
+          style={[
+            styles.toolChipText,
+            { color: opts.active ? '#FFFFFF' : c.text },
           ]}
+          numberOfLines={1}
         >
-          <Ticket size={14} stroke={c.primary} />
-          <Text style={[styles.actionText, { color: c.primary }]}>关联卡券</Text>
-        </Pressable>
-      </Card>
+          {opts.label}
+        </Text>
+      )}
     </Pressable>
   );
 
@@ -277,6 +597,113 @@ export default function ItemsScreen() {
         <Text style={[styles.countText, { color: c.textMuted }]}>
           共 {total} 件
         </Text>
+
+        {/* 同步 / 批量工具条 */}
+        <View style={styles.toolbar}>
+          {renderToolChip({
+            label: '同步本账号',
+            onPress: () => handleSync('one'),
+            disabled: !selectedAccountId || syncing !== '',
+            loading: syncing === 'one',
+          })}
+          {renderToolChip({
+            label: '同步全部',
+            onPress: () => handleSync('all'),
+            disabled: syncing !== '',
+            loading: syncing === 'all',
+          })}
+          {renderToolChip({
+            label: selectMode ? '退出批量' : '批量选择',
+            onPress: toggleSelectMode,
+            active: selectMode,
+          })}
+        </View>
+
+        {/* 搜索框 */}
+        <View style={[styles.searchRow, { borderColor: c.border }]}>
+          <Search size={16} stroke={c.textMuted} />
+          <Input
+            value={keywordInput}
+            onChangeText={setKeywordInput}
+            placeholder="搜索商品ID / 标题 / 详情"
+            placeholderTextColor={c.textMuted}
+            style={styles.searchInput}
+            returnKeyType="search"
+          />
+          {keywordInput ? (
+            <Pressable onPress={() => setKeywordInput('')} hitSlop={8}>
+              <X size={16} stroke={c.textMuted} />
+            </Pressable>
+          ) : null}
+        </View>
+
+        {/* 筛选 chips */}
+        <View style={styles.filterRow}>
+          {FILTER_CHIPS.map((chip) => {
+            const active =
+              chip.key === 'polished'
+                ? filterPolished
+                : chip.key === 'multiSpec'
+                  ? filterMultiSpec
+                  : filterMultiQty;
+            const setActive = (v: boolean) => {
+              if (chip.key === 'polished') setFilterPolished(v);
+              else if (chip.key === 'multiSpec') setFilterMultiSpec(v);
+              else setFilterMultiQty(v);
+            };
+            return (
+              <Pressable
+                key={chip.key}
+                onPress={() => setActive(!active)}
+                style={[
+                  styles.filterChip,
+                  {
+                    borderColor: active ? c.primary : c.border,
+                    backgroundColor: active ? c.primary : c.surface,
+                  },
+                ]}
+              >
+                <Text style={[styles.filterChipText, { color: active ? '#FFFFFF' : c.text }]}>
+                  {chip.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        {/* 批量操作条（仅选择模式显示） */}
+        {selectMode ? (
+          <View style={styles.selectBar}>
+            <Text style={[styles.selectCount, { color: c.text }]}>
+              已选 {selectedKeys.size} 件
+            </Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.selectActions}>
+              {renderToolChip({
+                label: allSelected ? '取消全选' : '全选',
+                onPress: toggleSelectAll,
+              })}
+              {renderToolChip({
+                label: '下架',
+                onPress: handleBatchOffline,
+                loading: batchBusy === 'offline',
+                disabled: batchBusy !== '' && batchBusy !== 'offline',
+              })}
+              {renderToolChip({
+                label: '删记录',
+                onPress: handleBatchDeleteRecords,
+                loading: batchBusy === 'delete',
+                disabled: batchBusy !== '' && batchBusy !== 'delete',
+              })}
+              {renderToolChip({
+                label: '清关联',
+                onPress: handleBatchClearRelations,
+                loading: batchBusy === 'clear',
+                disabled: batchBusy !== '' && batchBusy !== 'clear',
+              })}
+              {renderToolChip({ label: '退出', onPress: exitSelectMode })}
+            </ScrollView>
+          </View>
+        ) : null}
       </View>
 
       <FlatList
@@ -285,6 +712,7 @@ export default function ItemsScreen() {
         renderItem={renderItem}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
         contentContainerStyle={styles.list}
+        keyboardShouldPersistTaps="handled"
         onEndReached={handleLoadMore}
         onEndReachedThreshold={0.3}
         ListEmptyComponent={
@@ -300,7 +728,13 @@ export default function ItemsScreen() {
             <EmptyState
               icon={Package}
               title="暂无商品"
-              message={selectedAccountId ? '该账号暂无已发布商品' : '暂无已发布商品'}
+              message={
+                keyword || filterPolished || filterMultiSpec || filterMultiQty
+                  ? '没有符合条件的商品，试试调整搜索或筛选'
+                  : selectedAccountId
+                    ? '该账号暂无已发布商品'
+                    : '暂无已发布商品'
+              }
             />
           )
         }
@@ -346,9 +780,67 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.xs,
   },
-  list: { padding: spacing.lg, gap: spacing.md },
+  toolbar: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+  },
+  toolChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 36,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    borderWidth: 1,
+  },
+  toolChipText: { ...typography.small, fontWeight: '600' },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderRadius: radius.md,
+  },
+  searchInput: {
+    flex: 1,
+    minHeight: 40,
+    borderWidth: 0,
+    paddingHorizontal: 0,
+    paddingVertical: spacing.xs,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+  },
+  filterChip: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    borderWidth: 1,
+  },
+  filterChipText: { ...typography.small },
+  selectBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+  },
+  selectCount: { ...typography.small, fontWeight: '600' },
+  selectActions: { gap: spacing.sm, paddingVertical: 2 },
+  list: { padding: spacing.lg, paddingBottom: 80, gap: spacing.md },
   card: { padding: spacing.md },
   cardRow: { flexDirection: 'row', gap: spacing.md },
+  checkWrap: { alignItems: 'center', justifyContent: 'center' },
   thumb: {
     width: 56,
     height: 56,

--- a/xianyu-mobile/app/(tabs)/mine/listing-monitor.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/listing-monitor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   View,
   Text,
@@ -17,19 +17,104 @@ import { Card, Button, Input, Loading, EmptyState } from '@/components/ui';
 import { Eye } from 'lucide-react-native';
 import { colors, spacing, typography, radius } from '@/lib/theme';
 import {
-  getListingTasks,
   getListingOverview,
   getMonitoredItems,
   getListingCategories,
-  createListingTask,
   updateListingTaskStatus,
   runListingTask,
-  deleteListingTask,
-  type ListingTask,
   type ListingOverview,
   type ListingCategory,
   type MonitoredItem,
 } from '@/api/wrappers/products';
+import {
+  getMonitorTasksFull,
+  createMonitorTask,
+  updateMonitorTask,
+  batchDeleteMonitorTasks,
+  batchUpdateMonitorAccounts,
+  batchUpdateMonitorCategory,
+  batchUpdateMonitorDmContent,
+  type MonitorTaskFull,
+  type MonitorTaskPayload,
+} from '@/api/wrappers/monitor';
+import { getAccountOptions, type AccountOption } from '@/api/wrappers/accounts';
+
+/** 监控类型选项（value 与后端一致） */
+const MONITOR_TYPES: { value: string; label: string }[] = [
+  { value: 'listing', label: '上新监控' },
+  { value: 'price_drop', label: '降价监控' },
+];
+
+/** 上新天数筛选选项（仅上新监控展示；''=最新不限天数） */
+const PUBLISH_DAYS: { value: string; label: string }[] = [
+  { value: '', label: '最新' },
+  { value: '1', label: '1天内' },
+  { value: '3', label: '3天内' },
+  { value: '7', label: '7天内' },
+  { value: '14', label: '14天内' },
+];
+
+/** 任务表单状态（字段对齐 web ListingMonitorFormModal） */
+interface TaskFormState {
+  monitorType: string;
+  categoryId: number | null;
+  keyword: string;
+  priceMin: string;
+  priceMax: string;
+  publishDays: string;
+  intervalText: string;
+  collectPagesText: string;
+  proxyUrl: string;
+  accountIds: string[];
+  orderAccountIds: string[];
+  dmContent: string;
+  dmBatchSizeText: string;
+  orderBatchSizeText: string;
+  directOrder: boolean;
+  enabled: boolean;
+}
+
+/** 新建表单初始值（默认值对齐 web：间隔 5 分钟、采集 1 页、批量 5） */
+const EMPTY_FORM: TaskFormState = {
+  monitorType: 'listing',
+  categoryId: null,
+  keyword: '',
+  priceMin: '',
+  priceMax: '',
+  publishDays: '',
+  intervalText: '5',
+  collectPagesText: '1',
+  proxyUrl: '',
+  accountIds: [],
+  orderAccountIds: [],
+  dmContent: '',
+  dmBatchSizeText: '5',
+  orderBatchSizeText: '5',
+  directOrder: false,
+  enabled: true,
+};
+
+/** 编辑表单：由任务完整字段回填 */
+function formFromTask(task: MonitorTaskFull): TaskFormState {
+  return {
+    monitorType: task.monitor_type || 'listing',
+    categoryId: task.category_id ?? null,
+    keyword: task.keyword || '',
+    priceMin: task.price_min != null ? String(task.price_min) : '',
+    priceMax: task.price_max != null ? String(task.price_max) : '',
+    publishDays: task.publish_days != null ? String(task.publish_days) : '',
+    intervalText: task.interval_minutes != null ? String(task.interval_minutes) : '5',
+    collectPagesText: task.collect_pages != null ? String(task.collect_pages) : '1',
+    proxyUrl: task.proxy_url || '',
+    accountIds: [...(task.account_ids || [])],
+    orderAccountIds: [...(task.order_account_ids || [])],
+    dmContent: task.dm_content || '',
+    dmBatchSizeText: task.dm_batch_size != null ? String(task.dm_batch_size) : '5',
+    orderBatchSizeText: task.order_batch_size != null ? String(task.order_batch_size) : '5',
+    directOrder: Boolean(task.direct_order),
+    enabled: task.is_enabled,
+  };
+}
 
 /** 监控类型 → 展示文案 */
 function monitorTypeLabel(type: string | undefined): string {
@@ -37,7 +122,7 @@ function monitorTypeLabel(type: string | undefined): string {
 }
 
 /** 价格区间展示文案，未配置时返回 null */
-function priceRangeText(task: ListingTask): string | null {
+function priceRangeText(task: MonitorTaskFull): string | null {
   const hasMin = task.price_min != null;
   const hasMax = task.price_max != null;
   if (!hasMin && !hasMax) return null;
@@ -45,11 +130,61 @@ function priceRangeText(task: ListingTask): string | null {
   return hasMin ? `≥ ¥${task.price_min}` : `≤ ¥${task.price_max}`;
 }
 
+/** 账号展示名：备注（ID）优先，退化为纯 ID */
+function accountLabel(a: AccountOption): string {
+  return a.remark ? `${a.remark}（${a.id}）` : a.id;
+}
+
+/** 多选账号选择器（表单内嵌 chips，勾选高亮） */
+function AccountPicker({
+  options,
+  selected,
+  onToggle,
+  c,
+}: {
+  options: AccountOption[];
+  selected: string[];
+  onToggle: (id: string) => void;
+  c: (typeof colors)['light'];
+}) {
+  if (options.length === 0) {
+    return <Text style={[styles.hint, { color: c.textMuted }]}>暂无启用账号</Text>;
+  }
+  return (
+    <View style={styles.chipWrap}>
+      {options.map((a) => {
+        const checked = selected.includes(a.id);
+        return (
+          <Pressable
+            key={a.id}
+            onPress={() => onToggle(a.id)}
+            style={[
+              styles.chip,
+              {
+                borderColor: checked ? c.primary : c.border,
+                backgroundColor: checked ? c.primary : 'transparent',
+              },
+            ]}
+          >
+            <Text
+              style={[styles.chipText, { color: checked ? '#FFF' : c.text }]}
+              numberOfLines={1}
+            >
+              {checked ? '✓ ' : ''}
+              {accountLabel(a)}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
 export default function ListingMonitorScreen() {
   const scheme = useColorScheme();
   const c = colors[scheme === 'dark' ? 'dark' : 'light'];
 
-  const [tasks, setTasks] = useState<ListingTask[]>([]);
+  const [tasks, setTasks] = useState<MonitorTaskFull[]>([]);
   const [overview, setOverview] = useState<ListingOverview | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -61,17 +196,27 @@ export default function ListingMonitorScreen() {
   const [running, setRunning] = useState<Record<number, boolean>>({});
 
   const [categories, setCategories] = useState<ListingCategory[]>([]);
+  const [accounts, setAccounts] = useState<AccountOption[]>([]);
 
-  // 新建任务表单
+  // 任务表单（新建/编辑共用）
   const [modalVisible, setModalVisible] = useState(false);
+  const [editingTask, setEditingTask] = useState<MonitorTaskFull | null>(null);
+  const [form, setForm] = useState<TaskFormState>(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
-  const [keyword, setKeyword] = useState('');
-  const [categoryId, setCategoryId] = useState<number | null>(null);
-  const [categoryText, setCategoryText] = useState('');
-  const [priceMin, setPriceMin] = useState('');
-  const [priceMax, setPriceMax] = useState('');
-  const [intervalText, setIntervalText] = useState('30');
-  const [createEnabled, setCreateEnabled] = useState(true);
+
+  // 批量多选模式
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [batchBusy, setBatchBusy] = useState(false);
+  /** 批量操作弹窗类型：accounts-批量改账号，category-批量改分类，dm-批量改私信内容 */
+  const [batchModal, setBatchModal] = useState<'accounts' | 'category' | 'dm' | null>(null);
+  const [batchField, setBatchField] = useState<'account_ids' | 'order_account_ids'>('account_ids');
+  const [batchAccountIds, setBatchAccountIds] = useState<string[]>([]);
+  const [batchCategoryId, setBatchCategoryId] = useState<number | null>(null);
+  const [batchDmContent, setBatchDmContent] = useState('');
+
+  // 启用账号（下单账号仅允许启用账号，与 web 一致）
+  const enabledAccounts = useMemo(() => accounts.filter((a) => a.enabled), [accounts]);
 
   const loadOverview = useCallback(async () => {
     try {
@@ -89,10 +234,18 @@ export default function ListingMonitorScreen() {
     }
   }, []);
 
+  const loadAccounts = useCallback(async () => {
+    try {
+      setAccounts(await getAccountOptions());
+    } catch {
+      // 账号列表加载失败不阻塞页面，仅账号选择为空
+    }
+  }, []);
+
   const loadTasks = useCallback(async () => {
     setRefreshing(true);
     try {
-      setTasks(await getListingTasks());
+      setTasks(await getMonitorTasksFull());
     } catch (e) {
       Alert.alert('加载失败', (e as Error).message);
     } finally {
@@ -105,18 +258,20 @@ export default function ListingMonitorScreen() {
     loadTasks();
     loadOverview();
     loadCategories();
-  }, [loadTasks, loadOverview, loadCategories]);
+    loadAccounts();
+  }, [loadTasks, loadOverview, loadCategories, loadAccounts]);
 
   const categoryName = useCallback(
-    (id?: number): string | null => {
-      if (id == null) return null;
-      return categories.find((cat) => cat.id === id)?.name ?? null;
+    (id?: number | null): string => {
+      if (id == null) return '未分类';
+      return categories.find((cat) => cat.id === id)?.name ?? `分类 #${id}`;
     },
     [categories],
   );
 
   const toggleExpand = useCallback(
-    async (task: ListingTask) => {
+    async (task: MonitorTaskFull) => {
+      if (selectMode) return; // 多选模式下点击卡片为勾选
       if (expandedId === task.id) {
         setExpandedId(null);
         return;
@@ -134,16 +289,16 @@ export default function ListingMonitorScreen() {
         setItemsLoading((prev) => ({ ...prev, [task.id]: false }));
       }
     },
-    [expandedId, itemsMap],
+    [expandedId, itemsMap, selectMode],
   );
 
   /** 启用/停用：先乐观更新本地状态，失败时回滚 */
   const handleToggle = useCallback(
-    async (task: ListingTask, value: boolean) => {
+    async (task: MonitorTaskFull, value: boolean) => {
       const nextStatus = value ? 'active' : 'inactive';
       setTasks((prev) =>
         prev.map((t) =>
-          t.id === task.id ? { ...t, is_enabled: value, status: nextStatus } : t,
+          t.id === task.id ? { ...t, is_enabled: value } : t,
         ),
       );
       setToggling((prev) => ({ ...prev, [task.id]: true }));
@@ -153,9 +308,7 @@ export default function ListingMonitorScreen() {
       } catch (e) {
         setTasks((prev) =>
           prev.map((t) =>
-            t.id === task.id
-              ? { ...t, is_enabled: !value, status: value ? 'inactive' : 'active' }
-              : t,
+            t.id === task.id ? { ...t, is_enabled: !value } : t,
           ),
         );
         Alert.alert('操作失败', (e as Error).message);
@@ -167,7 +320,7 @@ export default function ListingMonitorScreen() {
   );
 
   const handleRun = useCallback(
-    async (task: ListingTask) => {
+    async (task: MonitorTaskFull) => {
       setRunning((prev) => ({ ...prev, [task.id]: true }));
       try {
         await runListingTask(task.id);
@@ -188,15 +341,15 @@ export default function ListingMonitorScreen() {
     [loadOverview],
   );
 
-  const confirmDelete = useCallback((task: ListingTask) => {
-    const label = task.keyword || task.name || `任务 #${task.id}`;
+  const confirmDelete = useCallback((task: MonitorTaskFull) => {
+    const label = task.keyword || `任务 #${task.id}`;
     Alert.alert('删除任务', `确定删除「${label}」吗？此操作不可恢复。`, [
       { text: '取消', style: 'cancel' },
       {
         text: '删除',
         style: 'destructive',
         onPress: () => {
-          deleteListingTask(task.id)
+          batchDeleteMonitorTasks([task.id])
             .then(() => {
               if (expandedId === task.id) setExpandedId(null);
               return Promise.all([loadTasks(), loadOverview()]);
@@ -209,66 +362,253 @@ export default function ListingMonitorScreen() {
     ]);
   }, [expandedId, loadTasks, loadOverview]);
 
+  /** 长按任务卡片弹出操作菜单（编辑/删除） */
+  const showTaskMenu = useCallback((task: MonitorTaskFull) => {
+    const label = task.keyword || `任务 #${task.id}`;
+    Alert.alert(label, undefined, [
+      { text: '编辑', onPress: () => openEdit(task) },
+      { text: '删除', style: 'destructive', onPress: () => confirmDelete(task) },
+      { text: '取消', style: 'cancel' },
+    ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [confirmDelete]);
+
   function openCreate() {
-    setKeyword('');
-    setCategoryId(null);
-    setCategoryText('');
-    setPriceMin('');
-    setPriceMax('');
-    setIntervalText('30');
-    setCreateEnabled(true);
+    setEditingTask(null);
+    setForm(EMPTY_FORM);
     setModalVisible(true);
     // 分类列表可能在首次加载时失败，打开表单时兜底重试
     if (categories.length === 0) loadCategories();
   }
 
-  async function save() {
-    const kw = keyword.trim();
+  function openEdit(task: MonitorTaskFull) {
+    setEditingTask(task);
+    setForm(formFromTask(task));
+    setModalVisible(true);
+    if (categories.length === 0) loadCategories();
+    if (accounts.length === 0) loadAccounts();
+  }
+
+  /** 表单 → 后端 payload（对齐 web：publish_days 仅上新监控生效） */
+  function buildPayload(): MonitorTaskPayload | null {
+    const kw = form.keyword.trim();
     if (!kw) {
-      Alert.alert('提示', '请输入监控关键词');
-      return;
+      Alert.alert('提示', '请输入商品监控关键词');
+      return null;
     }
-    if (categoryId == null) {
+    if (form.categoryId == null) {
       Alert.alert('提示', '请选择所属分类');
-      return;
+      return null;
     }
-    const interval = Math.floor(Number(intervalText));
+    const interval = Math.floor(Number(form.intervalText));
     if (!Number.isFinite(interval) || interval < 1) {
-      Alert.alert('提示', '执行间隔需为不小于 1 的分钟数');
-      return;
+      Alert.alert('提示', '任务间隔需为不小于 1 的整数分钟');
+      return null;
     }
-    const min = priceMin.trim() === '' ? undefined : Number(priceMin);
-    const max = priceMax.trim() === '' ? undefined : Number(priceMax);
+    const pages = Math.floor(Number(form.collectPagesText));
+    if (!Number.isFinite(pages) || pages < 1) {
+      Alert.alert('提示', '采集页数需为不小于 1 的整数');
+      return null;
+    }
+    const min = form.priceMin.trim() === '' ? null : Number(form.priceMin);
+    const max = form.priceMax.trim() === '' ? null : Number(form.priceMax);
     if (min != null && (!Number.isFinite(min) || min < 0)) {
       Alert.alert('提示', '最低价需为不小于 0 的数字');
-      return;
+      return null;
     }
     if (max != null && (!Number.isFinite(max) || max < 0)) {
       Alert.alert('提示', '最高价需为不小于 0 的数字');
-      return;
+      return null;
     }
     if (min != null && max != null && min > max) {
       Alert.alert('提示', '最低价不能高于最高价');
-      return;
+      return null;
     }
+    if (
+      form.orderAccountIds.length > 0 &&
+      !form.dmContent.trim() &&
+      !form.directOrder
+    ) {
+      Alert.alert('提示', '配置了下单账号后，私信内容必填（或开启采集后直接下单）');
+      return null;
+    }
+    if (form.directOrder && form.orderAccountIds.length === 0) {
+      Alert.alert('提示', '开启采集后直接下单需先配置下单账号');
+      return null;
+    }
+    const dmBatch = Math.floor(Number(form.dmBatchSizeText));
+    if (!Number.isInteger(dmBatch) || dmBatch < 1 || dmBatch > 100) {
+      Alert.alert('提示', '每次私信处理条数需为 1~100 的整数');
+      return null;
+    }
+    const orderBatch = Math.floor(Number(form.orderBatchSizeText));
+    if (!Number.isInteger(orderBatch) || orderBatch < 1 || orderBatch > 100) {
+      Alert.alert('提示', '每次下单处理条数需为 1~100 的整数');
+      return null;
+    }
+    return {
+      monitor_type: form.monitorType,
+      category_id: form.categoryId,
+      keyword: kw,
+      price_min: min,
+      price_max: max,
+      publish_days:
+        form.monitorType === 'listing'
+          ? form.publishDays === ''
+            ? null
+            : Math.floor(Number(form.publishDays))
+          : null,
+      interval_minutes: interval,
+      collect_pages: pages,
+      proxy_url: form.proxyUrl.trim() || null,
+      account_ids: form.accountIds,
+      order_account_ids: form.orderAccountIds,
+      dm_content: form.dmContent.trim() || null,
+      dm_batch_size: dmBatch,
+      order_batch_size: orderBatch,
+      direct_order: form.directOrder,
+      is_enabled: form.enabled,
+    };
+  }
+
+  async function save() {
+    const payload = buildPayload();
+    if (!payload) return;
     setSaving(true);
     try {
-      await createListingTask({
-        keyword: kw,
-        categoryId,
-        intervalMinutes: interval,
-        priceMin: min,
-        priceMax: max,
-        enabled: createEnabled,
-      });
+      if (editingTask) {
+        // 编辑不传 is_enabled，启停由列表开关单独控制（与 web 一致）
+        const { is_enabled: _ignored, ...updateBody } = payload;
+        await updateMonitorTask(editingTask.id, updateBody);
+      } else {
+        await createMonitorTask(payload);
+      }
       setModalVisible(false);
+      setEditingTask(null);
+      // 任务字段可能已变化，清空展开缓存
+      setItemsMap({});
       await Promise.all([loadTasks(), loadOverview()]);
     } catch (e) {
-      Alert.alert('创建失败', (e as Error).message);
+      Alert.alert(editingTask ? '保存失败' : '创建失败', (e as Error).message);
     } finally {
       setSaving(false);
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // 批量操作
+  // ---------------------------------------------------------------------------
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }, []);
+
+  const toggleSelect = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      const allSelected = tasks.length > 0 && tasks.every((t) => prev.has(t.id));
+      return allSelected ? new Set() : new Set(tasks.map((t) => t.id));
+    });
+  }, [tasks]);
+
+  const selectedArr = useMemo(() => Array.from(selectedIds), [selectedIds]);
+
+  const handleBatchDelete = useCallback(() => {
+    if (selectedArr.length === 0) return;
+    Alert.alert(
+      '批量删除',
+      `确定删除选中的 ${selectedArr.length} 个监控任务吗？此操作不可恢复。`,
+      [
+        { text: '取消', style: 'cancel' },
+        {
+          text: '删除',
+          style: 'destructive',
+          onPress: () => {
+            setBatchBusy(true);
+            batchDeleteMonitorTasks(selectedArr)
+              .then((r) => {
+                Alert.alert('成功', `已删除 ${r.success_count} 个监控任务`);
+                setSelectedIds(new Set());
+                return Promise.all([loadTasks(), loadOverview()]);
+              })
+              .catch((e: unknown) => Alert.alert('批量删除失败', (e as Error).message))
+              .finally(() => setBatchBusy(false));
+          },
+        },
+      ],
+    );
+  }, [selectedArr, loadTasks, loadOverview]);
+
+  const openBatchModal = useCallback(
+    (kind: 'accounts' | 'category' | 'dm') => {
+      if (selectedArr.length === 0) {
+        Alert.alert('提示', '请先勾选要操作的任务');
+        return;
+      }
+      if (kind === 'accounts') {
+        setBatchField('account_ids');
+        setBatchAccountIds([]);
+      } else if (kind === 'category') {
+        setBatchCategoryId(null);
+      } else {
+        setBatchDmContent('');
+      }
+      if (categories.length === 0) loadCategories();
+      if (accounts.length === 0) loadAccounts();
+      setBatchModal(kind);
+    },
+    [selectedArr, categories.length, accounts.length, loadCategories, loadAccounts],
+  );
+
+  const submitBatchModal = useCallback(async () => {
+    setBatchBusy(true);
+    try {
+      if (batchModal === 'accounts') {
+        const r = await batchUpdateMonitorAccounts(
+          selectedArr,
+          batchField,
+          batchAccountIds,
+        );
+        Alert.alert(
+          '成功',
+          `已为 ${r.success_count} 个任务修改${batchField === 'account_ids' ? '采集账号' : '下单账号'}`,
+        );
+      } else if (batchModal === 'category') {
+        if (batchCategoryId == null) {
+          Alert.alert('提示', '请选择目标分类');
+          return;
+        }
+        const r = await batchUpdateMonitorCategory(selectedArr, batchCategoryId);
+        Alert.alert('成功', `已为 ${r.success_count} 个任务修改分类`);
+      } else if (batchModal === 'dm') {
+        const content = batchDmContent.trim();
+        if (!content) {
+          Alert.alert('提示', '请输入私信内容');
+          return;
+        }
+        const r = await batchUpdateMonitorDmContent(selectedArr, content);
+        Alert.alert('成功', `已为 ${r.success_count} 个任务修改私信内容`);
+      }
+      setBatchModal(null);
+      await loadTasks();
+    } catch (e) {
+      Alert.alert('批量操作失败', (e as Error).message);
+    } finally {
+      setBatchBusy(false);
+    }
+  }, [batchModal, batchField, batchAccountIds, batchCategoryId, batchDmContent, selectedArr, loadTasks]);
 
   if (loading) {
     return (
@@ -303,10 +643,28 @@ export default function ListingMonitorScreen() {
     </View>
   );
 
+  /** 通用小段标题（表单内） */
+  const label = (text: string, required?: boolean) => (
+    <Text style={[styles.label, { color: c.textSecondary }]}>
+      {text}
+      {required ? <Text style={{ color: c.error }}> *</Text> : null}
+    </Text>
+  );
+
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
       <View style={styles.header}>
-        <Button label="+ 新建" onPress={openCreate} variant="secondary" />
+        {selectMode ? (
+          <>
+            <Button label="全选/取消" onPress={toggleSelectAll} variant="secondary" />
+            <Button label="退出多选" onPress={exitSelectMode} variant="ghost" />
+          </>
+        ) : (
+          <>
+            <Button label="批量管理" onPress={() => setSelectMode(true)} variant="secondary" />
+            <Button label="+ 新建" onPress={openCreate} />
+          </>
+        )}
       </View>
 
       <FlatList
@@ -328,23 +686,45 @@ export default function ListingMonitorScreen() {
         }
         renderItem={({ item }) => {
           const expanded = expandedId === item.id;
-          const enabled = item.is_enabled ?? item.status === 'active';
+          const enabled = item.is_enabled;
           const items = itemsMap[item.id];
           const busyToggling = !!toggling[item.id];
           const busyRunning = !!running[item.id];
           const range = priceRangeText(item);
-          const catLabel = categoryName(item.category_id) ?? `分类 #${item.category_id ?? '?'}`;
+          const checked = selectedIds.has(item.id);
           return (
-            <Card style={styles.card}>
+            <Card style={[styles.card, selectMode && checked && { borderColor: c.primary, borderWidth: 1 }]}>
               <View style={styles.taskHeader}>
+                {selectMode && (
+                  <Pressable onPress={() => toggleSelect(item.id)} hitSlop={8} style={styles.checkBox}>
+                    <View
+                      style={[
+                        styles.checkBoxInner,
+                        {
+                          borderColor: checked ? c.primary : c.border,
+                          backgroundColor: checked ? c.primary : 'transparent',
+                        },
+                      ]}
+                    >
+                      {checked && <Text style={styles.checkMark}>✓</Text>}
+                    </View>
+                  </Pressable>
+                )}
                 <Pressable
                   style={styles.taskInfo}
-                  onPress={() => toggleExpand(item)}
-                  onLongPress={() => confirmDelete(item)}
+                  onPress={() => (selectMode ? toggleSelect(item.id) : toggleExpand(item))}
+                  onLongPress={() => (selectMode ? toggleSelect(item.id) : showTaskMenu(item))}
                 >
-                  <Text style={[styles.taskName, { color: c.text }]} numberOfLines={1}>
-                    {item.keyword || item.name || `任务 #${item.id}`}
-                  </Text>
+                  <View style={styles.taskNameRow}>
+                    <Text style={[styles.taskName, { color: c.text }]} numberOfLines={1}>
+                      {item.keyword || `任务 #${item.id}`}
+                    </Text>
+                    {item.dm_content || (item.order_account_ids?.length ?? 0) > 0 ? (
+                      <View style={[styles.badge, { backgroundColor: c.primaryLight }]}>
+                        <Text style={[styles.badgeText, { color: c.primary }]}>自动私信</Text>
+                      </View>
+                    ) : null}
+                  </View>
                   <View style={styles.taskMeta}>
                     <View style={[styles.badge, { backgroundColor: c.primaryLight }]}>
                       <Text style={[styles.badgeText, { color: c.primary }]}>
@@ -352,38 +732,51 @@ export default function ListingMonitorScreen() {
                       </Text>
                     </View>
                     <Text style={[styles.metaText, { color: c.textMuted }]} numberOfLines={1}>
-                      {catLabel}
+                      {categoryName(item.category_id)}
                       {item.interval_minutes != null
                         ? ` · 每 ${item.interval_minutes} 分钟`
                         : ''}
                       {range ? ` · ${range}` : ''}
+                      {(item.account_ids?.length ?? 0) > 0
+                        ? ` · 采集账号 ${item.account_ids.length} 个`
+                        : ''}
                     </Text>
                   </View>
                 </Pressable>
-                <Switch
-                  value={enabled}
-                  onValueChange={(value) => handleToggle(item, value)}
-                  disabled={busyToggling}
-                  trackColor={{ false: c.border, true: c.primary }}
-                />
+                {!selectMode && (
+                  <Switch
+                    value={enabled}
+                    onValueChange={(value) => handleToggle(item, value)}
+                    disabled={busyToggling}
+                    trackColor={{ false: c.border, true: c.primary }}
+                  />
+                )}
               </View>
 
-              <View style={styles.taskActions}>
-                <Button
-                  label="执行"
-                  variant="secondary"
-                  onPress={() => handleRun(item)}
-                  loading={busyRunning}
-                  // 后端拒绝执行停用中的任务，这里直接禁用
-                  disabled={!enabled || busyRunning}
-                  style={styles.runBtn}
-                />
-                <Text style={[styles.expandHint, { color: c.textMuted }]}>
-                  {expanded ? '收起商品列表 ▲' : '点击查看采集商品 ▼'}
-                </Text>
-              </View>
+              {!selectMode && (
+                <View style={styles.taskActions}>
+                  <Button
+                    label="执行"
+                    variant="secondary"
+                    onPress={() => handleRun(item)}
+                    loading={busyRunning}
+                    // 后端拒绝执行停用中的任务，这里直接禁用
+                    disabled={!enabled || busyRunning}
+                    style={styles.runBtn}
+                  />
+                  <Button
+                    label="编辑"
+                    variant="secondary"
+                    onPress={() => openEdit(item)}
+                    style={styles.runBtn}
+                  />
+                  <Text style={[styles.expandHint, { color: c.textMuted }]}>
+                    {expanded ? '收起商品列表 ▲' : '点击查看采集商品 ▼'}
+                  </Text>
+                </View>
+              )}
 
-              {expanded && (
+              {expanded && !selectMode && (
                 <View
                   style={[styles.itemsWrap, { borderTopColor: c.border, borderTopWidth: 1 }]}
                 >
@@ -411,7 +804,22 @@ export default function ListingMonitorScreen() {
         }}
       />
 
-      {/* 新建任务 Modal */}
+      {/* 批量操作栏 */}
+      {selectMode && selectedArr.length > 0 && (
+        <View style={[styles.batchBar, { backgroundColor: c.surface, borderTopColor: c.border }]}>
+          <Text style={[styles.batchCount, { color: c.textSecondary }]}>
+            已选 {selectedArr.length}
+          </Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.batchActions}>
+            <Button label="删除" variant="danger" onPress={handleBatchDelete} loading={batchBusy} disabled={batchBusy} style={styles.batchBtn} />
+            <Button label="改账号" variant="secondary" onPress={() => openBatchModal('accounts')} disabled={batchBusy} style={styles.batchBtn} />
+            <Button label="改分类" variant="secondary" onPress={() => openBatchModal('category')} disabled={batchBusy} style={styles.batchBtn} />
+            <Button label="改私信" variant="secondary" onPress={() => openBatchModal('dm')} disabled={batchBusy} style={styles.batchBtn} />
+          </ScrollView>
+        </View>
+      )}
+
+      {/* 新建/编辑任务 Modal */}
       <Modal
         visible={modalVisible}
         transparent
@@ -424,31 +832,48 @@ export default function ListingMonitorScreen() {
             onPress={() => {}}
           >
             <View style={styles.modalHeader}>
-              <Text style={[styles.modalTitle, { color: c.text }]}>新建监控任务</Text>
+              <Text style={[styles.modalTitle, { color: c.text }]}>
+                {editingTask ? '编辑监控任务' : '新建监控任务'}
+              </Text>
               <Pressable onPress={() => setModalVisible(false)} hitSlop={8}>
                 <Text style={[styles.closeBtn, { color: c.textMuted }]}>✕</Text>
               </Pressable>
             </View>
 
             <ScrollView style={styles.modalScroll} keyboardShouldPersistTaps="handled">
-              <Text style={[styles.label, { color: c.textSecondary }]}>监控关键词</Text>
-              <Input
-                value={keyword}
-                onChangeText={setKeyword}
-                placeholder="如：iPhone 16 Pro"
-                maxLength={200}
-                autoFocus
-              />
+              {label('监控类型', true)}
+              <View style={styles.chipWrap}>
+                {MONITOR_TYPES.map((t) => {
+                  const selected = form.monitorType === t.value;
+                  return (
+                    <Pressable
+                      key={t.value}
+                      onPress={() => setForm((p) => ({ ...p, monitorType: t.value }))}
+                      style={[
+                        styles.chip,
+                        {
+                          borderColor: selected ? c.primary : c.border,
+                          backgroundColor: selected ? c.primary : 'transparent',
+                        },
+                      ]}
+                    >
+                      <Text style={[styles.chipText, { color: selected ? '#FFF' : c.text }]}>
+                        {t.label}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
 
-              <Text style={[styles.label, { color: c.textSecondary }]}>所属分类</Text>
+              {label('所属分类', true)}
               {categories.length > 0 ? (
                 <View style={styles.chipWrap}>
                   {categories.map((cat) => {
-                    const selected = categoryId === cat.id;
+                    const selected = form.categoryId === cat.id;
                     return (
                       <Pressable
                         key={cat.id}
-                        onPress={() => setCategoryId(cat.id)}
+                        onPress={() => setForm((p) => ({ ...p, categoryId: cat.id }))}
                         style={[
                           styles.chip,
                           {
@@ -469,53 +894,188 @@ export default function ListingMonitorScreen() {
                 </View>
               ) : (
                 <Input
-                  value={categoryText}
+                  value={form.categoryId != null ? String(form.categoryId) : ''}
                   onChangeText={(text) => {
-                    setCategoryText(text);
-                    setCategoryId(Math.floor(Number(text)) || null);
+                    const id = Math.floor(Number(text));
+                    setForm((p) => ({ ...p, categoryId: Number.isFinite(id) && id > 0 ? id : null }));
                   }}
                   placeholder="分类列表加载失败，请输入分类ID"
                   keyboardType="number-pad"
                 />
               )}
 
-              <Text style={[styles.label, { color: c.textSecondary }]}>价格区间（可选）</Text>
+              {label('商品关键词', true)}
+              <Input
+                value={form.keyword}
+                onChangeText={(text) => setForm((p) => ({ ...p, keyword: text }))}
+                placeholder="如：iPhone 16 Pro"
+                maxLength={200}
+              />
+
+              {label('价格区间（可选）')}
               <View style={styles.priceRow}>
                 <Input
-                  value={priceMin}
-                  onChangeText={setPriceMin}
+                  value={form.priceMin}
+                  onChangeText={(text) => setForm((p) => ({ ...p, priceMin: text }))}
                   placeholder="最低价"
                   keyboardType="decimal-pad"
                   style={styles.priceInput}
                 />
                 <Text style={[styles.priceSep, { color: c.textMuted }]}>-</Text>
                 <Input
-                  value={priceMax}
-                  onChangeText={setPriceMax}
+                  value={form.priceMax}
+                  onChangeText={(text) => setForm((p) => ({ ...p, priceMax: text }))}
                   placeholder="最高价"
                   keyboardType="decimal-pad"
                   style={styles.priceInput}
                 />
               </View>
 
-              <Text style={[styles.label, { color: c.textSecondary }]}>执行间隔（分钟）</Text>
+              {form.monitorType === 'listing' && (
+                <>
+                  {label('上新天数（按发布时间筛选）')}
+                  <View style={styles.chipWrap}>
+                    {PUBLISH_DAYS.map((d) => {
+                      const selected = form.publishDays === d.value;
+                      return (
+                        <Pressable
+                          key={`${d.value}-${d.label}`}
+                          onPress={() => setForm((p) => ({ ...p, publishDays: d.value }))}
+                          style={[
+                            styles.chip,
+                            {
+                              borderColor: selected ? c.primary : c.border,
+                              backgroundColor: selected ? c.primary : 'transparent',
+                            },
+                          ]}
+                        >
+                          <Text style={[styles.chipText, { color: selected ? '#FFF' : c.text }]}>
+                            {d.label}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                </>
+              )}
+
+              <View style={styles.twoColRow}>
+                <View style={styles.twoColItem}>
+                  {label('任务间隔（分钟）', true)}
+                  <Input
+                    value={form.intervalText}
+                    onChangeText={(text) => setForm((p) => ({ ...p, intervalText: text }))}
+                    placeholder="5"
+                    keyboardType="number-pad"
+                  />
+                </View>
+                <View style={styles.twoColItem}>
+                  {label('采集页数', true)}
+                  <Input
+                    value={form.collectPagesText}
+                    onChangeText={(text) => setForm((p) => ({ ...p, collectPagesText: text }))}
+                    placeholder="1"
+                    keyboardType="number-pad"
+                  />
+                </View>
+              </View>
+
+              {label('代理API地址（选填）')}
               <Input
-                value={intervalText}
-                onChangeText={setIntervalText}
-                placeholder="30"
-                keyboardType="number-pad"
+                value={form.proxyUrl}
+                onChangeText={(text) => setForm((p) => ({ ...p, proxyUrl: text }))}
+                placeholder="留空不使用代理"
+                autoCapitalize="none"
               />
+
+              {label('采集账号（可多选，留空回退兜底账号）')}
+              <AccountPicker
+                options={enabledAccounts}
+                selected={form.accountIds}
+                onToggle={(id) =>
+                  setForm((p) => ({
+                    ...p,
+                    accountIds: p.accountIds.includes(id)
+                      ? p.accountIds.filter((x) => x !== id)
+                      : [...p.accountIds, id],
+                  }))
+                }
+                c={c}
+              />
+
+              {label('下单账号（可多选，私信与下单共用）')}
+              <AccountPicker
+                options={enabledAccounts}
+                selected={form.orderAccountIds}
+                onToggle={(id) =>
+                  setForm((p) => ({
+                    ...p,
+                    orderAccountIds: p.orderAccountIds.includes(id)
+                      ? p.orderAccountIds.filter((x) => x !== id)
+                      : [...p.orderAccountIds, id],
+                  }))
+                }
+                c={c}
+              />
+
+              {label(form.orderAccountIds.length > 0 ? '私信内容（必填）' : '私信内容（配置下单账号后必填）')}
+              <Input
+                value={form.dmContent}
+                onChangeText={(text) => setForm((p) => ({ ...p, dmContent: text }))}
+                placeholder="命中商品后向卖家发送的私信内容"
+                multiline
+                maxLength={1000}
+              />
+
+              <View style={styles.twoColRow}>
+                <View style={styles.twoColItem}>
+                  {label('每次私信条数', true)}
+                  <Input
+                    value={form.dmBatchSizeText}
+                    onChangeText={(text) => setForm((p) => ({ ...p, dmBatchSizeText: text }))}
+                    placeholder="5"
+                    keyboardType="number-pad"
+                  />
+                </View>
+                <View style={styles.twoColItem}>
+                  {label('每次下单条数', true)}
+                  <Input
+                    value={form.orderBatchSizeText}
+                    onChangeText={(text) => setForm((p) => ({ ...p, orderBatchSizeText: text }))}
+                    placeholder="5"
+                    keyboardType="number-pad"
+                  />
+                </View>
+              </View>
 
               <View style={styles.switchRow}>
                 <View style={styles.switchInfo}>
-                  <Text style={[styles.label, { color: c.textSecondary }]}>创建后立即启用</Text>
+                  <Text style={[styles.label, { color: c.textSecondary, marginTop: 0 }]}>
+                    采集后直接下单
+                  </Text>
+                  <Text style={[styles.switchHint, { color: c.textMuted }]}>
+                    开启后新采集商品跳过私信立即下单，需配置下单账号
+                  </Text>
+                </View>
+                <Switch
+                  value={form.directOrder}
+                  onValueChange={(value) => setForm((p) => ({ ...p, directOrder: value }))}
+                  trackColor={{ false: c.border, true: c.primary }}
+                />
+              </View>
+
+              <View style={styles.switchRow}>
+                <View style={styles.switchInfo}>
+                  <Text style={[styles.label, { color: c.textSecondary, marginTop: 0 }]}>
+                    创建后立即启用
+                  </Text>
                   <Text style={[styles.switchHint, { color: c.textMuted }]}>
                     停用后可在列表中随时开启
                   </Text>
                 </View>
                 <Switch
-                  value={createEnabled}
-                  onValueChange={setCreateEnabled}
+                  value={form.enabled}
+                  onValueChange={(value) => setForm((p) => ({ ...p, enabled: value }))}
                   trackColor={{ false: c.border, true: c.primary }}
                 />
               </View>
@@ -529,12 +1089,159 @@ export default function ListingMonitorScreen() {
                 style={styles.modalBtn}
               />
               <Button
-                label="保存"
+                label={editingTask ? '保存修改' : '确认新建'}
                 onPress={save}
                 loading={saving}
                 disabled={saving}
                 style={styles.modalBtn}
               />
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      {/* 批量改账号 Modal */}
+      <Modal
+        visible={batchModal === 'accounts'}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setBatchModal(null)}
+      >
+        <Pressable style={styles.overlay} onPress={() => setBatchModal(null)}>
+          <Pressable style={[styles.modal, styles.batchModal, { backgroundColor: c.surface }]} onPress={() => {}}>
+            <View style={styles.modalHeader}>
+              <Text style={[styles.modalTitle, { color: c.text }]}>批量修改账号</Text>
+              <Pressable onPress={() => setBatchModal(null)} hitSlop={8}>
+                <Text style={[styles.closeBtn, { color: c.textMuted }]}>✕</Text>
+              </Pressable>
+            </View>
+            <View style={styles.chipWrap}>
+              {[
+                { value: 'account_ids', label: '采集账号' },
+                { value: 'order_account_ids', label: '下单账号' },
+              ].map((f) => {
+                const selected = batchField === f.value;
+                return (
+                  <Pressable
+                    key={f.value}
+                    onPress={() => {
+                      setBatchField(f.value as 'account_ids' | 'order_account_ids');
+                      setBatchAccountIds([]);
+                    }}
+                    style={[
+                      styles.chip,
+                      {
+                        borderColor: selected ? c.primary : c.border,
+                        backgroundColor: selected ? c.primary : 'transparent',
+                      },
+                    ]}
+                  >
+                    <Text style={[styles.chipText, { color: selected ? '#FFF' : c.text }]}>
+                      {f.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            {label(batchField === 'account_ids' ? '选择采集账号（覆盖所选任务）' : '选择下单账号（覆盖所选任务）')}
+            <ScrollView style={styles.batchPickerScroll}>
+              <AccountPicker
+                options={enabledAccounts}
+                selected={batchAccountIds}
+                onToggle={(id) =>
+                  setBatchAccountIds((prev) =>
+                    prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+                  )
+                }
+                c={c}
+              />
+            </ScrollView>
+            <View style={styles.modalActions}>
+              <Button label="取消" variant="ghost" onPress={() => setBatchModal(null)} style={styles.modalBtn} />
+              <Button label="保存" onPress={submitBatchModal} loading={batchBusy} disabled={batchBusy} style={styles.modalBtn} />
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      {/* 批量改分类 Modal */}
+      <Modal
+        visible={batchModal === 'category'}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setBatchModal(null)}
+      >
+        <Pressable style={styles.overlay} onPress={() => setBatchModal(null)}>
+          <Pressable style={[styles.modal, styles.batchModal, { backgroundColor: c.surface }]} onPress={() => {}}>
+            <View style={styles.modalHeader}>
+              <Text style={[styles.modalTitle, { color: c.text }]}>批量修改分类</Text>
+              <Pressable onPress={() => setBatchModal(null)} hitSlop={8}>
+                <Text style={[styles.closeBtn, { color: c.textMuted }]}>✕</Text>
+              </Pressable>
+            </View>
+            {label('目标分类', true)}
+            <ScrollView style={styles.batchPickerScroll}>
+              {categories.length > 0 ? (
+                <View style={styles.chipWrap}>
+                  {categories.map((cat) => {
+                    const selected = batchCategoryId === cat.id;
+                    return (
+                      <Pressable
+                        key={cat.id}
+                        onPress={() => setBatchCategoryId(cat.id)}
+                        style={[
+                          styles.chip,
+                          {
+                            borderColor: selected ? c.primary : c.border,
+                            backgroundColor: selected ? c.primary : 'transparent',
+                          },
+                        ]}
+                      >
+                        <Text style={[styles.chipText, { color: selected ? '#FFF' : c.text }]} numberOfLines={1}>
+                          {cat.name}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              ) : (
+                <Text style={[styles.hint, { color: c.textMuted }]}>分类列表加载失败，请稍后重试</Text>
+              )}
+            </ScrollView>
+            <View style={styles.modalActions}>
+              <Button label="取消" variant="ghost" onPress={() => setBatchModal(null)} style={styles.modalBtn} />
+              <Button label="保存" onPress={submitBatchModal} loading={batchBusy} disabled={batchBusy} style={styles.modalBtn} />
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      {/* 批量改私信内容 Modal */}
+      <Modal
+        visible={batchModal === 'dm'}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setBatchModal(null)}
+      >
+        <Pressable style={styles.overlay} onPress={() => setBatchModal(null)}>
+          <Pressable style={[styles.modal, styles.batchModal, { backgroundColor: c.surface }]} onPress={() => {}}>
+            <View style={styles.modalHeader}>
+              <Text style={[styles.modalTitle, { color: c.text }]}>批量修改私信内容</Text>
+              <Pressable onPress={() => setBatchModal(null)} hitSlop={8}>
+                <Text style={[styles.closeBtn, { color: c.textMuted }]}>✕</Text>
+              </Pressable>
+            </View>
+            {label('私信内容', true)}
+            <Input
+              value={batchDmContent}
+              onChangeText={setBatchDmContent}
+              placeholder="输入新的私信内容（覆盖所选任务）"
+              multiline
+              maxLength={1000}
+            />
+            <View style={styles.modalActions}>
+              <Button label="取消" variant="ghost" onPress={() => setBatchModal(null)} style={styles.modalBtn} />
+              <Button label="保存" onPress={submitBatchModal} loading={batchBusy} disabled={batchBusy} style={styles.modalBtn} />
             </View>
           </Pressable>
         </Pressable>
@@ -551,8 +1258,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
+    gap: spacing.sm,
   },
-  list: { padding: spacing.lg, paddingTop: 0, gap: spacing.md },
+  list: { padding: spacing.lg, paddingTop: 0, gap: spacing.md, paddingBottom: 80 },
   // 统计卡片
   statsCard: {
     flexDirection: 'row',
@@ -569,7 +1277,8 @@ const styles = StyleSheet.create({
   card: { gap: spacing.sm },
   taskHeader: { flexDirection: 'row', alignItems: 'center' },
   taskInfo: { flex: 1, marginRight: spacing.sm, gap: spacing.xs },
-  taskName: { ...typography.body, fontWeight: '600' },
+  taskNameRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  taskName: { ...typography.body, fontWeight: '600', flexShrink: 1 },
   taskMeta: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   badge: {
     paddingHorizontal: spacing.sm,
@@ -596,9 +1305,34 @@ const styles = StyleSheet.create({
   itemTitle: { ...typography.caption, flex: 1, marginRight: spacing.sm },
   itemPrice: { ...typography.caption, fontWeight: '600' },
   hint: { ...typography.small, paddingVertical: spacing.sm },
-  empty: { alignItems: 'center', paddingVertical: 28 },
-  emptyText: { ...typography.body },
-  // 新建 Modal
+  // 多选勾选框
+  checkBox: { marginRight: spacing.sm },
+  checkBoxInner: {
+    width: 22,
+    height: 22,
+    borderRadius: radius.sm,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkMark: { fontSize: 14, fontWeight: '700', color: '#FFF', lineHeight: 16 },
+  // 批量操作栏
+  batchBar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderTopWidth: 1,
+    gap: spacing.sm,
+  },
+  batchCount: { ...typography.small },
+  batchActions: { flex: 1 },
+  batchBtn: { minHeight: 38, paddingHorizontal: spacing.md, marginRight: spacing.sm },
+  // 表单 Modal
   overlay: {
     flex: 1,
     justifyContent: 'center',
@@ -606,6 +1340,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.5)',
   },
   modal: { borderRadius: radius.lg, padding: spacing.lg, gap: spacing.sm },
+  batchModal: { maxHeight: '80%' },
   modalHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -627,6 +1362,8 @@ const styles = StyleSheet.create({
   priceRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   priceInput: { flex: 1 },
   priceSep: { ...typography.body },
+  twoColRow: { flexDirection: 'row', gap: spacing.sm },
+  twoColItem: { flex: 1 },
   switchRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -638,4 +1375,5 @@ const styles = StyleSheet.create({
   switchHint: { ...typography.small },
   modalActions: { flexDirection: 'row', gap: spacing.sm, marginTop: spacing.md },
   modalBtn: { flex: 1 },
+  batchPickerScroll: { maxHeight: 260 },
 });

--- a/xianyu-mobile/app/(tabs)/mine/logs.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/logs.tsx
@@ -18,11 +18,11 @@ import { useAuthStore } from '@/stores/auth';
 import { getAccountOptions, type AccountOption } from '@/api/wrappers/accounts';
 import {
   getAdminLogs,
-  clearAdminLogs,
   getAutoReplyLogs,
   getAccountLoginLogs,
   clearAccountLoginLogs,
   type LogEntry,
+  type AutoReplyLogEntry,
   type AccountLoginLog,
 } from '@/api/wrappers/admin';
 import { usePagedList } from '@/hooks/usePagedList';
@@ -46,6 +46,14 @@ const LOGIN_STATUS_LABELS: Record<string, { text: string; variant: BadgeVariant 
   failed: { text: '失败', variant: 'danger' },
   skipped_cooldown: { text: '冷却跳过', variant: 'warning' },
   no_credentials: { text: '未配置账密', variant: 'gray' },
+};
+
+// 自动回复发送状态 -> 中文（对齐后端 send_status 取值）
+const SEND_STATUS_LABELS: Record<string, string> = {
+  success: '发送成功',
+  failed: '发送失败',
+  unknown: '待确认',
+  timeout: '超时',
 };
 
 // 失败/跳过细分原因中文映射（对齐 web FAILURE_REASON_LABELS）
@@ -140,7 +148,6 @@ export default function LogsScreen() {
   const [loginStatus, setLoginStatus] = useState('');
   const [loginDateRange, setLoginDateRange] = useState<DateRange>('today');
 
-  const [clearing, setClearing] = useState(false);
   const [loginClearing, setLoginClearing] = useState(false);
 
   // 首次切到未加载 Tab 时的整屏 loading（对齐原共享 loading 行为）
@@ -148,24 +155,25 @@ export default function LogsScreen() {
   const autoStartedRef = useRef(false);
   const loginStartedRef = useRef(false);
 
-  // ---- 管理员日志（page 分页，带 total，追加按 id 去重） ----
+  // ---- 系统日志（原"管理员日志"Tab）----
+  // 后端 GET /admin/logs 是 logs/*.log 的 tail（query: lines/level），非分页接口：
+  // 一次取最新 1000 行，wrapper 内已解析为 LogEntry 并按时间倒序，无加载更多。
   const adminList = usePagedList<LogEntry>({
     mode: 'page',
     pageSize: PAGE_SIZE,
-    dedupeBy: (l) => l.id,
-    fetchPage: async ({ page = 1 }) => {
-      const resp = await getAdminLogs(page, PAGE_SIZE);
-      return { items: resp.data, total: resp.total };
+    fetchPage: async () => {
+      const items = await getAdminLogs(1000);
+      return { items, total: items.length };
     },
     onError: (e, phase) => {
-      console.error('加载管理员日志失败', e);
+      console.error('加载系统日志失败', e);
       if (phase === 'refresh') Alert.alert('加载失败', e.message);
     },
   });
 
   // ---- 自动回复日志（page 分页；接口无 total，按"是否满一页"折算 hasMore） ----
   const autoLoadedRef = useRef(0);
-  const autoList = usePagedList<LogEntry>({
+  const autoList = usePagedList<AutoReplyLogEntry>({
     mode: 'page',
     pageSize: PAGE_SIZE,
     auto: false, // 首次切到该 Tab 时才加载
@@ -266,28 +274,6 @@ export default function LogsScreen() {
     loginList.refresh();
   }
 
-  async function handleClear() {
-    Alert.alert('清除日志', '确定清除所有管理员日志吗？此操作不可恢复。', [
-      { text: '取消', style: 'cancel' },
-      {
-        text: '清除',
-        style: 'destructive',
-        onPress: async () => {
-          setClearing(true);
-          try {
-            await clearAdminLogs();
-            adminList.reset();
-            Alert.alert('成功', '日志已清除');
-          } catch (e) {
-            Alert.alert('清除失败', (e as Error).message);
-          } finally {
-            setClearing(false);
-          }
-        },
-      },
-    ]);
-  }
-
   function handleClearLogin(mode: 'older_than_10d' | 'all') {
     const is10d = mode === 'older_than_10d';
     Alert.alert(
@@ -369,15 +355,7 @@ export default function LogsScreen() {
       edges={['left', 'right', 'bottom']}
     >
       <View style={styles.header}>
-        {tab === 'admin' && (
-          <Button
-            label="清除日志"
-            onPress={handleClear}
-            variant="danger"
-            loading={clearing}
-            disabled={clearing}
-          />
-        )}
+        {/* 原"清除日志"按钮已移除：后端 POST /admin/logs/clear 会清空全部系统日志文件，语义不符 */}
         {tab === 'login' && (
           <View style={styles.loginActions}>
             <Button
@@ -545,7 +523,11 @@ export default function LogsScreen() {
               </Card>
             );
           }
-          const log = item as LogEntry;
+          const log = item as AutoReplyLogEntry;
+          const isAutoReply = tab === 'autoreply';
+          const sendLabel = log.send_status
+            ? SEND_STATUS_LABELS[log.send_status] ?? log.send_status
+            : null;
           return (
             <Card style={styles.card}>
               {log.type ? (
@@ -567,6 +549,26 @@ export default function LogsScreen() {
               <Text style={[styles.content, { color: c.text }]}>
                 {log.content || '(无内容)'}
               </Text>
+              {isAutoReply && log.keyword ? (
+                <Text style={[styles.sub, { color: c.textSecondary }]} numberOfLines={1}>
+                  关键词：{log.keyword}
+                </Text>
+              ) : null}
+              {isAutoReply && log.strategy ? (
+                <Text style={[styles.sub, { color: c.textSecondary }]}>
+                  策略：{log.strategy}
+                </Text>
+              ) : null}
+              {isAutoReply && sendLabel ? (
+                <Text
+                  style={[
+                    styles.sub,
+                    { color: log.send_status === 'failed' ? c.error : c.textMuted },
+                  ]}
+                >
+                  发送：{sendLabel}
+                </Text>
+              ) : null}
             </Card>
           );
         }}
@@ -734,7 +736,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   chipText: { fontSize: 12, fontWeight: '500' },
-  listContent: { padding: spacing.lg, gap: spacing.md },
+  listContent: { padding: spacing.lg, gap: spacing.md, paddingBottom: 80 },
   card: { gap: spacing.sm, padding: spacing.md },
   cardHeader: {
     flexDirection: 'row',

--- a/xianyu-mobile/app/(tabs)/mine/message-notifications.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/message-notifications.tsx
@@ -19,7 +19,7 @@ import {
   getNotificationChannels,
   getMessageNotifications,
   createMessageNotification,
-  updateMessageNotification,
+  upsertMessageNotification,
   deleteMessageNotification,
   type MessageNotificationBinding,
 } from '@/api/wrappers/notifications';
@@ -68,7 +68,8 @@ export default function MessageNotificationsScreen() {
   async function handleToggle(item: MessageNotificationBinding) {
     const next = !item.enabled;
     setBindings((prev) => prev.map((b) => (b.id === item.id ? { ...b, enabled: next } : b)));
-    try { await updateMessageNotification(item.id, next); }
+    // 后端无 PUT /{id}，用 POST /{cookie_id} upsert（按账号+渠道更新 enabled）
+    try { await upsertMessageNotification(item.account_id, item.channel_id, next); }
     catch (e) {
       setBindings((prev) => prev.map((b) => (b.id === item.id ? { ...b, enabled: !next } : b)));
       Alert.alert('操作失败', (e as Error).message);

--- a/xianyu-mobile/app/(tabs)/mine/monitor-items.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/monitor-items.tsx
@@ -1,0 +1,715 @@
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Pressable,
+  ScrollView,
+  Alert,
+  Modal,
+  RefreshControl,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useColorScheme } from 'react-native';
+import { Card, Button, Input, Loading, EmptyState, DetailRow } from '@/components/ui';
+import { PackageSearch } from 'lucide-react-native';
+import { colors, spacing, typography, radius } from '@/lib/theme';
+import { usePagedList } from '@/hooks/usePagedList';
+import {
+  getMonitorItems,
+  getMonitorTaskOptions,
+  getMonitorItemDetail,
+  resetMonitorItemsDm,
+  isEndpointMissing,
+  type MonitorItem,
+  type MonitorTaskOption,
+} from '@/api/wrappers/monitor';
+
+const PAGE_SIZE = 20;
+
+/** 私信状态筛选项（value 与后端 dm_state 枚举一致） */
+const DM_STATE_FILTERS: { value: string; label: string }[] = [
+  { value: '', label: '私信全部' },
+  { value: 'not_sent', label: '未私信' },
+  { value: 'waiting', label: '等待重试' },
+  { value: 'pending', label: '已发待确认' },
+  { value: 'success', label: '私信成功' },
+  { value: 'failed', label: '私信失败' },
+];
+
+/** 下单状态筛选项（value 与后端 order_state 枚举一致） */
+const ORDER_STATE_FILTERS: { value: string; label: string }[] = [
+  { value: '', label: '下单全部' },
+  { value: 'not_ordered', label: '未下单' },
+  { value: 'ordered', label: '已下单' },
+  { value: 'failed', label: '下单失败' },
+  { value: 'no_account', label: '无可用账号' },
+  { value: 'duplicate', label: '重复跳过' },
+];
+
+/** 是否已获取详情筛选项 */
+const HAS_DETAIL_FILTERS: { value: string; label: string }[] = [
+  { value: '', label: '详情全部' },
+  { value: 'true', label: '已获取详情' },
+  { value: 'false', label: '未获取详情' },
+];
+
+type BadgeTone = 'ok' | 'warn' | 'err' | 'info' | 'muted';
+
+/** 由原始字段派生私信状态展示信息（对齐 web MonitorItems 的判定顺序） */
+function dmStatusInfo(item: MonitorItem): { label: string; tone: BadgeTone } {
+  if (item.dm_status === 'failed') {
+    return {
+      label: item.dm_attempts >= 3 ? '私信失败(已放弃)' : '私信失败(重试中)',
+      tone: 'err',
+    };
+  }
+  if (item.is_dm_sent) {
+    return item.dm_status === 'success'
+      ? { label: '私信成功', tone: 'ok' }
+      : { label: '已发待确认', tone: 'info' };
+  }
+  if (item.dm_status === 'waiting') return { label: '等待重试', tone: 'warn' };
+  return { label: '未私信', tone: 'muted' };
+}
+
+/** 由原始字段派生下单状态展示信息 */
+function orderStatusInfo(item: MonitorItem): { label: string; tone: BadgeTone } {
+  if (item.order_status === 'duplicate') return { label: '重复跳过', tone: 'info' };
+  if (item.is_ordered) return { label: '已下单', tone: 'ok' };
+  if (item.order_status === 'no_account') return { label: '无可用账号', tone: 'warn' };
+  if (item.order_status === 'failed') {
+    return {
+      label: item.order_attempts >= 3 ? '下单失败(已放弃)' : '下单失败(重试中)',
+      tone: 'err',
+    };
+  }
+  return { label: '未下单', tone: 'muted' };
+}
+
+function toneColor(tone: BadgeTone, c: (typeof colors)['light']): { bg: string; fg: string } {
+  switch (tone) {
+    case 'ok':
+      return { bg: c.success, fg: '#FFFFFF' };
+    case 'warn':
+      return { bg: c.warning, fg: '#FFFFFF' };
+    case 'err':
+      return { bg: c.error, fg: '#FFFFFF' };
+    case 'info':
+      return { bg: c.info, fg: '#FFFFFF' };
+    default:
+      return { bg: c.border, fg: c.textSecondary };
+  }
+}
+
+/** ISO 时间 → 可读字符串，无法解析时原样返回 */
+function formatDateTime(iso?: string | null): string {
+  if (!iso) return '-';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(
+    d.getHours(),
+  )}:${p(d.getMinutes())}`;
+}
+
+export default function MonitorItemsScreen() {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+
+  // 筛选：任务/私信/下单/详情 chips 即时生效；文本条件由「查询」提交
+  const [taskFilter, setTaskFilter] = useState<number | null>(null);
+  const [dmState, setDmState] = useState('');
+  const [orderState, setOrderState] = useState('');
+  const [hasDetail, setHasDetail] = useState('');
+  const [taskOptions, setTaskOptions] = useState<MonitorTaskOption[]>([]);
+  // 文本输入（未提交）
+  const [keywordInput, setKeywordInput] = useState('');
+  const [areaInput, setAreaInput] = useState('');
+  const [sellerNickInput, setSellerNickInput] = useState('');
+  const [itemIdInput, setItemIdInput] = useState('');
+  // 已提交的文本条件
+  const [keyword, setKeyword] = useState('');
+  const [area, setArea] = useState('');
+  const [sellerNick, setSellerNick] = useState('');
+  const [itemId, setItemId] = useState('');
+  const [searchToken, setSearchToken] = useState(0);
+  // 更多筛选展开
+  const [moreExpanded, setMoreExpanded] = useState(false);
+
+  // 多选模式 + 批量重置私信失败
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [resetting, setResetting] = useState(false);
+
+  // 详情弹窗
+  const [detailPk, setDetailPk] = useState<number | null>(null);
+  const [detailItem, setDetailItem] = useState<MonitorItem | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const list = usePagedList<MonitorItem>({
+    mode: 'page',
+    pageSize: PAGE_SIZE,
+    auto: false, // 由筛选 effect 统一触发首次加载
+    dedupeBy: (it) => it.id,
+    fetchPage: async ({ page = 1 }) => {
+      const resp = await getMonitorItems({
+        page,
+        pageSize: PAGE_SIZE,
+        monitorTaskId: taskFilter ?? undefined,
+        keyword: keyword.trim() || undefined,
+        area: area.trim() || undefined,
+        sellerNick: sellerNick.trim() || undefined,
+        itemId: itemId.trim() || undefined,
+        dmState: dmState || undefined,
+        orderState: orderState || undefined,
+        hasDetail: hasDetail === '' ? undefined : hasDetail === 'true',
+      });
+      return { items: resp.list, total: resp.total };
+    },
+    onError: (e, phase) => {
+      if (phase !== 'refresh') return;
+      if (isEndpointMissing(e)) {
+        Alert.alert('功能不可用', '采集商品需要后端新版支持，请升级后端服务');
+      } else {
+        Alert.alert('加载失败', e.message);
+      }
+    },
+  });
+
+  // 挂载与筛选变化时回到第一页重新加载（effect 在渲染后执行，fetchPage 闭包取到最新筛选）
+  useEffect(() => {
+    list.refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [taskFilter, dmState, orderState, hasDetail, searchToken]);
+
+  useEffect(() => {
+    getMonitorTaskOptions()
+      .then(setTaskOptions)
+      .catch(() => {
+        // 任务选项加载失败不阻塞列表，仅无法按任务筛选
+      });
+  }, []);
+
+  /** 「查询」：提交文本筛选并回到第一页（state 提交后由 effect 触发加载） */
+  const handleSearch = useCallback(() => {
+    setKeyword(keywordInput);
+    setArea(areaInput);
+    setSellerNick(sellerNickInput);
+    setItemId(itemIdInput);
+    setSearchToken((t) => t + 1);
+  }, [keywordInput, areaInput, sellerNickInput, itemIdInput]);
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }, []);
+
+  const toggleSelect = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      const items = list.items;
+      const allSelected = items.length > 0 && items.every((it) => prev.has(it.id));
+      return allSelected ? new Set() : new Set(items.map((it) => it.id));
+    });
+  }, [list.items]);
+
+  const selectedArr = useMemo(() => Array.from(selectedIds), [selectedIds]);
+
+  /** 打开详情弹窗并加载数据库中采集到的完整信息 */
+  const openDetail = useCallback((pk: number) => {
+    setDetailPk(pk);
+    setDetailItem(null);
+    setDetailLoading(true);
+    getMonitorItemDetail(pk)
+      .then(setDetailItem)
+      .catch((e: unknown) => {
+        Alert.alert('加载详情失败', (e as Error).message);
+        setDetailPk(null);
+      })
+      .finally(() => setDetailLoading(false));
+  }, []);
+
+  /** 批量重置「私信失败」为未私信，等待定时任务重试 */
+  const handleResetDm = useCallback(() => {
+    if (selectedArr.length === 0) {
+      Alert.alert('提示', '请先勾选要重置的采集商品');
+      return;
+    }
+    Alert.alert(
+      '重置私信失败状态',
+      `已选中 ${selectedArr.length} 条数据，仅其中「私信失败」的商品会被重置为「未私信」，并等待定时任务重新发送私信。是否继续？`,
+      [
+        { text: '取消', style: 'cancel' },
+        {
+          text: '确定重置',
+          onPress: () => {
+            setResetting(true);
+            resetMonitorItemsDm(selectedArr)
+              .then((r) => {
+                if (r.success_count === 0) {
+                  Alert.alert('提示', '选中的数据中没有可重置的「私信失败」商品');
+                  return;
+                }
+                Alert.alert('成功', `已重置 ${r.success_count} 条私信失败商品，等待定时任务重试`);
+                setSelectedIds(new Set());
+                return list.refresh();
+              })
+              .catch((e: unknown) => Alert.alert('重置失败', (e as Error).message))
+              .finally(() => setResetting(false));
+          },
+        },
+      ],
+    );
+  }, [selectedArr, list]);
+
+  const taskKeyword = useCallback(
+    (item: MonitorItem): string => {
+      if (item.monitor_task_keyword) return item.monitor_task_keyword;
+      if (item.monitor_task_id != null) {
+        return (
+          taskOptions.find((t) => t.id === item.monitor_task_id)?.keyword ||
+          `任务 #${item.monitor_task_id}`
+        );
+      }
+      return '未知任务';
+    },
+    [taskOptions],
+  );
+
+  /** 详情弹窗行数据（仅展示有值字段，避免整屏 "-"） */
+  const detailRows = useMemo(() => {
+    if (!detailItem) return [];
+    const rows: { label: string; value: string }[] = [
+      { label: '商品ID', value: detailItem.item_id || '-' },
+      { label: '商品标题', value: detailItem.title || '-' },
+      { label: '价格', value: detailItem.price ? `¥${detailItem.price}` : '-' },
+      { label: '地区', value: detailItem.area || '-' },
+      { label: '卖家昵称', value: detailItem.seller_nick || '-' },
+      { label: '卖家真实ID', value: detailItem.seller_user_id || '-' },
+      { label: '想要数', value: detailItem.want_count > 0 ? String(detailItem.want_count) : '-' },
+      { label: '营销标签', value: detailItem.tags || '-' },
+      { label: '发布时间', value: formatDateTime(detailItem.publish_time) },
+      { label: '私信状态', value: dmStatusInfo(detailItem).label },
+      { label: '私信账号', value: detailItem.dm_account_id || '-' },
+      { label: '私信失败原因', value: detailItem.dm_fail_reason || '-' },
+      { label: '下单状态', value: orderStatusInfo(detailItem).label },
+      { label: '订单ID', value: detailItem.order_id || '-' },
+      { label: '下单账号', value: detailItem.order_account_id || '-' },
+      { label: '下单失败原因', value: detailItem.order_fail_reason || '-' },
+      { label: '是否获取详情', value: detailItem.has_detail ? '已获取' : '未获取' },
+      { label: '最近采集', value: formatDateTime(detailItem.last_seen_at) },
+      { label: '采集时间', value: formatDateTime(detailItem.created_at) },
+      { label: '更新时间', value: formatDateTime(detailItem.updated_at) },
+    ];
+    return rows;
+  }, [detailItem]);
+
+  if (list.loading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
+        <Loading label="加载采集商品..." />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
+      <View style={styles.header}>
+        {selectMode ? (
+          <>
+            <Button
+              label={`重置私信失败 (${selectedIds.size})`}
+              onPress={handleResetDm}
+              loading={resetting}
+              disabled={resetting || selectedIds.size === 0}
+            />
+            <Button label="全选/取消" onPress={toggleSelectAll} variant="secondary" />
+            <Button label="取消" onPress={exitSelectMode} variant="ghost" />
+          </>
+        ) : (
+          <>
+            <Button label="批量重置" onPress={() => setSelectMode(true)} variant="secondary" />
+            <Button label="刷新" onPress={() => list.refresh()} loading={list.refreshing} />
+          </>
+        )}
+      </View>
+
+      {/* 筛选区：任务 chips / 搜索框 / 状态 chips / 更多筛选 */}
+      <View style={styles.filterSection}>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View style={styles.chipRow}>
+            <Pressable
+              onPress={() => setTaskFilter(null)}
+              style={[
+                styles.chip,
+                {
+                  borderColor: taskFilter == null ? c.primary : c.border,
+                  backgroundColor: taskFilter == null ? c.primary : 'transparent',
+                },
+              ]}
+            >
+              <Text style={[styles.chipText, { color: taskFilter == null ? '#FFF' : c.text }]}>
+                全部任务
+              </Text>
+            </Pressable>
+            {taskOptions.map((t) => {
+              const selected = taskFilter === t.id;
+              return (
+                <Pressable
+                  key={t.id}
+                  onPress={() => setTaskFilter(t.id)}
+                  style={[
+                    styles.chip,
+                    {
+                      borderColor: selected ? c.primary : c.border,
+                      backgroundColor: selected ? c.primary : 'transparent',
+                    },
+                  ]}
+                >
+                  <Text
+                    style={[styles.chipText, { color: selected ? '#FFF' : c.text }]}
+                    numberOfLines={1}
+                  >
+                    {t.keyword || `任务 #${t.id}`}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </ScrollView>
+
+        <View style={styles.searchRow}>
+          <Input
+            value={keywordInput}
+            onChangeText={setKeywordInput}
+            placeholder="搜索商品标题"
+            style={styles.searchInput}
+            returnKeyType="search"
+            onSubmitEditing={handleSearch}
+          />
+          <Button label="查询" onPress={handleSearch} style={styles.searchBtn} />
+          <Button
+            label={moreExpanded ? '收起' : '更多'}
+            variant="secondary"
+            onPress={() => setMoreExpanded((v) => !v)}
+            style={styles.searchBtn}
+          />
+        </View>
+
+        {moreExpanded && (
+          <View style={[styles.morePanel, { backgroundColor: c.surface, borderColor: c.borderLight }]}>
+            <Text style={[styles.moreLabel, { color: c.textSecondary }]}>地区</Text>
+            <Input value={areaInput} onChangeText={setAreaInput} placeholder="如：江苏" />
+            <Text style={[styles.moreLabel, { color: c.textSecondary }]}>卖家昵称</Text>
+            <Input value={sellerNickInput} onChangeText={setSellerNickInput} placeholder="输入卖家昵称" />
+            <Text style={[styles.moreLabel, { color: c.textSecondary }]}>商品ID（精确）</Text>
+            <Input value={itemIdInput} onChangeText={setItemIdInput} placeholder="输入商品ID" />
+            <Button label="应用筛选" variant="secondary" onPress={handleSearch} style={styles.applyBtn} />
+          </View>
+        )}
+
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View style={styles.chipRow}>
+            {DM_STATE_FILTERS.map((f) => {
+              const selected = dmState === f.value;
+              return (
+                <Pressable
+                  key={f.value || 'all'}
+                  onPress={() => setDmState(f.value)}
+                  style={[
+                    styles.chip,
+                    {
+                      borderColor: selected ? c.primary : c.border,
+                      backgroundColor: selected ? c.primary : 'transparent',
+                    },
+                  ]}
+                >
+                  <Text style={[styles.chipText, { color: selected ? '#FFF' : c.text }]}>
+                    {f.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </ScrollView>
+
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View style={styles.chipRow}>
+            {ORDER_STATE_FILTERS.map((f) => {
+              const selected = orderState === f.value;
+              return (
+                <Pressable
+                  key={f.value || 'all'}
+                  onPress={() => setOrderState(f.value)}
+                  style={[
+                    styles.chip,
+                    {
+                      borderColor: selected ? c.primary : c.border,
+                      backgroundColor: selected ? c.primary : 'transparent',
+                    },
+                  ]}
+                >
+                  <Text style={[styles.chipText, { color: selected ? '#FFF' : c.text }]}>
+                    {f.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </ScrollView>
+
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View style={styles.chipRow}>
+            {HAS_DETAIL_FILTERS.map((f) => {
+              const selected = hasDetail === f.value;
+              return (
+                <Pressable
+                  key={f.value || 'all'}
+                  onPress={() => setHasDetail(f.value)}
+                  style={[
+                    styles.chip,
+                    {
+                      borderColor: selected ? c.primary : c.border,
+                      backgroundColor: selected ? c.primary : 'transparent',
+                    },
+                  ]}
+                >
+                  <Text style={[styles.chipText, { color: selected ? '#FFF' : c.text }]}>
+                    {f.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </ScrollView>
+      </View>
+
+      <FlatList
+        data={list.items}
+        keyExtractor={(item) => String(item.id)}
+        refreshControl={
+          <RefreshControl refreshing={list.refreshing} onRefresh={list.refresh} />
+        }
+        onEndReached={list.loadMore}
+        onEndReachedThreshold={0.3}
+        contentContainerStyle={styles.list}
+        ListEmptyComponent={
+          <EmptyState
+            icon={PackageSearch}
+            title="暂无采集商品"
+            message="监控任务采集到商品后会展示在这里"
+          />
+        }
+        ListFooterComponent={
+          list.loadingMore ? (
+            <Text style={[styles.loadingMore, { color: c.textMuted }]}>加载中...</Text>
+          ) : null
+        }
+        renderItem={({ item }) => {
+          const dm = dmStatusInfo(item);
+          const order = orderStatusInfo(item);
+          const dmTone = toneColor(dm.tone, c);
+          const orderTone = toneColor(order.tone, c);
+          const checked = selectedIds.has(item.id);
+          return (
+            <Pressable
+              onPress={() => (selectMode ? toggleSelect(item.id) : openDetail(item.id))}
+            >
+              <Card style={[styles.card, selectMode && checked && { borderColor: c.primary, borderWidth: 1 }]}>
+                <View style={styles.cardHeader}>
+                  <View style={styles.badgeRow}>
+                    {selectMode && (
+                      <View
+                        style={[
+                          styles.checkBoxInner,
+                          {
+                            borderColor: checked ? c.primary : c.border,
+                            backgroundColor: checked ? c.primary : 'transparent',
+                          },
+                        ]}
+                      >
+                        {checked && <Text style={styles.checkMark}>✓</Text>}
+                      </View>
+                    )}
+                    <View style={[styles.statusBadge, { backgroundColor: dmTone.bg }]}>
+                      <Text style={[styles.statusText, { color: dmTone.fg }]}>{dm.label}</Text>
+                    </View>
+                    <View style={[styles.statusBadge, { backgroundColor: orderTone.bg }]}>
+                      <Text style={[styles.statusText, { color: orderTone.fg }]}>{order.label}</Text>
+                    </View>
+                    {item.has_detail ? (
+                      <View style={[styles.statusBadge, { backgroundColor: c.primaryLight }]}>
+                        <Text style={[styles.statusText, { color: c.primary }]}>有详情</Text>
+                      </View>
+                    ) : null}
+                  </View>
+                  <Text style={[styles.price, { color: c.primary }]}>
+                    {item.price ? `¥${item.price}` : '-'}
+                  </Text>
+                </View>
+
+                <Text style={[styles.title, { color: c.text }]} numberOfLines={2}>
+                  {item.title || item.item_id || '（无标题）'}
+                </Text>
+
+                <Text style={[styles.meta, { color: c.textMuted }]} numberOfLines={1}>
+                  {taskKeyword(item)}
+                  {item.area ? ` · ${item.area}` : ''}
+                  {item.seller_nick ? ` · ${item.seller_nick}` : ''}
+                </Text>
+                <Text style={[styles.meta, { color: c.textMuted }]}>
+                  采集于 {formatDateTime(item.created_at)}
+                </Text>
+                {!selectMode && (
+                  <Text style={[styles.detailHint, { color: c.primary }]}>点击查看详情</Text>
+                )}
+              </Card>
+            </Pressable>
+          );
+        }}
+      />
+
+      {/* 采集商品详情弹窗 */}
+      <Modal
+        visible={detailPk != null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setDetailPk(null)}
+      >
+        <Pressable style={styles.overlay} onPress={() => setDetailPk(null)}>
+          <Pressable style={[styles.modal, { backgroundColor: c.surface }]} onPress={() => {}}>
+            <View style={styles.modalHeader}>
+              <Text style={[styles.modalTitle, { color: c.text }]}>采集商品详情</Text>
+              <Pressable onPress={() => setDetailPk(null)} hitSlop={8}>
+                <Text style={[styles.closeBtn, { color: c.textMuted }]}>✕</Text>
+              </Pressable>
+            </View>
+            {detailLoading ? (
+              <Loading label="加载详情..." />
+            ) : (
+              <ScrollView style={styles.detailScroll} keyboardShouldPersistTaps="handled">
+                {detailRows.map((row) => (
+                  <DetailRow key={row.label} label={row.label} value={row.value} c={c} />
+                ))}
+              </ScrollView>
+            )}
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  filterSection: { gap: spacing.sm, paddingBottom: spacing.sm },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  chip: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    maxWidth: 160,
+  },
+  chipText: { ...typography.small },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  searchInput: { flex: 1, minHeight: 40 },
+  searchBtn: { minHeight: 40, paddingHorizontal: spacing.md },
+  morePanel: {
+    marginHorizontal: spacing.lg,
+    padding: spacing.md,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    gap: spacing.xs,
+  },
+  moreLabel: { ...typography.small, marginTop: spacing.xs },
+  applyBtn: { minHeight: 40, marginTop: spacing.sm },
+  list: { padding: spacing.lg, paddingTop: spacing.sm, gap: spacing.md, paddingBottom: 80 },
+  card: { gap: spacing.xs },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    flexShrink: 1,
+    flexWrap: 'wrap',
+  },
+  statusBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radius.sm,
+  },
+  statusText: { ...typography.micro },
+  checkBoxInner: {
+    width: 20,
+    height: 20,
+    borderRadius: radius.sm,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkMark: { fontSize: 13, fontWeight: '700', color: '#FFF', lineHeight: 15 },
+  price: { ...typography.body, fontWeight: '700' },
+  title: { ...typography.caption, fontWeight: '600' },
+  meta: { ...typography.small },
+  detailHint: { ...typography.small },
+  loadingMore: { textAlign: 'center', padding: spacing.md },
+  // 详情弹窗
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: spacing.lg,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  modal: {
+    borderRadius: radius.lg,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    maxHeight: '80%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  modalTitle: { ...typography.heading },
+  closeBtn: { fontSize: 22, paddingHorizontal: spacing.xs },
+  detailScroll: { maxHeight: 420, gap: spacing.xs },
+});

--- a/xianyu-mobile/app/(tabs)/mine/monitor-logs.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/monitor-logs.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   View,
   Text,
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useColorScheme } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
 import { Card, Button, Loading } from '@/components/ui';
 import { colors, spacing, typography, radius } from '@/lib/theme';
 import { usePagedList } from '@/hooks/usePagedList';
@@ -18,6 +19,7 @@ import {
   getMonitorLogs,
   getMonitorTaskOptions,
   clearMonitorLogs,
+  copyMonitorLogCookies,
   isEndpointMissing,
   type MonitorLog,
   type MonitorTaskOption,
@@ -31,6 +33,13 @@ const STATUS_FILTERS: { value: string; label: string }[] = [
   { value: 'success', label: '成功' },
   { value: 'partial', label: '部分成功' },
   { value: 'failed', label: '失败' },
+];
+
+/** 监控类型筛选项（value 与后端 monitor_type 枚举一致） */
+const MONITOR_TYPE_FILTERS: { value: string; label: string }[] = [
+  { value: '', label: '全部类型' },
+  { value: 'listing', label: '上新' },
+  { value: 'price_drop', label: '降价' },
 ];
 
 /** 监控类型 → 展示文案（与 listing-monitor 页一致） */
@@ -68,11 +77,16 @@ export default function MonitorLogsScreen() {
   const scheme = useColorScheme();
   const c = colors[scheme === 'dark' ? 'dark' : 'light'];
 
-  // 筛选条件：按任务 / 按状态；变化后由 effect 触发重新加载
+  // 筛选条件：按任务 / 按监控类型 / 按状态；变化后由 effect 触发重新加载
   const [taskFilter, setTaskFilter] = useState<number | null>(null);
+  const [typeFilter, setTypeFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [taskOptions, setTaskOptions] = useState<MonitorTaskOption[]>([]);
   const [clearing, setClearing] = useState(false);
+  // 多选模式：勾选日志后批量复制账号Cookies
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [copying, setCopying] = useState(false);
 
   const list = usePagedList<MonitorLog>({
     mode: 'page',
@@ -85,6 +99,7 @@ export default function MonitorLogsScreen() {
         pageSize: PAGE_SIZE,
         monitorTaskId: taskFilter ?? undefined,
         status: statusFilter || undefined,
+        monitorType: typeFilter || undefined,
       });
       return { items: resp.list, total: resp.total };
     },
@@ -102,7 +117,7 @@ export default function MonitorLogsScreen() {
   useEffect(() => {
     list.refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [taskFilter, statusFilter]);
+  }, [taskFilter, typeFilter, statusFilter]);
 
   useEffect(() => {
     getMonitorTaskOptions()
@@ -138,6 +153,58 @@ export default function MonitorLogsScreen() {
     );
   }, [list]);
 
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }, []);
+
+  const toggleSelect = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      const items = list.items;
+      const allSelected = items.length > 0 && items.every((l) => prev.has(l.id));
+      return allSelected ? new Set() : new Set(items.map((l) => l.id));
+    });
+  }, [list.items]);
+
+  /** 批量复制选中日志涉及账号的 Cookies（JSON 串写入剪贴板） */
+  const handleCopyCookies = useCallback(() => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) {
+      Alert.alert('提示', '请先勾选要复制的监控日志');
+      return;
+    }
+    setCopying(true);
+    copyMonitorLogCookies(ids)
+      .then(async (accountList) => {
+        if (accountList.length === 0) {
+          Alert.alert('提示', '选中的日志没有可复制的账号信息');
+          return;
+        }
+        const json = JSON.stringify(accountList, null, 2);
+        try {
+          await Clipboard.setStringAsync(json);
+          Alert.alert('成功', `已复制 ${accountList.length} 个账号的 Cookies 到剪贴板`);
+        } catch {
+          // expo-clipboard 原生模块不可用时降级提示
+          Alert.alert('复制失败', '剪贴板不可用，请升级 App 后重试');
+        }
+      })
+      .catch((e: unknown) => Alert.alert('复制账号Cookies失败', (e as Error).message))
+      .finally(() => setCopying(false));
+  }, [selectedIds]);
+
   const taskKeyword = useCallback(
     (taskId: number | null): string => {
       if (taskId == null) return '';
@@ -160,13 +227,29 @@ export default function MonitorLogsScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
       <View style={styles.header}>
-        <Button
-          label="清空日志"
-          onPress={handleClear}
-          variant="danger"
-          loading={clearing}
-          disabled={clearing}
-        />
+        {selectMode ? (
+          <>
+            <Button
+              label={`复制Cookies (${selectedIds.size})`}
+              onPress={handleCopyCookies}
+              loading={copying}
+              disabled={copying || selectedIds.size === 0}
+            />
+            <Button label="全选/取消" onPress={toggleSelectAll} variant="secondary" />
+            <Button label="取消" onPress={exitSelectMode} variant="ghost" />
+          </>
+        ) : (
+          <>
+            <Button label="多选" onPress={() => setSelectMode(true)} variant="secondary" />
+            <Button
+              label="清空日志"
+              onPress={handleClear}
+              variant="danger"
+              loading={clearing}
+              disabled={clearing}
+            />
+          </>
+        )}
       </View>
 
       {/* 任务筛选（横向 chips） */}
@@ -214,6 +297,37 @@ export default function MonitorLogsScreen() {
                     numberOfLines={1}
                   >
                     {t.keyword || `任务 #${t.id}`}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </ScrollView>
+
+        {/* 监控类型筛选 */}
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View style={styles.chipRow}>
+            {MONITOR_TYPE_FILTERS.map((f) => {
+              const selected = typeFilter === f.value;
+              return (
+                <Pressable
+                  key={f.value || 'all'}
+                  onPress={() => setTypeFilter(f.value)}
+                  style={[
+                    styles.chip,
+                    {
+                      borderColor: selected ? c.primary : c.border,
+                      backgroundColor: selected ? c.primary : 'transparent',
+                    },
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.chipText,
+                      { color: selected ? '#FFF' : c.text },
+                    ]}
+                  >
+                    {f.label}
                   </Text>
                 </Pressable>
               );
@@ -274,47 +388,71 @@ export default function MonitorLogsScreen() {
         }
         renderItem={({ item }) => {
           const badge = statusStyle(item.status, c);
+          const checked = selectedIds.has(item.id);
           return (
-            <Card style={styles.card}>
-              <View style={styles.cardHeader}>
-                <View style={styles.badgeRow}>
-                  <View style={[styles.statusBadge, { backgroundColor: badge.bg }]}>
-                    <Text style={[styles.statusText, { color: badge.fg }]}>
-                      {badge.label}
+            <Pressable
+              onPress={() => (selectMode ? toggleSelect(item.id) : undefined)}
+              disabled={!selectMode}
+            >
+              <Card style={[styles.card, selectMode && checked && { borderColor: c.primary, borderWidth: 1 }]}>
+                {selectMode && (
+                  <View style={styles.selectRow}>
+                    <View
+                      style={[
+                        styles.checkBoxInner,
+                        {
+                          borderColor: checked ? c.primary : c.border,
+                          backgroundColor: checked ? c.primary : 'transparent',
+                        },
+                      ]}
+                    >
+                      {checked && <Text style={styles.checkMark}>✓</Text>}
+                    </View>
+                    <Text style={[styles.selectHint, { color: c.textMuted }]}>
+                      {checked ? '已勾选' : '点击勾选'}
                     </Text>
                   </View>
-                  <View style={[styles.typeBadge, { backgroundColor: c.primaryLight }]}>
-                    <Text style={[styles.typeText, { color: c.primary }]}>
-                      {monitorTypeLabel(item.monitor_type)}
-                    </Text>
+                )}
+                <View style={styles.cardHeader}>
+                  <View style={styles.badgeRow}>
+                    <View style={[styles.statusBadge, { backgroundColor: badge.bg }]}>
+                      <Text style={[styles.statusText, { color: badge.fg }]}>
+                        {badge.label}
+                      </Text>
+                    </View>
+                    <View style={[styles.typeBadge, { backgroundColor: c.primaryLight }]}>
+                      <Text style={[styles.typeText, { color: c.primary }]}>
+                        {monitorTypeLabel(item.monitor_type)}
+                      </Text>
+                    </View>
+                    {item.trigger_type ? (
+                      <Text style={[styles.trigger, { color: c.textMuted }]}>
+                        {triggerLabel(item.trigger_type)}
+                      </Text>
+                    ) : null}
                   </View>
-                  {item.trigger_type ? (
-                    <Text style={[styles.trigger, { color: c.textMuted }]}>
-                      {triggerLabel(item.trigger_type)}
-                    </Text>
-                  ) : null}
+                  <Text style={[styles.time, { color: c.textMuted }]}>
+                    {formatDate(item.created_at)}
+                  </Text>
                 </View>
-                <Text style={[styles.time, { color: c.textMuted }]}>
-                  {formatDate(item.created_at)}
+
+                <Text style={[styles.keyword, { color: c.text }]} numberOfLines={1}>
+                  {item.keyword || taskKeyword(item.monitor_task_id) || '未知任务'}
                 </Text>
-              </View>
 
-              <Text style={[styles.keyword, { color: c.text }]} numberOfLines={1}>
-                {item.keyword || taskKeyword(item.monitor_task_id) || '未知任务'}
-              </Text>
-
-              <Text style={[styles.meta, { color: c.textMuted }]}>
-                采集 {item.fetched_count} · 新增 {item.inserted_count} · 更新{' '}
-                {item.updated_count}
-                {item.pages > 0 ? ` · ${item.pages} 页` : ''}
-              </Text>
-
-              {item.message ? (
-                <Text style={[styles.message, { color: c.textSecondary }]} numberOfLines={2}>
-                  {item.message}
+                <Text style={[styles.meta, { color: c.textMuted }]}>
+                  采集 {item.fetched_count} · 新增 {item.inserted_count} · 更新{' '}
+                  {item.updated_count}
+                  {item.pages > 0 ? ` · ${item.pages} 页` : ''}
                 </Text>
-              ) : null}
-            </Card>
+
+                {item.message ? (
+                  <Text style={[styles.message, { color: c.textSecondary }]} numberOfLines={2}>
+                    {item.message}
+                  </Text>
+                ) : null}
+              </Card>
+            </Pressable>
           );
         }}
       />
@@ -328,6 +466,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
   },
@@ -346,8 +486,24 @@ const styles = StyleSheet.create({
     maxWidth: 160,
   },
   chipText: { ...typography.small },
-  list: { padding: spacing.lg, paddingTop: spacing.sm, gap: spacing.md },
+  list: { padding: spacing.lg, paddingTop: spacing.sm, gap: spacing.md, paddingBottom: 80 },
   card: { gap: spacing.xs },
+  selectRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  checkBoxInner: {
+    width: 20,
+    height: 20,
+    borderRadius: radius.sm,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkMark: { fontSize: 13, fontWeight: '700', color: '#FFF', lineHeight: 15 },
+  selectHint: { ...typography.small },
   cardHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/xianyu-mobile/app/(tabs)/mine/notification-channels.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/notification-channels.tsx
@@ -7,14 +7,13 @@ import {
   Pressable,
   Switch,
   Alert,
-  Modal,
   RefreshControl,
   ScrollView,
   useColorScheme,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Bell, Plus } from 'lucide-react-native';
-import { Card, Button, Input, Loading, EmptyState } from '@/components/ui';
+import { Card, Button, Input, Loading, EmptyState, FormModal } from '@/components/ui';
 import { colors, spacing, typography, radius } from '@/lib/theme';
 import {
   getNotificationChannels,
@@ -22,24 +21,123 @@ import {
   updateNotificationChannel,
   deleteNotificationChannel,
   testNotificationChannel,
-  CHANNEL_TYPES,
   type NotificationChannel,
 } from '@/api/wrappers/notifications';
 
-/** 按渠道类型展示的 config 字段提示 */
-const TYPE_FIELD_HINTS: Record<string, { urlLabel: string; urlPlaceholder: string; urlHint: string; tokenHint: string }> = {
-  dingtalk: { urlLabel: 'Webhook 地址', urlPlaceholder: 'https://oapi.dingtalk.com/robot/send?access_token=...', urlHint: '钉钉自定义机器人的 Webhook 地址', tokenHint: '加签密钥（SEC 开头，可留空）' },
-  feishu: { urlLabel: 'Webhook 地址', urlPlaceholder: 'https://open.feishu.cn/open-apis/bot/v2/hook/...', urlHint: '飞书自定义机器人的 Webhook 地址', tokenHint: '签名校验密钥（可留空）' },
-  bark: { urlLabel: '服务器地址', urlPlaceholder: 'https://api.day.app', urlHint: 'Bark 推送服务器地址', tokenHint: 'Bark 设备 Key' },
-  email: { urlLabel: 'SMTP 地址', urlPlaceholder: 'smtp.qq.com:465', urlHint: 'SMTP 服务器地址（含端口）', tokenHint: 'SMTP 授权码 / 登录密码' },
-  webhook: { urlLabel: '回调地址', urlPlaceholder: 'https://example.com/hook', urlHint: '接收通知的自定义 Webhook 地址', tokenHint: '鉴权 Token（可留空）' },
-  wecom: { urlLabel: 'Webhook 地址', urlPlaceholder: 'https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=...', urlHint: '企业微信群机器人的 Webhook 地址', tokenHint: '可留空' },
-};
+// ---------------------------------------------------------------------------
+// 渠道类型 × 动态配置字段
+// 字段 key 与后端 common/utils/notification_utils.py 的发送函数一一对应：
+//   dingtalk/feishu: webhook_url + secret（加签）
+//   email: smtp_server / smtp_port / email_user / email_password / recipient_email
+//   telegram: bot_token + chat_id；pushplus: token(+topic/template)
+//   bark: server_url + device_key；webhook/wecom: webhook_url
+// ---------------------------------------------------------------------------
+interface FieldDef {
+  key: string;
+  label: string;
+  hint?: string;
+  placeholder?: string;
+  /** 可留空 */
+  optional?: boolean;
+  /** 数字输入（保存时转 Number） */
+  numeric?: boolean;
+  /** 密码框 */
+  secure?: boolean;
+  /** 新建时的默认值 */
+  defaultValue?: string;
+}
 
-const DEFAULT_FIELD_HINTS = { urlLabel: 'Webhook 地址', urlPlaceholder: 'https://...', urlHint: '通知接收地址', tokenHint: '访问令牌 / 密钥（可留空）' };
+interface ChannelTypeDef {
+  value: string;
+  label: string;
+  fields: FieldDef[];
+}
+
+const CHANNEL_TYPE_DEFS: ChannelTypeDef[] = [
+  {
+    value: 'webhook',
+    label: 'Webhook',
+    fields: [
+      { key: 'webhook_url', label: '回调地址', placeholder: 'https://example.com/hook', hint: '接收通知消息的自定义 HTTP 地址' },
+    ],
+  },
+  {
+    value: 'dingtalk',
+    label: '钉钉',
+    fields: [
+      { key: 'webhook_url', label: 'Webhook 地址', placeholder: 'https://oapi.dingtalk.com/robot/send?access_token=...', hint: '钉钉自定义机器人的 Webhook 地址' },
+      { key: 'secret', label: '加签密钥', hint: 'SEC 开头的签名密钥，未开启加签可留空', optional: true },
+    ],
+  },
+  {
+    value: 'feishu',
+    label: '飞书',
+    fields: [
+      { key: 'webhook_url', label: 'Webhook 地址', placeholder: 'https://open.feishu.cn/open-apis/bot/v2/hook/...', hint: '飞书自定义机器人的 Webhook 地址' },
+      { key: 'secret', label: '签名校验密钥', hint: '开启签名校验时填写，可留空', optional: true },
+    ],
+  },
+  {
+    value: 'email',
+    label: '邮件',
+    fields: [
+      { key: 'smtp_server', label: 'SMTP 服务器', placeholder: 'smtp.qq.com', hint: '邮箱服务商的 SMTP 地址' },
+      { key: 'smtp_port', label: 'SMTP 端口', placeholder: '587', numeric: true, defaultValue: '587', hint: '465 为 SSL，587 为 STARTTLS' },
+      { key: 'email_user', label: '发件邮箱账号', placeholder: 'you@example.com' },
+      { key: 'email_password', label: 'SMTP 授权码 / 密码', secure: true, hint: 'QQ 邮箱等需填写授权码' },
+      { key: 'recipient_email', label: '收件邮箱', placeholder: 'receiver@example.com' },
+    ],
+  },
+  {
+    value: 'telegram',
+    label: 'Telegram',
+    fields: [
+      { key: 'bot_token', label: 'Bot Token', placeholder: '123456:ABC-xxx', hint: '@BotFather 创建机器人后获得的 Token' },
+      { key: 'chat_id', label: 'Chat ID', placeholder: '聊天 / 频道 ID' },
+    ],
+  },
+  {
+    value: 'pushplus',
+    label: 'PushPlus',
+    fields: [
+      { key: 'token', label: 'Token', placeholder: 'PushPlus 官网获取的推送 Token', hint: 'pushplus.plus 用户中心获取' },
+      { key: 'topic', label: '群组编码', hint: '一对多推送时填写，普通推送留空', optional: true },
+      { key: 'template', label: '模板', placeholder: 'txt', defaultValue: 'txt', hint: 'html / txt / json 等，默认 txt', optional: true },
+    ],
+  },
+  {
+    value: 'bark',
+    label: 'Bark',
+    fields: [
+      { key: 'server_url', label: '服务器地址', placeholder: 'https://api.day.app', defaultValue: 'https://api.day.app', hint: 'Bark 推送服务器，默认官方地址', optional: true },
+      { key: 'device_key', label: '设备 Key', placeholder: 'Bark App 中的设备密钥' },
+    ],
+  },
+  {
+    value: 'wecom',
+    label: '企业微信',
+    fields: [
+      { key: 'webhook_url', label: 'Webhook 地址', placeholder: 'https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=...', hint: '企业微信群机器人的 Webhook 地址' },
+    ],
+  },
+];
+
+function typeDefOf(type: string): ChannelTypeDef {
+  return CHANNEL_TYPE_DEFS.find((t) => t.value === type) ?? CHANNEL_TYPE_DEFS[0];
+}
 
 function typeLabel(type: string): string {
-  return CHANNEL_TYPES.find((t) => t.value === type)?.label ?? type;
+  return CHANNEL_TYPE_DEFS.find((t) => t.value === type)?.label ?? type;
+}
+
+/** 按类型生成表单初始 config（编辑时优先回填已有值） */
+function initialConfig(type: string, existing?: Record<string, unknown>): Record<string, string> {
+  const cfg: Record<string, string> = {};
+  for (const f of typeDefOf(type).fields) {
+    const prev = existing?.[f.key];
+    cfg[f.key] = prev != null && String(prev) !== '' ? String(prev) : (f.defaultValue ?? '');
+  }
+  return cfg;
 }
 
 export default function NotificationChannelsScreen() {
@@ -49,14 +147,19 @@ export default function NotificationChannelsScreen() {
   const [channels, setChannels] = useState<NotificationChannel[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [addVisible, setAddVisible] = useState(false);
-  const [newName, setNewName] = useState('');
-  const [newType, setNewType] = useState<string>(CHANNEL_TYPES[0].value);
-  const [newWebhookUrl, setNewWebhookUrl] = useState('');
-  const [newToken, setNewToken] = useState('');
-  const [creating, setCreating] = useState(false);
+  const [testingId, setTestingId] = useState<number | null>(null);
 
-  const fieldHints = TYPE_FIELD_HINTS[newType] ?? DEFAULT_FIELD_HINTS;
+  // 新建/编辑共用表单
+  const [formVisible, setFormVisible] = useState(false);
+  const [editing, setEditing] = useState<NotificationChannel | null>(null);
+  const [formName, setFormName] = useState('');
+  const [formType, setFormType] = useState<string>(CHANNEL_TYPE_DEFS[0].value);
+  const [formConfig, setFormConfig] = useState<Record<string, string>>(
+    () => initialConfig(CHANNEL_TYPE_DEFS[0].value),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const activeDef = typeDefOf(formType);
 
   const loadChannels = useCallback(async () => {
     try {
@@ -69,6 +172,53 @@ export default function NotificationChannelsScreen() {
 
   useEffect(() => { loadChannels(); }, [loadChannels]);
 
+  function openCreate() {
+    setEditing(null);
+    setFormName('');
+    setFormType(CHANNEL_TYPE_DEFS[0].value);
+    setFormConfig(initialConfig(CHANNEL_TYPE_DEFS[0].value));
+    setFormVisible(true);
+  }
+
+  function openEdit(item: NotificationChannel) {
+    setEditing(item);
+    setFormName(item.name);
+    setFormType(item.type);
+    setFormConfig(initialConfig(item.type, item.config));
+    setFormVisible(true);
+  }
+
+  function switchType(next: string) {
+    setFormType(next);
+    setFormConfig(initialConfig(next));
+  }
+
+  async function handleSave() {
+    const name = formName.trim();
+    if (!name) { Alert.alert('提示', '请输入渠道名称'); return; }
+    const config: Record<string, unknown> = {};
+    for (const f of activeDef.fields) {
+      const raw = (formConfig[f.key] ?? '').trim();
+      if (!raw) {
+        if (!f.optional) { Alert.alert('提示', `请填写「${f.label}」`); return; }
+        continue;
+      }
+      config[f.key] = f.numeric ? Number(raw) || 0 : raw;
+    }
+    setSaving(true);
+    try {
+      if (editing) {
+        await updateNotificationChannel(editing.id, { name, type: formType, config });
+      } else {
+        await createNotificationChannel(name, formType, config);
+      }
+      setFormVisible(false);
+      setEditing(null);
+      await loadChannels();
+    } catch (e) { Alert.alert('保存失败', (e as Error).message); }
+    finally { setSaving(false); }
+  }
+
   async function handleToggle(item: NotificationChannel) {
     const next = !item.enabled;
     setChannels((prev) => prev.map((ch) => (ch.id === item.id ? { ...ch, enabled: next } : ch)));
@@ -79,45 +229,24 @@ export default function NotificationChannelsScreen() {
     }
   }
 
-  function handleLongPress(item: NotificationChannel) {
-    Alert.alert(item.name || '通知渠道', `类型: ${typeLabel(item.type)}`, [
-      { text: '发送测试', onPress: () => handleTest(item) },
-      { text: '删除', style: 'destructive', onPress: () => handleDelete(item) },
-      { text: '取消', style: 'cancel' },
-    ]);
-  }
-
   async function handleTest(item: NotificationChannel) {
+    setTestingId(item.id);
     try {
       const res = await testNotificationChannel(item.id);
       if (res.success) Alert.alert('测试成功', res.message || '测试消息已发送');
       else Alert.alert('测试失败', res.message || '请检查渠道配置');
     } catch (e) { Alert.alert('测试失败', (e as Error).message); }
+    finally { setTestingId(null); }
   }
 
   function handleDelete(item: NotificationChannel) {
-    Alert.alert('确认删除', `删除通知渠道"${item.name}"？`, [
-      { text: '取消' },
+    Alert.alert('确认删除', `删除通知渠道「${item.name}」？此操作不可恢复。`, [
+      { text: '取消', style: 'cancel' },
       { text: '删除', style: 'destructive', onPress: async () => {
         try { await deleteNotificationChannel(item.id); await loadChannels(); }
         catch (e) { Alert.alert('删除失败', (e as Error).message); }
       } },
     ]);
-  }
-
-  async function handleCreate() {
-    if (!newName.trim()) { Alert.alert('提示', '请输入渠道名称'); return; }
-    setCreating(true);
-    try {
-      const config: Record<string, unknown> = {};
-      if (newWebhookUrl.trim()) config.webhook_url = newWebhookUrl.trim();
-      if (newToken.trim()) config.token = newToken.trim();
-      await createNotificationChannel(newName.trim(), newType, config);
-      setNewName(''); setNewWebhookUrl(''); setNewToken(''); setNewType(CHANNEL_TYPES[0].value);
-      setAddVisible(false);
-      await loadChannels();
-    } catch (e) { Alert.alert('创建失败', (e as Error).message); }
-    finally { setCreating(false); }
   }
 
   if (loading) {
@@ -128,9 +257,9 @@ export default function NotificationChannelsScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
       <View style={styles.header}>
         <View style={styles.headerTitle}>
-          <Text style={[styles.hint, { color: c.textMuted }]}>长按渠道可测试或删除</Text>
+          <Text style={[styles.hint, { color: c.textMuted }]}>长按渠道可删除，编辑可修改配置</Text>
         </View>
-        <Pressable onPress={() => setAddVisible(true)} style={[styles.addBtn, { backgroundColor: c.primary }]} hitSlop={8}>
+        <Pressable onPress={openCreate} style={[styles.addBtn, { backgroundColor: c.primary }]} hitSlop={8}>
           <Plus size={20} color="#FFF" />
         </Pressable>
       </View>
@@ -139,7 +268,7 @@ export default function NotificationChannelsScreen() {
         data={channels} keyExtractor={(item) => String(item.id)}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={loadChannels} />}
         renderItem={({ item }) => (
-          <Pressable onLongPress={() => handleLongPress(item)} delayLongPress={400}>
+          <Pressable onLongPress={() => handleDelete(item)} delayLongPress={400}>
             <Card style={styles.card}>
               <View style={styles.cardRow}>
                 <View style={styles.cardContent}>
@@ -149,11 +278,24 @@ export default function NotificationChannelsScreen() {
                     </View>
                     <Text style={[styles.name, { color: c.text }]} numberOfLines={1}>{item.name}</Text>
                   </View>
+                  <Text style={[styles.configSummary, { color: c.textMuted }]} numberOfLines={1}>
+                    {summarizeConfig(item)}
+                  </Text>
                 </View>
                 <Switch
                   value={item.enabled}
                   onValueChange={() => handleToggle(item)}
                   trackColor={{ false: c.border, true: c.primary }}
+                />
+              </View>
+              <View style={styles.cardActions}>
+                <Button label="编辑" variant="secondary" onPress={() => openEdit(item)} style={styles.actionBtn} />
+                <Button
+                  label="测试连接"
+                  variant="ghost"
+                  onPress={() => handleTest(item)}
+                  loading={testingId === item.id}
+                  style={styles.actionBtn}
                 />
               </View>
             </Card>
@@ -165,43 +307,73 @@ export default function NotificationChannelsScreen() {
             title="暂无通知渠道"
             message="添加渠道后即可接收监控提醒"
             actionLabel="添加渠道"
-            onAction={() => setAddVisible(true)}
+            onAction={openCreate}
           />
         }
         contentContainerStyle={styles.list}
       />
 
-      <Modal visible={addVisible} transparent animationType="slide" onRequestClose={() => setAddVisible(false)}>
-        <Pressable style={styles.sheetOverlay} onPress={() => setAddVisible(false)}>
-          <Pressable style={[styles.sheet, { backgroundColor: c.surface }]} onPress={() => {}}>
-            <View style={[styles.sheetHandle, { backgroundColor: c.border }]} />
-            <Text style={[styles.sheetTitle, { color: c.text }]}>新建通知渠道</Text>
-            <Text style={[styles.label, { color: c.textSecondary }]}>名称</Text>
-            <Input value={newName} onChangeText={setNewName} placeholder="渠道名称" style={styles.input} />
-            <Text style={[styles.label, { color: c.textSecondary, marginTop: spacing.sm }]}>类型</Text>
-            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.typeSelector} contentContainerStyle={styles.typeSelectorContent}>
-              {CHANNEL_TYPES.map((t) => (
-                <Pressable key={t.value} onPress={() => setNewType(t.value)}
-                  style={[styles.typeOption, { backgroundColor: newType === t.value ? c.primary : c.background, borderColor: newType === t.value ? c.primary : c.border }]}>
-                  <Text style={[styles.typeOptionText, { color: newType === t.value ? '#FFF' : c.text }]}>{t.label}</Text>
-                </Pressable>
-              ))}
-            </ScrollView>
-            <Text style={[styles.label, { color: c.textSecondary, marginTop: spacing.sm }]}>{fieldHints.urlLabel}</Text>
-            <Text style={[styles.hint, { color: c.textMuted }]}>{fieldHints.urlHint}</Text>
-            <Input value={newWebhookUrl} onChangeText={setNewWebhookUrl} placeholder={fieldHints.urlPlaceholder} autoCapitalize="none" style={styles.input} />
-            <Text style={[styles.label, { color: c.textSecondary, marginTop: spacing.sm }]}>Token</Text>
-            <Text style={[styles.hint, { color: c.textMuted }]}>{fieldHints.tokenHint}</Text>
-            <Input value={newToken} onChangeText={setNewToken} placeholder="Token / 密钥" autoCapitalize="none" style={styles.input} />
-            <View style={styles.sheetActions}>
-              <Button label="取消" variant="secondary" onPress={() => setAddVisible(false)} style={styles.sheetBtn} />
-              <Button label="创建" onPress={handleCreate} loading={creating} style={styles.sheetBtn} />
+      <FormModal
+        visible={formVisible}
+        onClose={() => setFormVisible(false)}
+        title={editing ? '编辑通知渠道' : '新建通知渠道'}
+      >
+        <ScrollView nestedScrollEnabled style={styles.formScroll} contentContainerStyle={styles.formContent}>
+          <Text style={[styles.label, { color: c.textSecondary }]}>名称</Text>
+          <Input value={formName} onChangeText={setFormName} placeholder="渠道名称，如：钉钉群提醒" style={styles.input} />
+
+          <Text style={[styles.label, { color: c.textSecondary, marginTop: spacing.md }]}>类型</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.typeSelector} contentContainerStyle={styles.typeSelectorContent}>
+            {CHANNEL_TYPE_DEFS.map((t) => (
+              <Pressable key={t.value} onPress={() => switchType(t.value)}
+                style={[styles.typeOption, { backgroundColor: formType === t.value ? c.primary : c.background, borderColor: formType === t.value ? c.primary : c.border }]}>
+                <Text style={[styles.typeOptionText, { color: formType === t.value ? '#FFF' : c.text }]}>{t.label}</Text>
+              </Pressable>
+            ))}
+          </ScrollView>
+
+          {activeDef.fields.map((f) => (
+            <View key={f.key}>
+              <Text style={[styles.label, { color: c.textSecondary, marginTop: spacing.sm }]}>
+                {f.label}
+                {f.optional ? '（可选）' : ''}
+              </Text>
+              {f.hint ? <Text style={[styles.hint, { color: c.textMuted }]}>{f.hint}</Text> : null}
+              <Input
+                value={formConfig[f.key] ?? ''}
+                onChangeText={(v) => setFormConfig((prev) => ({ ...prev, [f.key]: v }))}
+                placeholder={f.placeholder ?? f.label}
+                autoCapitalize="none"
+                keyboardType={f.numeric ? 'number-pad' : 'default'}
+                secureTextEntry={f.secure}
+                style={styles.input}
+              />
             </View>
-          </Pressable>
-        </Pressable>
-      </Modal>
+          ))}
+        </ScrollView>
+
+        <View style={styles.sheetActions}>
+          <Button label="取消" variant="secondary" onPress={() => setFormVisible(false)} style={styles.sheetBtn} />
+          <Button label={editing ? '保存' : '创建'} onPress={handleSave} loading={saving} style={styles.sheetBtn} />
+        </View>
+      </FormModal>
     </SafeAreaView>
   );
+}
+
+/** 卡片上的一行配置摘要，避免敏感字段直接暴露 */
+function summarizeConfig(item: NotificationChannel): string {
+  const def = typeDefOf(item.type);
+  const parts: string[] = [];
+  for (const f of def.fields) {
+    const v = item.config?.[f.key];
+    if (v == null || String(v) === '') continue;
+    const text = String(v);
+    if (f.secure) parts.push(`${f.label}: ••••`);
+    else if (text.length > 24) parts.push(`${f.label}: ${text.slice(0, 24)}…`);
+    else parts.push(`${f.label}: ${text}`);
+  }
+  return parts.join('　') || '未配置';
 }
 
 const styles = StyleSheet.create({
@@ -210,26 +382,25 @@ const styles = StyleSheet.create({
   headerTitle: { flex: 1, marginRight: spacing.md, gap: 2 },
   hint: { ...typography.small },
   addBtn: { width: 32, height: 32, borderRadius: radius.full, alignItems: 'center', justifyContent: 'center' },
-  list: { padding: spacing.lg, paddingTop: 0, gap: spacing.md },
-  card: { gap: spacing.xs },
+  list: { padding: spacing.lg, paddingTop: 0, gap: spacing.md, paddingBottom: 80 },
+  card: { gap: spacing.sm },
   cardRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
   cardContent: { flex: 1, marginRight: spacing.md, gap: spacing.xs },
   typeRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   typeBadge: { paddingHorizontal: spacing.sm, paddingVertical: 2, borderRadius: 4 },
   typeText: { color: '#FFF', fontSize: 11, fontWeight: '600' },
-  name: { ...typography.body, flex: 1 },
-  empty: { alignItems: 'center', paddingVertical: 28 },
-  emptyText: { ...typography.body },
-  sheetOverlay: { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' },
-  sheet: { borderTopLeftRadius: radius.xl, borderTopRightRadius: radius.xl, padding: spacing.lg, gap: spacing.xs },
-  sheetHandle: { width: 36, height: 4, borderRadius: 2, alignSelf: 'center', marginBottom: spacing.sm },
-  sheetTitle: { ...typography.heading, textAlign: 'center', marginBottom: spacing.sm },
+  name: { ...typography.body, flex: 1, fontWeight: '600' },
+  configSummary: { ...typography.small },
+  cardActions: { flexDirection: 'row', gap: spacing.sm },
+  actionBtn: { flex: 1, minHeight: 38 },
+  formScroll: { flexGrow: 0 },
+  formContent: { gap: spacing.xs, paddingBottom: spacing.sm },
   label: { ...typography.caption },
   typeSelector: { flexGrow: 0 },
   typeSelectorContent: { gap: spacing.sm, paddingVertical: spacing.xs },
   typeOption: { paddingHorizontal: spacing.md, paddingVertical: spacing.sm, borderRadius: radius.sm, borderWidth: 1 },
   typeOptionText: { ...typography.caption },
   input: { marginTop: spacing.xs },
-  sheetActions: { flexDirection: 'row', gap: spacing.sm, marginTop: spacing.md },
+  sheetActions: { flexDirection: 'row', gap: spacing.sm, marginTop: spacing.sm },
   sheetBtn: { flex: 1 },
 });

--- a/xianyu-mobile/app/(tabs)/mine/personal.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/personal.tsx
@@ -14,8 +14,9 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useColorScheme } from 'react-native';
 import { useRouter } from 'expo-router';
+import * as Clipboard from 'expo-clipboard';
 import { Card, Button, Input, Loading, FormModal, Badge } from '@/components/ui';
-import { colors, spacing, typography, radius } from '@/lib/theme';
+import { colors, spacing, typography, radius, type ThemeColors } from '@/lib/theme';
 import { useAuthStore } from '@/stores/auth';
 import {
   changePassword,
@@ -31,8 +32,15 @@ import {
   type SettlementRecord,
 } from '@/api/wrappers/settings';
 import {
+  getDockCode,
+  resetDockCode,
+  getSecretKey,
+  resetSecretKey,
+} from '@/api/wrappers/users-self';
+import {
   User,
   KeyRound,
+  ShieldCheck,
   Wallet,
   Eye,
   EyeOff,
@@ -86,6 +94,12 @@ function isExpired(value?: string | null): boolean {
   return Number.isFinite(t) && t < Date.now();
 }
 
+/** 凭证打码显示：保留首尾各2位，中间以 **** 代替 */
+function maskCredential(value: string): string {
+  if (value.length <= 6) return '****';
+  return `${value.slice(0, 2)}****${value.slice(-2)}`;
+}
+
 /** 结算记录状态 -> 徽章文案 + 配色 */
 function settlementStatusMeta(
   status: SettlementRecord['status'],
@@ -109,6 +123,86 @@ function paymentTypeLabel(rec: SettlementRecord): string {
   if (rec.payment_type === 'wechat') return '微信';
   if (rec.payment_type === 'alipay') return '支付宝';
   return rec.alipay_id ? '支付宝' : '-';
+}
+
+/** 凭证行：打码/明文展示 + 查看/复制/重置操作 */
+function CredentialRow({
+  label,
+  value,
+  visible,
+  loading,
+  onToggleVisible,
+  onCopy,
+  onReset,
+  c,
+}: {
+  label: string;
+  value: string | null;
+  visible: boolean;
+  loading: boolean;
+  onToggleVisible: () => void;
+  onCopy: () => void;
+  onReset: () => void;
+  c: ThemeColors;
+}) {
+  return (
+    <View style={styles.credRow}>
+      <View style={styles.credInfo}>
+        <Text style={[styles.credLabel, { color: c.text }]}>{label}</Text>
+        <Text
+          style={[styles.credValue, { color: c.textMuted }]}
+          numberOfLines={1}
+          selectable={visible && value != null}
+        >
+          {value == null
+            ? loading
+              ? '加载中...'
+              : '—'
+            : visible
+              ? value
+              : maskCredential(value)}
+        </Text>
+      </View>
+      <View style={styles.credActions}>
+        <Pressable
+          onPress={onToggleVisible}
+          hitSlop={6}
+          style={styles.credIconBtn}
+          disabled={value == null}
+        >
+          {visible ? (
+            <EyeOff size={16} stroke={c.textSecondary} />
+          ) : (
+            <Eye size={16} stroke={c.textSecondary} />
+          )}
+        </Pressable>
+        <Pressable
+          onPress={onCopy}
+          disabled={value == null}
+          style={[
+            styles.credBtn,
+            { borderColor: c.border },
+            value == null && { opacity: 0.4 },
+          ]}
+        >
+          <Text style={[styles.credBtnText, { color: c.textSecondary }]}>
+            复制
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={onReset}
+          disabled={value == null}
+          style={[
+            styles.credBtn,
+            { borderColor: c.error },
+            value == null && { opacity: 0.4 },
+          ]}
+        >
+          <Text style={[styles.credBtnText, { color: c.error }]}>重置</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
 }
 
 export default function PersonalSettingsScreen() {
@@ -163,6 +257,86 @@ export default function PersonalSettingsScreen() {
   const [settlementPageSize] = useState(20);
   const [settlementTotal, setSettlementTotal] = useState(0);
   const [settlementTotalPages, setSettlementTotalPages] = useState(0);
+
+  // 我的凭证：对接码 / 分销 API 秘钥（默认打码，点眼睛查看明文）
+  const [dockCode, setDockCode] = useState<string | null>(null);
+  const [dockVisible, setDockVisible] = useState(false);
+  const [secretKey, setSecretKey] = useState<string | null>(null);
+  const [secretVisible, setSecretVisible] = useState(false);
+  const [credLoading, setCredLoading] = useState(false);
+
+  const loadCredentials = useCallback(async () => {
+    setCredLoading(true);
+    try {
+      const [dock, key] = await Promise.all([getDockCode(), getSecretKey()]);
+      setDockCode(dock);
+      setSecretKey(key);
+    } catch (e) {
+      // 凭证加载失败不阻断页面，卡片内显示占位
+      setDockCode(null);
+      setSecretKey(null);
+      console.warn('加载凭证失败', e);
+    } finally {
+      setCredLoading(false);
+    }
+  }, []);
+
+  // ---- 凭证：复制 / 重置 ----
+  async function copyCredential(kind: 'dock' | 'secret') {
+    const value = kind === 'dock' ? dockCode : secretKey;
+    if (!value) {
+      Alert.alert('提示', '凭证尚未加载，请先刷新');
+      return;
+    }
+    try {
+      await Clipboard.setStringAsync(value);
+      Alert.alert('已复制', kind === 'dock' ? '对接码已复制到剪贴板' : 'API秘钥已复制到剪贴板');
+    } catch (e) {
+      Alert.alert('复制失败', (e as Error).message);
+    }
+  }
+
+  function confirmResetCredential(kind: 'dock' | 'secret') {
+    Alert.alert(
+      kind === 'dock' ? '重置对接码' : '重置API秘钥',
+      kind === 'dock'
+        ? '重置后旧对接码立即失效，所有已绑定的分销商与对接记录将被清除。确定重置吗？'
+        : '重置后旧API秘钥立即失效，使用旧秘钥的对接将无法继续。确定重置吗？',
+      [
+        { text: '取消', style: 'cancel' },
+        { text: '重置', style: 'destructive', onPress: () => doResetCredential(kind) },
+      ],
+      { cancelable: true },
+    );
+  }
+
+  async function doResetCredential(kind: 'dock' | 'secret') {
+    try {
+      if (kind === 'dock') {
+        const r = await resetDockCode();
+        if (!r.success) {
+          Alert.alert('重置失败', r.message ?? '请稍后重试');
+          return;
+        }
+        const code = await getDockCode();
+        setDockCode(code);
+        setDockVisible(true);
+        Alert.alert('成功', r.message ?? '对接码已重置，请及时通知分销商更新');
+      } else {
+        const r = await resetSecretKey();
+        if (!r.success) {
+          Alert.alert('重置失败', r.message ?? '请稍后重试');
+          return;
+        }
+        const key = r.secret_key ?? (await getSecretKey());
+        setSecretKey(key);
+        setSecretVisible(true);
+        Alert.alert('成功', r.message ?? 'API秘钥已重置，请及时更新对接配置');
+      }
+    } catch (e) {
+      Alert.alert('重置失败', (e as Error).message);
+    }
+  }
 
   const loadFlows = useCallback(async () => {
     setFlowsLoading(true);
@@ -236,7 +410,8 @@ export default function PersonalSettingsScreen() {
     loadFlows();
     loadProfile();
     loadRenewPrice();
-  }, [loadFlows, loadProfile, loadRenewPrice]);
+    loadCredentials();
+  }, [loadFlows, loadProfile, loadRenewPrice, loadCredentials]);
 
   // ---- 修改密码 ----
   async function handleChangePassword() {
@@ -484,6 +659,56 @@ export default function PersonalSettingsScreen() {
               账户已到期，请尽快续期以恢复服务。
             </Text>
           )}
+        </Card>
+
+        {/* 我的凭证 */}
+        <Card style={styles.section}>
+          <View style={styles.sectionTitleRow}>
+            <ShieldCheck size={16} stroke={c.textSecondary} />
+            <Text style={[styles.sectionTitle, { color: c.textSecondary }]}>
+              我的凭证
+            </Text>
+            <Pressable
+              onPress={loadCredentials}
+              hitSlop={8}
+              disabled={credLoading}
+              style={styles.refreshBtn}
+            >
+              {credLoading ? (
+                <ActivityIndicator size="small" color={c.primary} />
+              ) : (
+                <RefreshCw size={16} stroke={c.textSecondary} />
+              )}
+            </Pressable>
+          </View>
+
+          <CredentialRow
+            label="对接码"
+            value={dockCode}
+            visible={dockVisible}
+            loading={credLoading}
+            onToggleVisible={() => setDockVisible((v) => !v)}
+            onCopy={() => copyCredential('dock')}
+            onReset={() => confirmResetCredential('dock')}
+            c={c}
+          />
+          <Text style={[styles.credHint, { color: c.textMuted }]}>
+            用于分销商绑定，重置后旧码失效且清除全部绑定记录
+          </Text>
+
+          <CredentialRow
+            label="API秘钥"
+            value={secretKey}
+            visible={secretVisible}
+            loading={credLoading}
+            onToggleVisible={() => setSecretVisible((v) => !v)}
+            onCopy={() => copyCredential('secret')}
+            onReset={() => confirmResetCredential('secret')}
+            c={c}
+          />
+          <Text style={[styles.credHint, { color: c.textMuted }]}>
+            用于分销对接鉴权，重置后旧秘钥立即失效
+          </Text>
         </Card>
 
         {/* 余额管理 */}
@@ -1134,6 +1359,27 @@ const styles = StyleSheet.create({
   // 4 个按钮按 2×2 排列，避免在窄屏挤一行
   balanceActions: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
   balanceBtn: { flexGrow: 1, flexBasis: '47%' },
+  // 我的凭证
+  credRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    paddingTop: spacing.xs,
+  },
+  credInfo: { flex: 1, flexShrink: 1, gap: 2 },
+  credLabel: { ...typography.body, fontWeight: '600' },
+  credValue: { ...typography.small },
+  credActions: { flexDirection: 'row', alignItems: 'center', gap: spacing.xs },
+  credIconBtn: { padding: spacing.xs },
+  credBtn: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: radius.sm,
+    borderWidth: 1,
+  },
+  credBtnText: { ...typography.small, fontWeight: '600' },
+  credHint: { ...typography.small, marginTop: 2 },
   fieldGroup: { gap: spacing.xs },
   fieldLabel: { ...typography.caption },
   showPwdRow: {

--- a/xianyu-mobile/app/(tabs)/mine/popup-announcements.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/popup-announcements.tsx
@@ -1,0 +1,319 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Pressable,
+  Alert,
+  RefreshControl,
+  Switch,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useColorScheme } from 'react-native';
+import { Image } from 'lucide-react-native';
+import { Card, Button, Input, Loading, EmptyState, FormModal } from '@/components/ui';
+import { colors, spacing, typography, radius } from '@/lib/theme';
+import { useAuthStore } from '@/stores/auth';
+import {
+  getPopupAnnouncements,
+  createPopupAnnouncement,
+  updatePopupAnnouncement,
+  togglePopupAnnouncement,
+  deletePopupAnnouncement,
+  type PopupAnnouncement,
+} from '@/api/wrappers/popup-announcements';
+
+/** 将 ISO/字符串时间格式化为简洁的可读形式，失败则原样返回 */
+function formatTime(raw?: string): string {
+  if (!raw) return '';
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export default function PopupAnnouncementsScreen() {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+  const isAdmin = useAuthStore((s) => s.user?.is_admin ?? false);
+
+  const [items, setItems] = useState<PopupAnnouncement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [togglingId, setTogglingId] = useState<number | null>(null);
+
+  // 新增/编辑 Modal 共用
+  const [modalVisible, setModalVisible] = useState(false);
+  const [editing, setEditing] = useState<PopupAnnouncement | null>(null);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [link, setLink] = useState('');
+  const [enabled, setEnabled] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const list = await getPopupAnnouncements();
+      setItems(list);
+    } catch (e) {
+      Alert.alert('加载失败', (e as Error).message);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function openCreate() {
+    setEditing(null);
+    setTitle('');
+    setContent('');
+    setLink('');
+    setEnabled(true);
+    setModalVisible(true);
+  }
+
+  function openEdit(item: PopupAnnouncement) {
+    setEditing(item);
+    setTitle(item.title);
+    setContent(item.content);
+    setLink(item.link ?? '');
+    setEnabled(item.is_enabled);
+    setModalVisible(true);
+  }
+
+  async function handleSave() {
+    const t = title.trim();
+    const ct = content.trim();
+    if (!t) { Alert.alert('提示', '请输入公告标题'); return; }
+    if (!ct) { Alert.alert('提示', '请输入公告内容'); return; }
+    setSaving(true);
+    try {
+      const payload = { title: t, content: ct, link: link.trim(), is_enabled: enabled };
+      if (editing) await updatePopupAnnouncement(editing.id, payload);
+      else await createPopupAnnouncement(payload);
+      setModalVisible(false);
+      setEditing(null);
+      await load();
+    } catch (e) {
+      Alert.alert('保存失败', (e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleToggle(item: PopupAnnouncement) {
+    setTogglingId(item.id);
+    try {
+      const next = await togglePopupAnnouncement(item.id);
+      setItems((prev) => prev.map((a) => (a.id === item.id ? { ...a, is_enabled: next } : a)));
+    } catch (e) {
+      Alert.alert('操作失败', (e as Error).message);
+    } finally {
+      setTogglingId(null);
+    }
+  }
+
+  function handleDelete(item: PopupAnnouncement) {
+    Alert.alert('确认删除', `删除弹窗公告「${item.title}」？此操作不可恢复。`, [
+      { text: '取消', style: 'cancel' },
+      {
+        text: '删除',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await deletePopupAnnouncement(item.id);
+            setItems((prev) => prev.filter((a) => a.id !== item.id));
+          } catch (e) {
+            Alert.alert('删除失败', (e as Error).message);
+          }
+        },
+      },
+    ]);
+  }
+
+  if (loading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
+        <Loading label="加载弹窗公告..." />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
+      <View style={styles.header}>
+        <Text style={[styles.headerHint, { color: c.textMuted }]}>启用中的公告会在用户登录后弹窗展示</Text>
+        {isAdmin && <Button label="发布公告" onPress={openCreate} variant="secondary" style={styles.createBtn} />}
+      </View>
+
+      <FlatList
+        data={items}
+        keyExtractor={(item) => String(item.id)}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={load} />}
+        renderItem={({ item }) => (
+          <Pressable onLongPress={() => handleDelete(item)} delayLongPress={400}>
+            <Card style={[styles.card, { borderColor: c.border }]}>
+              <View style={styles.cardTop}>
+                <View style={styles.cardTexts}>
+                  <View style={styles.titleRow}>
+                    <Text style={[styles.cardTitle, { color: c.text }]} numberOfLines={1}>{item.title}</Text>
+                    {item.source === 'remote' && (
+                      <View style={[styles.sourceBadge, { backgroundColor: c.surfaceAlt }]}>
+                        <Text style={[styles.sourceText, { color: c.textMuted }]}>远程</Text>
+                      </View>
+                    )}
+                  </View>
+                  <Text style={[styles.cardContent, { color: c.textSecondary }]} numberOfLines={3}>
+                    {item.content || '(无内容)'}
+                  </Text>
+                  {item.link ? (
+                    <Text style={[styles.cardLink, { color: c.primary }]} numberOfLines={1}>{item.link}</Text>
+                  ) : null}
+                </View>
+                {isAdmin && item.source !== 'remote' && (
+                  <Switch
+                    value={item.is_enabled}
+                    onValueChange={() => handleToggle(item)}
+                    disabled={togglingId === item.id}
+                    trackColor={{ false: c.border, true: c.primary }}
+                  />
+                )}
+              </View>
+              <View style={styles.cardFooter}>
+                <Text style={[styles.time, { color: c.textMuted }]}>
+                  {item.is_enabled ? '启用中 · ' : '已停用 · '}{formatTime(item.created_at)}
+                </Text>
+                {isAdmin && item.source !== 'remote' && (
+                  <View style={styles.cardActions}>
+                    <Button label="编辑" variant="secondary" onPress={() => openEdit(item)} style={styles.btn} />
+                    <Button label="删除" variant="danger" onPress={() => handleDelete(item)} style={styles.btn} />
+                  </View>
+                )}
+              </View>
+            </Card>
+          </Pressable>
+        )}
+        ListEmptyComponent={
+          <EmptyState
+            icon={Image}
+            title="暂无弹窗公告"
+            message="发布的弹窗公告将在用户登录后展示"
+            actionLabel={isAdmin ? '发布公告' : undefined}
+            onAction={openCreate}
+          />
+        }
+        contentContainerStyle={styles.list}
+      />
+
+      {/* 新增/编辑 Modal */}
+      <FormModal
+        visible={modalVisible}
+        onClose={() => setModalVisible(false)}
+        title={editing ? '编辑弹窗公告' : '发布弹窗公告'}
+      >
+        <View style={styles.fieldGroup}>
+          <Text style={[styles.label, { color: c.textSecondary }]}>标题</Text>
+          <Input
+            value={title}
+            onChangeText={setTitle}
+            placeholder="请输入公告标题"
+            maxLength={100}
+          />
+        </View>
+        <View style={styles.fieldGroup}>
+          <Text style={[styles.label, { color: c.textSecondary }]}>内容</Text>
+          <Input
+            value={content}
+            onChangeText={setContent}
+            placeholder="请输入公告内容"
+            multiline
+            style={styles.contentInput}
+          />
+        </View>
+        <View style={styles.fieldGroup}>
+          <Text style={[styles.label, { color: c.textSecondary }]}>跳转链接（可选）</Text>
+          <Input
+            value={link}
+            onChangeText={setLink}
+            placeholder="https://..."
+            autoCapitalize="none"
+          />
+        </View>
+        <View style={[styles.switchRow, { borderColor: c.borderLight }]}>
+          <View style={styles.switchTexts}>
+            <Text style={[styles.label, { color: c.text }]}>启用</Text>
+            <Text style={[styles.hint, { color: c.textMuted }]}>停用后不再向用户弹窗展示</Text>
+          </View>
+          <Switch value={enabled} onValueChange={setEnabled} trackColor={{ false: c.border, true: c.primary }} />
+        </View>
+        <View style={styles.modalActions}>
+          <Button label="取消" variant="ghost" onPress={() => setModalVisible(false)} style={styles.modalBtn} />
+          <Button
+            label={editing ? '保存' : '发布'}
+            onPress={handleSave}
+            loading={saving}
+            disabled={saving}
+            style={styles.modalBtn}
+          />
+        </View>
+      </FormModal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    gap: spacing.md,
+  },
+  headerHint: { ...typography.small, flex: 1 },
+  createBtn: { minHeight: 40 },
+  list: { padding: spacing.lg, gap: spacing.md, paddingBottom: 80 },
+  card: { gap: spacing.sm, borderWidth: 1 },
+  cardTop: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' },
+  cardTexts: { flex: 1, marginRight: spacing.md, gap: spacing.xs },
+  titleRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  cardTitle: { ...typography.heading, flexShrink: 1 },
+  sourceBadge: { paddingHorizontal: spacing.sm, paddingVertical: 2, borderRadius: 4 },
+  sourceText: { ...typography.small, fontWeight: '600' },
+  cardContent: { ...typography.body, lineHeight: 22 },
+  cardLink: { ...typography.small },
+  cardFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: spacing.xs,
+  },
+  time: { ...typography.small, flex: 1 },
+  cardActions: { flexDirection: 'row', gap: spacing.xs },
+  btn: { minHeight: 36 },
+  // 表单弹层
+  fieldGroup: { gap: spacing.xs },
+  label: { ...typography.caption },
+  contentInput: { minHeight: 100, textAlignVertical: 'top' },
+  switchRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+  },
+  switchTexts: { flex: 1, marginRight: spacing.md, gap: 2 },
+  hint: { ...typography.small },
+  modalActions: { flexDirection: 'row', gap: spacing.sm },
+  modalBtn: { flex: 1 },
+});

--- a/xianyu-mobile/app/(tabs)/mine/product-publish.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/product-publish.tsx
@@ -1,25 +1,806 @@
-import { useState, useCallback, useEffect } from 'react';
-import { View, Text, StyleSheet, FlatList, RefreshControl, Alert } from 'react-native';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  FlatList,
+  Pressable,
+  Alert,
+  Modal,
+  KeyboardAvoidingView,
+  Platform,
+  Image,
+  RefreshControl,
+  ActivityIndicator,
+  useColorScheme,
+  type TextStyle,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useColorScheme } from 'react-native';
-import { Card, Loading } from '@/components/ui';
+import * as ImagePicker from 'expo-image-picker';
+import { Card, Button, Input, Badge, EmptyState } from '@/components/ui';
+import { Package, Plus, X } from 'lucide-react-native';
 import { colors, spacing, typography, radius } from '@/lib/theme';
-import { getPersonalAddresses, type PersonalAddress } from '@/api/wrappers/distribution';
+import { getAccountOptions, type AccountOption } from '@/api/wrappers/accounts';
+import {
+  uploadProductImages,
+  publishSingle,
+  publishBatch,
+  getBatchStatus,
+  getPublishLogs,
+  listMaterials,
+  createMaterial,
+  deleteMaterial,
+  recommendCategory,
+  type ProductMaterial,
+  type PublishLogItem,
+  type BatchStatus,
+  type CategoryCandidate,
+} from '@/api/wrappers/product-publish';
+
+// ---------------------------------------------------------------------------
+// 常量
+// ---------------------------------------------------------------------------
+
+const MAX_IMAGES = 9;
+const POLL_INTERVAL_MS = 5000;
+
+const CONDITION_OPTIONS = ['全新', '几乎全新', '轻微使用', '明显使用', '需要维修'];
+
+const DELIVERY_OPTIONS: { value: 'express' | 'pickup'; label: string }[] = [
+  { value: 'express', label: '快递发货' },
+  { value: 'pickup', label: '当面交易' },
+];
+
+const SHIPPING_OPTIONS: { value: 'free' | 'distance' | 'fixed' | 'none'; label: string }[] = [
+  { value: 'free', label: '包邮' },
+  { value: 'distance', label: '按距离' },
+  { value: 'fixed', label: '固定运费' },
+  { value: 'none', label: '不包邮' },
+];
+
+const LOG_STATUS_FILTERS: { key: string; label: string }[] = [
+  { key: '', label: '全部' },
+  { key: 'success', label: '成功' },
+  { key: 'failed', label: '失败' },
+  { key: 'publishing', label: '发布中' },
+  { key: 'pending', label: '等待' },
+];
+
+/** 已选本地图（uri 供预览，path 是服务器路径供发布提交） */
+interface LocalImage {
+  uri: string;
+  path: string;
+}
+
+type TabKey = 'single' | 'batch' | 'logs';
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'single', label: '单品发布' },
+  { key: 'batch', label: '批量发布' },
+  { key: 'logs', label: '发布记录' },
+];
+
+function accountLabel(acc: AccountOption): string {
+  return acc.remark || acc.id;
+}
+
+// ---------------------------------------------------------------------------
+// 页面骨架：分段控件（单品发布 / 批量发布 / 发布记录）
+// ---------------------------------------------------------------------------
 
 export default function ProductPublishScreen() {
   const scheme = useColorScheme();
   const c = colors[scheme === 'dark' ? 'dark' : 'light'];
 
-  const [addresses, setAddresses] = useState<PersonalAddress[]>([]);
+  const [tab, setTab] = useState<TabKey>('single');
+  const [accounts, setAccounts] = useState<AccountOption[]>([]);
+
+  // 批量任务状态放在父级：轮询跨 Tab 持续进行，切到"发布记录"也不中断
+  const [activeBatch, setActiveBatch] = useState<{ batchId: string; total: number } | null>(null);
+  const [batchStatus, setBatchStatus] = useState<BatchStatus | null>(null);
+  const [pollError, setPollError] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const finishedAlertedRef = useRef(false);
+
+  const loadAccounts = useCallback(async () => {
+    try {
+      setAccounts(await getAccountOptions());
+    } catch {
+      // 账号加载失败不阻塞页面，表单提交时会提示选择账号
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAccounts();
+  }, [loadAccounts]);
+
+  const stopPolling = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const pollOnce = useCallback(
+    async (batchId: string) => {
+      try {
+        const st = await getBatchStatus(batchId);
+        setBatchStatus(st);
+        setPollError(null);
+        if (st.finished) {
+          stopPolling();
+          if (!finishedAlertedRef.current) {
+            finishedAlertedRef.current = true;
+            Alert.alert(
+              '批量发布完成',
+              `共 ${st.total} 件：成功 ${st.success} 件，失败 ${st.failed} 件`,
+            );
+          }
+        }
+      } catch (e) {
+        // 任务过期等业务失败：停止轮询并展示原因
+        stopPolling();
+        setPollError((e as Error).message || '查询批量进度失败');
+      }
+    },
+    [stopPolling],
+  );
+
+  // 5 秒轮询批量进度直到 finished
+  useEffect(() => {
+    if (!activeBatch) return;
+    finishedAlertedRef.current = false;
+    setPollError(null);
+    pollOnce(activeBatch.batchId);
+    timerRef.current = setInterval(() => pollOnce(activeBatch.batchId), POLL_INTERVAL_MS);
+    return stopPolling;
+  }, [activeBatch, pollOnce, stopPolling]);
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
+      {/* 分段控件 */}
+      <View style={[styles.tabs, { backgroundColor: c.surfaceAlt }]}>
+        {TABS.map((t) => {
+          const on = tab === t.key;
+          return (
+            <Pressable key={t.key} onPress={() => setTab(t.key)} style={[styles.tabItem, on && { backgroundColor: c.primary }]}>
+              <Text style={[styles.tabText, { color: on ? '#FFFFFF' : c.textSecondary }]}>{t.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {tab === 'single' && (
+        <SinglePublishTab
+          accounts={accounts}
+          onPublished={() => setTab('logs')}
+        />
+      )}
+      {tab === 'batch' && (
+        <BatchPublishTab
+          accounts={accounts}
+          activeBatch={activeBatch}
+          batchStatus={batchStatus}
+          pollError={pollError}
+          onStartBatch={(b) => setActiveBatch(b)}
+        />
+      )}
+      {tab === 'logs' && <PublishLogsTab />}
+    </SafeAreaView>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 通用小组件
+// ---------------------------------------------------------------------------
+
+function FieldLabel({ label, required }: { label: string; required?: boolean }) {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+  return (
+    <View style={styles.fieldLabel}>
+      <Text style={[styles.fieldLabelText, { color: c.textSecondary }]}>{label}</Text>
+      {required ? <Text style={styles.required}> *</Text> : null}
+    </View>
+  );
+}
+
+function FieldHint({ text }: { text: string }) {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+  return <Text style={[styles.fieldHint, { color: c.textMuted }]}>{text}</Text>;
+}
+
+/** 单选账号胶囊（对齐 items.tsx 的写法） */
+function AccountChips({
+  accounts,
+  selectedId,
+  onSelect,
+}: {
+  accounts: AccountOption[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+}) {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+  if (accounts.length === 0) {
+    return <FieldHint text="暂无闲鱼账号，请先在「账号管理」中添加账号" />;
+  }
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipRowScroll}>
+      {accounts.map((acc) => {
+        const selected = selectedId === acc.id;
+        return (
+          <Pressable
+            key={acc.id}
+            onPress={() => onSelect(acc.id)}
+            style={[
+              styles.chip,
+              {
+                borderColor: selected ? c.primary : c.border,
+                backgroundColor: selected ? c.primary : c.surface,
+              },
+            ]}
+          >
+            <Text style={[styles.chipText, { color: selected ? '#FFFFFF' : c.text }]} numberOfLines={1}>
+              {accountLabel(acc)}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+/** 图片九宫格：预览 + 删除 + 添加（选中即上传换服务器路径） */
+function ImageGrid({
+  images,
+  uploading,
+  onPick,
+  onRemove,
+}: {
+  images: LocalImage[];
+  uploading: boolean;
+  onPick: () => void;
+  onRemove: (index: number) => void;
+}) {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+  return (
+    <View style={styles.imageGrid}>
+      {images.map((img, index) => (
+        <View key={`${img.uri}-${index}`} style={styles.imageCell}>
+          <Image source={{ uri: img.uri }} style={styles.thumb} />
+          <Pressable
+            onPress={() => onRemove(index)}
+            style={[styles.imageDel, { backgroundColor: c.error }]}
+            hitSlop={8}
+          >
+            <X color="#FFFFFF" size={12} strokeWidth={3} />
+          </Pressable>
+          <View style={styles.imageIndex}>
+            <Text style={styles.imageIndexText}>{index + 1}</Text>
+          </View>
+        </View>
+      ))}
+      {images.length < MAX_IMAGES && (
+        <Pressable
+          onPress={onPick}
+          style={[styles.imageAdd, { borderColor: c.border }]}
+          disabled={uploading}
+        >
+          {uploading ? (
+            <ActivityIndicator size="small" color={c.primary} />
+          ) : (
+            <>
+              <Plus color={c.textMuted} size={22} />
+              <Text style={[styles.imageAddText, { color: c.textMuted }]}>添加图片</Text>
+            </>
+          )}
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+/** 选图并上传，返回 {uri, path} 列表（共享给单品表单与素材表单） */
+async function pickAndUploadImages(remaining: number): Promise<LocalImage[]> {
+  if (remaining <= 0) return [];
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images'],
+    allowsMultipleSelection: true,
+    selectionLimit: remaining,
+    quality: 0.8,
+  });
+  if (result.canceled || !result.assets || result.assets.length === 0) return [];
+  const picked = result.assets.slice(0, remaining);
+  const uploaded = await uploadProductImages(picked.map((a) => a.uri));
+  return picked
+    .map((a, i) => ({ uri: a.uri, path: uploaded.paths[i] }))
+    .filter((x) => Boolean(x.path));
+}
+
+// ---------------------------------------------------------------------------
+// Tab 1：单品发布（表单）
+// ---------------------------------------------------------------------------
+
+interface SingleFormState {
+  accountId: string;
+  title: string;
+  description: string;
+  price: string;
+  originalPrice: string;
+  stock: string;
+  quantity: string;
+  condition: string;
+  brand: string;
+  category: string;
+  deliveryMethod: 'express' | 'pickup';
+  shippingMethod: 'free' | 'distance' | 'fixed' | 'none';
+  postage: string;
+  address: string;
+  images: LocalImage[];
+}
+
+const EMPTY_SINGLE_FORM: SingleFormState = {
+  accountId: '',
+  title: '',
+  description: '',
+  price: '',
+  originalPrice: '',
+  stock: '',
+  quantity: '1',
+  condition: '全新',
+  brand: '',
+  category: '',
+  deliveryMethod: 'express',
+  shippingMethod: 'free',
+  postage: '',
+  address: '',
+  images: [],
+};
+
+function SinglePublishTab({
+  accounts,
+  onPublished,
+}: {
+  accounts: AccountOption[];
+  onPublished: () => void;
+}) {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+
+  const [form, setForm] = useState<SingleFormState>(EMPTY_SINGLE_FORM);
+  const [uploading, setUploading] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [recommending, setRecommending] = useState(false);
+  const [candidates, setCandidates] = useState<CategoryCandidate[]>([]);
+  // 类目推荐选中的候选（携带平台分类字段，发布时一并提交）
+  const [selectedCat, setSelectedCat] = useState<CategoryCandidate | null>(null);
+
+  const update = <K extends keyof SingleFormState>(field: K, value: SingleFormState[K]) =>
+    setForm((prev) => ({ ...prev, [field]: value }));
+
+  const handlePick = useCallback(async () => {
+    try {
+      setUploading(true);
+      const next = await pickAndUploadImages(MAX_IMAGES - form.images.length);
+      if (next.length > 0) {
+        setForm((prev) => ({ ...prev, images: [...prev.images, ...next] }));
+      }
+    } catch (e) {
+      Alert.alert('上传失败', (e as Error).message);
+    } finally {
+      setUploading(false);
+    }
+  }, [form.images.length]);
+
+  const handleRemoveImage = useCallback((index: number) => {
+    setForm((prev) => {
+      const next = [...prev.images];
+      next.splice(index, 1);
+      return { ...prev, images: next };
+    });
+  }, []);
+
+  const handleRecommend = useCallback(async () => {
+    if (!form.title.trim() && !form.description.trim()) {
+      Alert.alert('提示', '请先填写商品标题或商品描述');
+      return;
+    }
+    setRecommending(true);
+    try {
+      const res = await recommendCategory({
+        title: form.title.trim(),
+        description: form.description.trim(),
+        account_id: form.accountId || undefined,
+      });
+      if (res.candidates.length === 0) {
+        Alert.alert('提示', '未推荐到合适的类目，请手动填写分类');
+      }
+      setCandidates(res.candidates);
+    } catch (e) {
+      Alert.alert('类目推荐失败', (e as Error).message);
+    } finally {
+      setRecommending(false);
+    }
+  }, [form.title, form.description, form.accountId]);
+
+  const handleSelectCandidate = useCallback((cand: CategoryCandidate) => {
+    setSelectedCat(cand);
+    setForm((prev) => ({ ...prev, category: cand.cat_name || '' }));
+  }, []);
+
+  async function handlePublish() {
+    const err = validateSingleForm(form);
+    if (err) {
+      Alert.alert('提示', err);
+      return;
+    }
+    setPublishing(true);
+    try {
+      const body = buildSingleBody(form, selectedCat);
+      const res = await publishSingle(body);
+      const detail = res.item_id ? `商品ID：${res.item_id}` : res.item_url || '已提交闲鱼发布';
+      Alert.alert('发布成功', detail, [{ text: '查看记录', onPress: onPublished }]);
+      setForm({ ...EMPTY_SINGLE_FORM, accountId: form.accountId });
+      setCandidates([]);
+      setSelectedCat(null);
+    } catch (e) {
+      Alert.alert('发布失败', (e as Error).message || '未知错误');
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  return (
+    <ScrollView
+      style={styles.flex}
+      contentContainerStyle={styles.formBody}
+      keyboardShouldPersistTaps="handled"
+    >
+      {/* 账号 */}
+      <FieldLabel label="发布账号" required />
+      <AccountChips
+        accounts={accounts}
+        selectedId={form.accountId}
+        onSelect={(id) => update('accountId', id)}
+      />
+
+      {/* 图片 */}
+      <FieldLabel label={`商品图片（${form.images.length}/${MAX_IMAGES}，至少 1 张）`} required />
+      <ImageGrid images={form.images} uploading={uploading} onPick={handlePick} onRemove={handleRemoveImage} />
+
+      {/* 标题 / 描述 */}
+      <FieldLabel label="商品标题" required />
+      <Input
+        value={form.title}
+        onChangeText={(v) => update('title', v)}
+        placeholder="请输入商品标题（最多 200 字）"
+        maxLength={200}
+      />
+
+      <FieldLabel label="商品描述" required />
+      <Input
+        value={form.description}
+        onChangeText={(v) => update('description', v)}
+        placeholder="请输入商品描述（最多 1500 字）"
+        multiline
+        numberOfLines={5}
+        maxLength={1500}
+        style={styles.textarea}
+      />
+
+      {/* 价格 */}
+      <View style={styles.row2}>
+        <View style={styles.flex1}>
+          <FieldLabel label="售价（元）" required />
+          <Input
+            value={form.price}
+            onChangeText={(v) => {
+              if (v === '' || /^\d*\.?\d{0,2}$/.test(v)) update('price', v);
+            }}
+            placeholder="0.00"
+            keyboardType="decimal-pad"
+          />
+        </View>
+        <View style={styles.flex1}>
+          <FieldLabel label="原价（划线价）" />
+          <Input
+            value={form.originalPrice}
+            onChangeText={(v) => {
+              if (v === '' || /^\d*\.?\d{0,2}$/.test(v)) update('originalPrice', v);
+            }}
+            placeholder="可选"
+            keyboardType="decimal-pad"
+          />
+        </View>
+      </View>
+
+      <View style={styles.row2}>
+        <View style={styles.flex1}>
+          <FieldLabel label="库存" />
+          <Input
+            value={form.stock}
+            onChangeText={(v) => {
+              if (v === '' || /^\d*$/.test(v)) update('stock', v);
+            }}
+            placeholder="可选"
+            keyboardType="number-pad"
+          />
+        </View>
+        <View style={styles.flex1}>
+          <FieldLabel label="发布数量" />
+          <Input
+            value={form.quantity}
+            onChangeText={(v) => {
+              if (v === '' || /^\d*$/.test(v)) update('quantity', v);
+            }}
+            placeholder="默认 1"
+            keyboardType="number-pad"
+          />
+        </View>
+      </View>
+
+      {/* 成色 / 品牌 */}
+      <FieldLabel label="成色" />
+      <View style={styles.chipRow}>
+        {CONDITION_OPTIONS.map((opt) => {
+          const on = form.condition === opt;
+          return (
+            <Pressable
+              key={opt}
+              onPress={() => update('condition', opt)}
+              style={[
+                styles.chip,
+                {
+                  borderColor: on ? c.primary : c.border,
+                  backgroundColor: on ? c.primary : c.surface,
+                },
+              ]}
+            >
+              <Text style={[styles.chipText, { color: on ? '#FFFFFF' : c.text }]}>{opt}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <FieldLabel label="品牌" />
+      <Input
+        value={form.brand}
+        onChangeText={(v) => update('brand', v)}
+        placeholder="可选，例如：苹果、小米"
+      />
+
+      {/* 分类 + 类目推荐 */}
+      <View style={styles.labelActionRow}>
+        <FieldLabel label="商品分类" />
+        <Pressable onPress={handleRecommend} disabled={recommending} hitSlop={6}>
+          <Text style={[styles.linkText, { color: c.primary }]}>
+            {recommending ? '推荐中...' : 'AI 推荐类目'}
+          </Text>
+        </Pressable>
+      </View>
+      <Input
+        value={form.category}
+        onChangeText={(v) => {
+          update('category', v);
+          if (selectedCat) setSelectedCat(null); // 手动改动视为放弃推荐结果
+        }}
+        placeholder="可选，例如：数码产品/手机"
+      />
+      {candidates.length > 0 && (
+        <View style={styles.chipRow}>
+          {candidates.map((cand, i) => {
+            const on = selectedCat === cand;
+            return (
+              <Pressable
+                key={`${cand.cat_id ?? i}-${i}`}
+                onPress={() => handleSelectCandidate(cand)}
+                style={[
+                  styles.chip,
+                  {
+                    borderColor: on ? c.primary : c.border,
+                    backgroundColor: on ? c.primary : c.surface,
+                  },
+                ]}
+              >
+                <Text style={[styles.chipText, { color: on ? '#FFFFFF' : c.text }]} numberOfLines={1}>
+                  {cand.cat_name || '未知类目'}
+                  {cand.score != null ? ` ${Math.round(cand.score * 100)}%` : ''}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
+      {candidates.length > 0 && (
+        <FieldHint text={selectedCat ? `已选择推荐类目：${selectedCat.cat_name}` : '点击候选类目可提高发布精度（可选）'} />
+      )}
+
+      {/* 发货方式 */}
+      <FieldLabel label="发货方式" />
+      <View style={styles.chipRow}>
+        {DELIVERY_OPTIONS.map((o) => {
+          const on = form.deliveryMethod === o.value;
+          return (
+            <Pressable
+              key={o.value}
+              onPress={() => update('deliveryMethod', o.value)}
+              style={[
+                styles.chip,
+                {
+                  borderColor: on ? c.primary : c.border,
+                  backgroundColor: on ? c.primary : c.surface,
+                },
+              ]}
+            >
+              <Text style={[styles.chipText, { color: on ? '#FFFFFF' : c.text }]}>{o.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {/* 运费 */}
+      <FieldLabel label="运费" />
+      <View style={styles.chipRow}>
+        {SHIPPING_OPTIONS.map((o) => {
+          const on = form.shippingMethod === o.value;
+          return (
+            <Pressable
+              key={o.value}
+              onPress={() => update('shippingMethod', o.value)}
+              style={[
+                styles.chip,
+                {
+                  borderColor: on ? c.primary : c.border,
+                  backgroundColor: on ? c.primary : c.surface,
+                },
+              ]}
+            >
+              <Text style={[styles.chipText, { color: on ? '#FFFFFF' : c.text }]}>{o.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      {form.shippingMethod === 'fixed' && (
+        <>
+          <FieldLabel label="运费金额（元）" required />
+          <Input
+            value={form.postage}
+            onChangeText={(v) => {
+              if (v === '' || /^\d*\.?\d{0,2}$/.test(v)) update('postage', v);
+            }}
+            placeholder="例如：10.00"
+            keyboardType="decimal-pad"
+          />
+        </>
+      )}
+
+      {/* 所在地 */}
+      <FieldLabel label="宝贝所在地" />
+      <Input
+        value={form.address}
+        onChangeText={(v) => update('address', v)}
+        placeholder="可选，例如：浙江省杭州市"
+      />
+
+      <Button
+        label={publishing ? '发布中...' : '发布商品'}
+        onPress={handlePublish}
+        loading={publishing}
+        disabled={publishing || uploading}
+        style={styles.submitBtn}
+      />
+      <FieldHint text="发布为同步操作，闲鱼处理可能需要数十秒，请耐心等待。" />
+    </ScrollView>
+  );
+}
+
+function validateSingleForm(f: SingleFormState): string {
+  if (!f.accountId) return '请选择发布账号';
+  if (f.images.length === 0) return '请至少上传 1 张商品图片';
+  if (!f.title.trim()) return '请输入商品标题';
+  if (!f.description.trim()) return '请输入商品描述';
+  const price = parseFloat(f.price);
+  if (!f.price.trim() || Number.isNaN(price) || price <= 0) return '请输入大于 0 的售价';
+  if (f.originalPrice.trim()) {
+    const orig = parseFloat(f.originalPrice);
+    if (Number.isNaN(orig) || orig < 0) return '请输入正确的原价';
+  }
+  if (f.stock.trim()) {
+    const stock = parseInt(f.stock, 10);
+    if (Number.isNaN(stock) || stock < 0) return '请输入正确的库存数量';
+  }
+  if (f.quantity.trim()) {
+    const qty = parseInt(f.quantity, 10);
+    if (Number.isNaN(qty) || qty < 1) return '发布数量必须大于 0';
+  }
+  if (f.shippingMethod === 'fixed') {
+    const postage = parseFloat(f.postage);
+    if (!f.postage.trim() || Number.isNaN(postage) || postage < 0) return '固定运费必须填写不小于 0 的金额';
+  }
+  return '';
+}
+
+function buildSingleBody(
+  f: SingleFormState,
+  selectedCat: CategoryCandidate | null,
+): Parameters<typeof publishSingle>[0] {
+  const body: Parameters<typeof publishSingle>[0] = {
+    account_id: f.accountId,
+    title: f.title.trim(),
+    description: f.description.trim(),
+    price: parseFloat(f.price),
+    images: f.images.map((i) => i.path),
+    condition: f.condition,
+    delivery_method: f.deliveryMethod,
+    shipping_method: f.shippingMethod,
+    postage: f.shippingMethod === 'fixed' ? parseFloat(f.postage) || 0 : 0,
+    quantity: f.quantity.trim() ? parseInt(f.quantity, 10) || 1 : 1,
+  };
+  if (f.originalPrice.trim()) body.original_price = parseFloat(f.originalPrice);
+  if (f.stock.trim()) body.stock = parseInt(f.stock, 10);
+  if (f.brand.trim()) body.brand = f.brand.trim();
+  if (f.address.trim()) body.address = f.address.trim();
+  if (f.category.trim()) body.category = f.category.trim();
+  if (selectedCat) {
+    // 携带类目推荐返回的平台分类字段，提升闲鱼发布成功率
+    body.category_source = 'recommendation';
+    if (selectedCat.score != null) body.category_confidence = selectedCat.score;
+    if (selectedCat.cat_id) body.platform_category_id = selectedCat.cat_id;
+    if (selectedCat.cat_name) body.platform_category_name = selectedCat.cat_name;
+    if (selectedCat.channel_cat_id) body.platform_channel_category_id = selectedCat.channel_cat_id;
+    if (selectedCat.channel_cat_name) body.platform_channel_category_name = selectedCat.channel_cat_name;
+    if (selectedCat.leaf_id) body.platform_leaf_id = selectedCat.leaf_id;
+    if (selectedCat.tb_cat_id) body.platform_tb_category_id = selectedCat.tb_cat_id;
+    if (selectedCat.path && selectedCat.path.length > 0) body.platform_category_path = selectedCat.path;
+  } else if (f.category.trim()) {
+    body.category_source = 'manual';
+  }
+  return body;
+}
+
+// ---------------------------------------------------------------------------
+// Tab 2：批量发布（素材多选 + 提交 + 进度展示）
+// ---------------------------------------------------------------------------
+
+const MATERIAL_PAGE_SIZE = 50;
+
+function BatchPublishTab({
+  accounts,
+  activeBatch,
+  batchStatus,
+  pollError,
+  onStartBatch,
+}: {
+  accounts: AccountOption[];
+  activeBatch: { batchId: string; total: number } | null;
+  batchStatus: BatchStatus | null;
+  pollError: string | null;
+  onStartBatch: (batch: { batchId: string; total: number }) => void;
+}) {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+
+  const [materials, setMaterials] = useState<ProductMaterial[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
+  const [selectedMaterialIds, setSelectedMaterialIds] = useState<number[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
 
-  const load = useCallback(async () => {
+  const loadMaterials = useCallback(async () => {
     setRefreshing(true);
     try {
-      setAddresses(await getPersonalAddresses());
+      const res = await listMaterials(1, MATERIAL_PAGE_SIZE);
+      setMaterials(res.list);
+      setTotal(res.total);
     } catch (e) {
-      Alert.alert('加载失败', (e as Error).message);
+      Alert.alert('加载素材失败', (e as Error).message);
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -27,69 +808,846 @@ export default function ProductPublishScreen() {
   }, []);
 
   useEffect(() => {
-    load();
-  }, [load]);
+    loadMaterials();
+  }, [loadMaterials]);
 
-  if (loading) {
-    return (
-      <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
-        <Loading label="加载地址..." />
-      </SafeAreaView>
+  const toggleAccount = useCallback((id: string) => {
+    setSelectedAccountIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
     );
+  }, []);
+
+  const toggleMaterial = useCallback((id: number) => {
+    setSelectedMaterialIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  }, []);
+
+  const handleDeleteMaterial = useCallback(
+    (material: ProductMaterial) => {
+      Alert.alert('删除素材', `确定删除「${material.title}」吗？此操作不可恢复。`, [
+        { text: '取消', style: 'cancel' },
+        {
+          text: '删除',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteMaterial(material.id);
+              setSelectedMaterialIds((prev) => prev.filter((x) => x !== material.id));
+              loadMaterials();
+            } catch (e) {
+              Alert.alert('删除失败', (e as Error).message);
+            }
+          },
+        },
+      ]);
+    },
+    [loadMaterials],
+  );
+
+  async function handleStart() {
+    if (selectedAccountIds.length === 0) {
+      Alert.alert('提示', '请至少选择 1 个发布账号');
+      return;
+    }
+    if (selectedMaterialIds.length === 0) {
+      Alert.alert('提示', '请至少选择 1 个发布素材');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await publishBatch(selectedAccountIds, selectedMaterialIds);
+      onStartBatch({ batchId: res.batch_id, total: res.total });
+      Alert.alert('批量任务已提交', res.total > 0 ? `共 ${res.total} 件商品，正在后台执行` : '正在后台执行');
+    } catch (e) {
+      Alert.alert('提交失败', (e as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
   }
 
-  return (
-    <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
+  // 进度百分比：已出结果（成功+失败）/ 总数
+  const done = batchStatus ? batchStatus.success + batchStatus.failed : 0;
+  const progressTotal = batchStatus && batchStatus.total > 0 ? batchStatus.total : activeBatch?.total ?? 0;
+  const percent = progressTotal > 0 ? Math.min(100, Math.round((done / progressTotal) * 100)) : 0;
 
-      <View style={styles.bannerWrap}>
-        <View style={[styles.banner, { backgroundColor: c.primaryLight }]}>
-          <Text style={[styles.bannerText, { color: c.primary }]}>
-            当前为 Phase 1：仅展示发布地址。发布操作将在 Phase 2 上线。
-          </Text>
-        </View>
+  return (
+    <View style={styles.flex}>
+      {/* 账号多选 */}
+      <View style={[styles.sectionBar, { borderBottomColor: c.borderLight }]}>
+        <FieldLabel label={`发布账号（已选 ${selectedAccountIds.length}）`} required />
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipRowScroll}>
+          {accounts.length === 0 && <FieldHint text="暂无闲鱼账号，请先在「账号管理」中添加账号" />}
+          {accounts.map((acc) => {
+            const on = selectedAccountIds.includes(acc.id);
+            return (
+              <Pressable
+                key={acc.id}
+                onPress={() => toggleAccount(acc.id)}
+                style={[
+                  styles.chip,
+                  {
+                    borderColor: on ? c.primary : c.border,
+                    backgroundColor: on ? c.primary : c.surface,
+                  },
+                ]}
+              >
+                <Text style={[styles.chipText, { color: on ? '#FFFFFF' : c.text }]} numberOfLines={1}>
+                  {on ? '✓ ' : ''}
+                  {accountLabel(acc)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
       </View>
 
-      <FlatList
-        data={addresses}
-        keyExtractor={(item) => String(item.id)}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={load} />}
-        contentContainerStyle={styles.list}
-        ListEmptyComponent={
-          <View style={styles.empty}>
-            <Text style={[styles.emptyText, { color: c.textMuted }]}>
-              暂无收货地址
-            </Text>
+      {/* 素材列表 */}
+      <View style={styles.materialHeader}>
+        <Text style={[styles.materialTitle, { color: c.text }]}>
+          发布素材（已选 {selectedMaterialIds.length}/{total}）
+        </Text>
+        <Button label="+ 新建素材" onPress={() => setModalVisible(true)} variant="secondary" />
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator size="small" color={c.primary} />
+        </View>
+      ) : (
+        <FlatList
+          data={materials}
+          keyExtractor={(item) => String(item.id)}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={loadMaterials} />}
+          contentContainerStyle={styles.materialList}
+          ListEmptyComponent={
+            <EmptyState
+              icon={Package}
+              title="暂无素材"
+              message="先新建素材，再选择素材批量发布"
+              actionLabel="新建素材"
+              onAction={() => setModalVisible(true)}
+            />
+          }
+          renderItem={({ item }) => {
+            const on = selectedMaterialIds.includes(item.id);
+            return (
+              <Pressable onPress={() => toggleMaterial(item.id)} onLongPress={() => handleDeleteMaterial(item)}>
+                <Card style={[styles.materialCard, on && { borderColor: c.primary, borderWidth: 1.5 }]}>
+                  <View style={styles.materialRow}>
+                    {item.images && item.images.length > 0 ? (
+                      <Image
+                        source={{ uri: item.images[0] }}
+                        style={[styles.materialThumb, { backgroundColor: c.surfaceAlt }]}
+                      />
+                    ) : (
+                      <View style={[styles.materialThumb, { backgroundColor: c.surfaceAlt }]}>
+                        <Package size={20} stroke={c.textMuted} />
+                      </View>
+                    )}
+                    <View style={styles.materialBody}>
+                      <Text style={[styles.materialName, { color: c.text }]} numberOfLines={2}>
+                        {item.title}
+                      </Text>
+                      <View style={styles.materialMeta}>
+                        <Text style={[styles.materialPrice, { color: c.warning }]}>¥{item.price}</Text>
+                        <Text style={[styles.materialMetaText, { color: c.textMuted }]}>
+                          {item.condition} · 数量 {item.quantity} · {item.images?.length ?? 0} 图
+                        </Text>
+                      </View>
+                    </View>
+                    <View style={[styles.checkbox, on && { backgroundColor: c.primary, borderColor: c.primary }, { borderColor: c.border }]}>
+                      {on ? <Text style={styles.checkboxText}>✓</Text> : null}
+                    </View>
+                  </View>
+                </Card>
+              </Pressable>
+            );
+          }}
+        />
+      )}
+
+      {/* 批量进度 */}
+      {activeBatch && (
+        <View style={[styles.progressCard, { backgroundColor: c.surface, borderColor: c.border }]}>
+          <View style={styles.progressHeader}>
+            <Text style={[styles.progressTitle, { color: c.text }]}>批量进度</Text>
+            <Text style={[styles.progressPercent, { color: c.primary }]}>{percent}%</Text>
           </View>
-        }
-        renderItem={({ item }) => (
-          <Card style={styles.card}>
-            <View style={styles.cardRow}>
-              <Text style={[styles.name, { color: c.text }]}>{item.name}</Text>
-              <Text style={[styles.phone, { color: c.textSecondary }]}>
-                {item.phone}
-              </Text>
-            </View>
-            <Text style={[styles.address, { color: c.textSecondary }]}>
-              {item.address}
-            </Text>
-          </Card>
-        )}
+          <View style={[styles.progressTrack, { backgroundColor: c.surfaceAlt }]}>
+            <View style={[styles.progressFill, { backgroundColor: c.primary, width: `${percent}%` }]} />
+          </View>
+          {batchStatus ? (
+            <>
+              <View style={styles.progressStats}>
+                <Text style={[styles.statText, { color: c.textSecondary }]}>
+                  总计 {batchStatus.total} · 成功 <Text style={{ color: c.success }}>{batchStatus.success}</Text> · 失败{' '}
+                  <Text style={{ color: c.error }}>{batchStatus.failed}</Text> · 发布中 {batchStatus.publishing} · 等待{' '}
+                  {batchStatus.pending}
+                </Text>
+                {!batchStatus.finished ? (
+                  <View style={styles.pollingRow}>
+                    <ActivityIndicator size="small" color={c.primary} />
+                    <Text style={[styles.pollingText, { color: c.textMuted }]}>每 5 秒自动刷新</Text>
+                  </View>
+                ) : (
+                  <Badge label="已完成" variant="success" />
+                )}
+              </View>
+              {/* 各账号失败/同步明细 */}
+              {batchStatus.account_statuses.map((acc) => (
+                <View key={acc.account_id} style={[styles.accountStatusRow, { borderTopColor: c.borderLight }]}>
+                  <Text style={[styles.accountStatusId, { color: c.text }]} numberOfLines={1}>
+                    {acc.account_id}
+                  </Text>
+                  <Text style={[styles.accountStatusText, { color: c.textSecondary }]}>
+                    成功 {acc.success} / 失败 <Text style={{ color: acc.failed > 0 ? c.error : c.textSecondary }}>{acc.failed}</Text> / 发布中 {acc.publishing} / 等待 {acc.pending}
+                  </Text>
+                  {acc.sync_status === 'failed' || acc.sync_status === 'running' ? (
+                    <Text style={[styles.syncMessage, { color: acc.sync_status === 'failed' ? c.error : c.textMuted }]} numberOfLines={2}>
+                      {acc.sync_message}
+                    </Text>
+                  ) : null}
+                </View>
+              ))}
+            </>
+          ) : (
+            <Text style={[styles.progressWaiting, { color: c.textMuted }]}>正在获取进度...</Text>
+          )}
+          {pollError && <Text style={[styles.pollError, { color: c.error }]}>{pollError}</Text>}
+        </View>
+      )}
+
+      {/* 底部提交按钮 */}
+      <View style={[styles.footer, { borderTopColor: c.border, backgroundColor: c.surface }]}>
+        <Button
+          label={submitting ? '提交中...' : `开始批量发布（${selectedAccountIds.length} 账号 × ${selectedMaterialIds.length} 素材）`}
+          onPress={handleStart}
+          loading={submitting}
+          disabled={submitting}
+          style={styles.flex1}
+        />
+      </View>
+
+      <MaterialCreateModal
+        visible={modalVisible}
+        onClose={() => setModalVisible(false)}
+        onCreated={() => {
+          setModalVisible(false);
+          loadMaterials();
+        }}
       />
-    </SafeAreaView>
+    </View>
   );
 }
 
+// ---------------------------------------------------------------------------
+// 素材新建弹窗（底部抽屉）
+// ---------------------------------------------------------------------------
+
+interface MaterialFormState {
+  title: string;
+  description: string;
+  price: string;
+  originalPrice: string;
+  category: string;
+  condition: string;
+  quantity: string;
+  images: LocalImage[];
+}
+
+const EMPTY_MATERIAL_FORM: MaterialFormState = {
+  title: '',
+  description: '',
+  price: '',
+  originalPrice: '',
+  category: '',
+  condition: '全新',
+  quantity: '1',
+  images: [],
+};
+
+function MaterialCreateModal({
+  visible,
+  onClose,
+  onCreated,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+
+  const [form, setForm] = useState<MaterialFormState>(EMPTY_MATERIAL_FORM);
+  const [uploading, setUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const update = <K extends keyof MaterialFormState>(field: K, value: MaterialFormState[K]) =>
+    setForm((prev) => ({ ...prev, [field]: value }));
+
+  const handlePick = useCallback(async () => {
+    try {
+      setUploading(true);
+      const next = await pickAndUploadImages(MAX_IMAGES - form.images.length);
+      if (next.length > 0) {
+        setForm((prev) => ({ ...prev, images: [...prev.images, ...next] }));
+      }
+    } catch (e) {
+      Alert.alert('上传失败', (e as Error).message);
+    } finally {
+      setUploading(false);
+    }
+  }, [form.images.length]);
+
+  const handleRemoveImage = useCallback((index: number) => {
+    setForm((prev) => {
+      const next = [...prev.images];
+      next.splice(index, 1);
+      return { ...prev, images: next };
+    });
+  }, []);
+
+  async function handleSave() {
+    if (!form.title.trim()) {
+      Alert.alert('提示', '请输入素材标题');
+      return;
+    }
+    if (!form.description.trim()) {
+      Alert.alert('提示', '请输入素材描述');
+      return;
+    }
+    const price = parseFloat(form.price);
+    if (!form.price.trim() || Number.isNaN(price) || price <= 0) {
+      Alert.alert('提示', '请输入大于 0 的售价');
+      return;
+    }
+    if (form.images.length === 0) {
+      Alert.alert('提示', '请至少上传 1 张图片');
+      return;
+    }
+    setSaving(true);
+    try {
+      await createMaterial({
+        title: form.title.trim(),
+        description: form.description.trim(),
+        price,
+        original_price: form.originalPrice.trim() ? parseFloat(form.originalPrice) : null,
+        category: form.category.trim() || null,
+        condition: form.condition,
+        quantity: form.quantity.trim() ? parseInt(form.quantity, 10) || 1 : 1,
+        images: form.images.map((i) => i.path),
+        delivery_method: 'express',
+        shipping_method: 'free',
+        postage: 0,
+      });
+      Alert.alert('成功', '素材创建成功');
+      setForm(EMPTY_MATERIAL_FORM);
+      onCreated();
+    } catch (e) {
+      Alert.alert('创建失败', (e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        style={styles.modalOverlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <Pressable style={styles.modalBackdrop} onPress={onClose} />
+        <View style={[styles.modalSheet, { backgroundColor: c.surface }]}>
+          <View style={[styles.modalHandle, { backgroundColor: c.border }]} />
+          <View style={styles.modalHeader}>
+            <Text style={[styles.modalTitle, { color: c.text }]}>新建发布素材</Text>
+            <Pressable onPress={onClose} hitSlop={8}>
+              <Text style={[styles.modalClose, { color: c.textMuted }]}>✕</Text>
+            </Pressable>
+          </View>
+
+          <ScrollView
+            style={styles.modalScroll}
+            contentContainerStyle={styles.modalBody}
+            keyboardShouldPersistTaps="handled"
+          >
+            <FieldLabel label="商品标题" required />
+            <Input
+              value={form.title}
+              onChangeText={(v) => update('title', v)}
+              placeholder="请输入商品标题（最多 200 字）"
+              maxLength={200}
+            />
+
+            <FieldLabel label="商品描述" required />
+            <Input
+              value={form.description}
+              onChangeText={(v) => update('description', v)}
+              placeholder="请输入商品描述（最多 1500 字）"
+              multiline
+              numberOfLines={4}
+              maxLength={1500}
+              style={styles.textarea}
+            />
+
+            <View style={styles.row2}>
+              <View style={styles.flex1}>
+                <FieldLabel label="售价（元）" required />
+                <Input
+                  value={form.price}
+                  onChangeText={(v) => {
+                    if (v === '' || /^\d*\.?\d{0,2}$/.test(v)) update('price', v);
+                  }}
+                  placeholder="0.00"
+                  keyboardType="decimal-pad"
+                />
+              </View>
+              <View style={styles.flex1}>
+                <FieldLabel label="原价（划线价）" />
+                <Input
+                  value={form.originalPrice}
+                  onChangeText={(v) => {
+                    if (v === '' || /^\d*\.?\d{0,2}$/.test(v)) update('originalPrice', v);
+                  }}
+                  placeholder="可选"
+                  keyboardType="decimal-pad"
+                />
+              </View>
+            </View>
+
+            <FieldLabel label={`商品图片（${form.images.length}/${MAX_IMAGES}，至少 1 张）`} required />
+            <ImageGrid images={form.images} uploading={uploading} onPick={handlePick} onRemove={handleRemoveImage} />
+
+            <FieldLabel label="成色" />
+            <View style={styles.chipRow}>
+              {CONDITION_OPTIONS.map((opt) => {
+                const on = form.condition === opt;
+                return (
+                  <Pressable
+                    key={opt}
+                    onPress={() => update('condition', opt)}
+                    style={[
+                      styles.chip,
+                      {
+                        borderColor: on ? c.primary : c.border,
+                        backgroundColor: on ? c.primary : c.surface,
+                      },
+                    ]}
+                  >
+                    <Text style={[styles.chipText, { color: on ? '#FFFFFF' : c.text }]}>{opt}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            <FieldLabel label="商品分类" />
+            <Input
+              value={form.category}
+              onChangeText={(v) => update('category', v)}
+              placeholder="可选，例如：数码产品/手机"
+            />
+
+            <FieldLabel label="发布数量" />
+            <Input
+              value={form.quantity}
+              onChangeText={(v) => {
+                if (v === '' || /^\d*$/.test(v)) update('quantity', v);
+              }}
+              placeholder="默认 1"
+              keyboardType="number-pad"
+            />
+            <FieldHint text="批量发布时每个账号按此数量重复发布该素材。" />
+          </ScrollView>
+
+          <View style={[styles.modalFooter, { borderTopColor: c.border }]}>
+            <Button label="取消" variant="ghost" onPress={onClose} style={styles.flex1} />
+            <Button
+              label="保存素材"
+              onPress={handleSave}
+              loading={saving}
+              disabled={saving}
+              style={styles.flex1}
+            />
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab 3：发布记录（日志列表）
+// ---------------------------------------------------------------------------
+
+const LOG_PAGE_SIZE = 20;
+
+function logStatusMeta(status: PublishLogItem['status']): { label: string; variant: 'success' | 'danger' | 'info' | 'gray' } {
+  switch (status) {
+    case 'success':
+      return { label: '成功', variant: 'success' };
+    case 'failed':
+      return { label: '失败', variant: 'danger' };
+    case 'publishing':
+      return { label: '发布中', variant: 'info' };
+    default:
+      return { label: '等待', variant: 'gray' };
+  }
+}
+
+function PublishLogsTab() {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+
+  const [logs, setLogs] = useState<PublishLogItem[]>([]);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadLogs = useCallback(
+    async (targetPage: number, status: string, opts?: { append?: boolean }) => {
+      if (opts?.append) setLoadingMore(true);
+      else setRefreshing(true);
+      setError(null);
+      try {
+        const res = await getPublishLogs(targetPage, LOG_PAGE_SIZE, undefined, status || undefined);
+        setLogs((prev) => (opts?.append ? [...prev, ...res.list] : res.list));
+        setPage(res.page);
+        setTotalPages(res.total_pages);
+        setTotal(res.total);
+      } catch (e) {
+        setError((e as Error).message || '加载发布记录失败');
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+        setLoadingMore(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    setLoading(true);
+    loadLogs(1, statusFilter);
+  }, [statusFilter, loadLogs]);
+
+  const handleLoadMore = useCallback(() => {
+    if (loadingMore || refreshing || loading) return;
+    if (totalPages > 0 && page >= totalPages) return;
+    loadLogs(page + 1, statusFilter, { append: true });
+  }, [loadingMore, refreshing, loading, totalPages, page, statusFilter, loadLogs]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: PublishLogItem }) => {
+      const meta = logStatusMeta(item.status);
+      return (
+        <Card style={styles.logCard}>
+          <View style={styles.logTop}>
+            <Text style={[styles.logTitle, { color: c.text }]} numberOfLines={2}>
+              {item.title || '无标题'}
+            </Text>
+            <Badge label={meta.label} variant={meta.variant} />
+          </View>
+          <View style={styles.logMeta}>
+            <Text style={[styles.logMetaText, { color: c.textSecondary }]} numberOfLines={1}>
+              账号 {item.account_id}
+            </Text>
+            {item.price ? (
+              <Text style={[styles.logPrice, { color: c.warning }]}>¥{item.price}</Text>
+            ) : null}
+          </View>
+          {item.error_message ? (
+            <Text style={[styles.logError, { color: c.error }]} numberOfLines={3}>
+              {item.error_message}
+            </Text>
+          ) : null}
+          {item.item_id ? (
+            <Text style={[styles.logMetaText, { color: c.textMuted }]} numberOfLines={1}>
+              商品ID：{item.item_id}
+            </Text>
+          ) : null}
+          <Text style={[styles.logTime, { color: c.textMuted }]}>{item.created_at}</Text>
+        </Card>
+      );
+    },
+    [c],
+  );
+
+  return (
+    <View style={styles.flex}>
+      {/* 状态筛选 */}
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipRowScroll}>
+        {LOG_STATUS_FILTERS.map((f) => {
+          const on = statusFilter === f.key;
+          return (
+            <Pressable
+              key={f.key}
+              onPress={() => setStatusFilter(f.key)}
+              style={[
+                styles.chip,
+                {
+                  borderColor: on ? c.primary : c.border,
+                  backgroundColor: on ? c.primary : c.surface,
+                },
+              ]}
+            >
+              <Text style={[styles.chipText, { color: on ? '#FFFFFF' : c.text }]}>{f.label}</Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+
+      <FlatList
+        data={logs}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={renderItem}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={() => loadLogs(1, statusFilter)} />}
+        contentContainerStyle={styles.logList}
+        onEndReached={handleLoadMore}
+        onEndReachedThreshold={0.3}
+        ListEmptyComponent={
+          error ? (
+            <EmptyState
+              icon={Package}
+              title="加载失败"
+              message={error}
+              error
+              onRetry={() => loadLogs(1, statusFilter)}
+            />
+          ) : (
+            <EmptyState icon={Package} title="暂无发布记录" message="单品或批量发布后会在这里生成记录" />
+          )
+        }
+        ListFooterComponent={
+          loadingMore ? (
+            <View style={styles.center}>
+              <ActivityIndicator size="small" color={c.primary} />
+            </View>
+          ) : logs.length > 0 && page >= totalPages && totalPages > 0 ? (
+            <Text style={[styles.footerText, { color: c.textMuted }]}>
+              共 {total} 条，没有更多了
+            </Text>
+          ) : null
+        }
+      />
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 样式
+// ---------------------------------------------------------------------------
+
+// Input 的 style 为 StyleProp<TextStyle>，自定义样式对象按 TextStyle 收窄
+type InputStyle = TextStyle;
+
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  bannerWrap: { paddingHorizontal: spacing.lg, paddingBottom: spacing.sm },
-  banner: { borderRadius: radius.md, padding: spacing.md },
-  bannerText: { ...typography.caption },
-  list: { padding: spacing.lg, gap: spacing.md },
-  card: { gap: spacing.xs },
-  cardRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  name: { ...typography.body, fontWeight: '600' },
-  phone: { ...typography.caption },
-  address: { ...typography.caption },
-  empty: { alignItems: 'center', paddingVertical: 28 },
-  emptyText: { ...typography.body },
+  flex: { flex: 1 },
+
+  // 分段控件
+  tabs: {
+    flexDirection: 'row',
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+    borderRadius: radius.md,
+    padding: 2,
+  },
+  tabItem: {
+    flex: 1,
+    height: 34,
+    borderRadius: radius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tabText: { fontSize: 13, fontWeight: '600' },
+
+  // 表单
+  formBody: { padding: spacing.lg, gap: spacing.xs, paddingBottom: 120 },
+  row2: { flexDirection: 'row', gap: spacing.sm },
+  flex1: { flex: 1 },
+  fieldLabel: { flexDirection: 'row', alignItems: 'center', marginTop: spacing.sm },
+  fieldLabelText: { ...typography.caption, fontWeight: '500' },
+  required: { color: '#EF4444', fontSize: 14 },
+  fieldHint: { ...typography.small, lineHeight: 16 },
+  labelActionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: spacing.sm,
+    paddingRight: spacing.xs,
+  },
+  linkText: { ...typography.caption, fontWeight: '600' },
+  textarea: { minHeight: 90, textAlignVertical: 'top' } as InputStyle,
+  submitBtn: { marginTop: spacing.lg },
+
+  // 胶囊
+  chipRowScroll: { gap: spacing.sm, paddingVertical: spacing.xs },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm, marginTop: spacing.xs },
+  chip: {
+    paddingHorizontal: spacing.md,
+    height: 32,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    maxWidth: 160,
+  },
+  chipText: { fontSize: 13, fontWeight: '500' },
+
+  // 图片九宫格
+  imageGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm, marginTop: spacing.xs },
+  imageCell: { width: 88, height: 88, position: 'relative' },
+  thumb: { width: '100%', height: '100%', borderRadius: radius.md },
+  imageDel: {
+    position: 'absolute',
+    top: -6,
+    right: -6,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  imageIndex: {
+    position: 'absolute',
+    bottom: 4,
+    left: 4,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    borderRadius: 4,
+    paddingHorizontal: 4,
+  },
+  imageIndexText: { color: '#FFFFFF', fontSize: 10, fontWeight: '600' },
+  imageAdd: {
+    width: 88,
+    height: 88,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  imageAddText: { ...typography.small, marginTop: 2 },
+
+  // 批量发布
+  sectionBar: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.xs,
+    paddingBottom: spacing.sm,
+    borderBottomWidth: 1,
+  },
+  materialHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.xs,
+  },
+  materialTitle: { ...typography.heading, flexShrink: 1 },
+  materialList: { padding: spacing.lg, paddingTop: spacing.xs, gap: spacing.md, paddingBottom: 120 },
+  materialCard: { padding: spacing.md },
+  materialRow: { flexDirection: 'row', gap: spacing.md, alignItems: 'center' },
+  materialThumb: {
+    width: 52,
+    height: 52,
+    borderRadius: radius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  materialBody: { flex: 1, gap: spacing.xs },
+  materialName: { ...typography.caption, fontWeight: '600', lineHeight: 18 },
+  materialMeta: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  materialPrice: { ...typography.small, fontWeight: '700' },
+  materialMetaText: { ...typography.small },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkboxText: { color: '#FFFFFF', fontSize: 13, fontWeight: '700' },
+
+  // 批量进度
+  progressCard: {
+    marginHorizontal: spacing.lg,
+    marginBottom: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  progressHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  progressTitle: { ...typography.caption, fontWeight: '600' },
+  progressPercent: { ...typography.heading },
+  progressTrack: { height: 8, borderRadius: 4, overflow: 'hidden' },
+  progressFill: { height: '100%', borderRadius: 4 },
+  progressStats: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.sm },
+  statText: { ...typography.small, flexShrink: 1 },
+  pollingRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.xs },
+  pollingText: { ...typography.small },
+  progressWaiting: { ...typography.small },
+  pollError: { ...typography.small },
+  accountStatusRow: { borderTopWidth: 1, paddingTop: spacing.sm, gap: 2 },
+  accountStatusId: { ...typography.small, fontWeight: '600' },
+  accountStatusText: { ...typography.small },
+  syncMessage: { ...typography.small },
+
+  // 底部提交
+  footer: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    padding: spacing.lg,
+    borderTopWidth: 1,
+  },
+
+  // 弹窗
+  modalOverlay: { flex: 1, justifyContent: 'flex-end' },
+  modalBackdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' },
+  modalSheet: {
+    maxHeight: '88%',
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    overflow: 'hidden',
+    flexDirection: 'column',
+  },
+  modalHandle: { width: 36, height: 4, borderRadius: 2, alignSelf: 'center', marginTop: spacing.sm },
+  modalHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+  },
+  modalTitle: { ...typography.heading },
+  modalClose: { fontSize: 22, paddingHorizontal: spacing.xs },
+  modalScroll: { flex: 1, paddingHorizontal: spacing.lg },
+  modalBody: { paddingBottom: spacing.lg, gap: spacing.xs },
+  modalFooter: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    padding: spacing.lg,
+    borderTopWidth: 1,
+  },
+
+  // 发布记录
+  logList: { padding: spacing.lg, paddingTop: spacing.xs, gap: spacing.md, paddingBottom: 120 },
+  logCard: { gap: spacing.xs },
+  logTop: { flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', gap: spacing.sm },
+  logTitle: { ...typography.caption, fontWeight: '600', flexShrink: 1, lineHeight: 20 },
+  logMeta: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  logMetaText: { ...typography.small, flexShrink: 1 },
+  logPrice: { ...typography.small, fontWeight: '700' },
+  logError: { ...typography.small },
+  logTime: { ...typography.small },
+  center: { paddingVertical: spacing.lg, alignItems: 'center' },
+  footerText: { ...typography.small, textAlign: 'center', paddingVertical: spacing.md },
 });

--- a/xianyu-mobile/app/(tabs)/mine/scheduled-tasks.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/scheduled-tasks.tsx
@@ -4,7 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useColorScheme } from 'react-native';
 import { Card, Loading, Badge } from '@/components/ui';
 import { colors, spacing, typography, radius } from '@/lib/theme';
-import { getScheduledTasks, updateScheduledTask, triggerScheduledTask, type ScheduledTask } from '@/api/wrappers/admin';
+// 定时任务走专用封装：task_code 定位 + query 参数传参（后端契约 admin.py:753-914）
+import { getScheduledTasks, updateScheduledTask, triggerScheduledTask, type ScheduledTask } from '@/api/wrappers/scheduled-tasks';
 
 function formatInterval(seconds: number): string {
   if (seconds >= 3600) return `${(seconds / 3600).toFixed(1)} 小时`;
@@ -36,7 +37,7 @@ export default function ScheduledTasksScreen() {
   async function handleToggle(task: ScheduledTask, next: boolean) {
     setTasks(prev => prev.map(t => t.id === task.id ? { ...t, enabled: next } : t));
     setUpdating(task.id);
-    try { await updateScheduledTask(task.id, { enabled: next }); }
+    try { await updateScheduledTask(task.task_code, { enabled: next }); }
     catch (e) {
       setTasks(prev => prev.map(t => t.id === task.id ? { ...t, enabled: task.enabled } : t));
       Alert.alert('操作失败', (e as Error).message);
@@ -48,9 +49,10 @@ export default function ScheduledTasksScreen() {
     if (!n || n < 1) { Alert.alert('提示', '请输入有效间隔秒数'); return; }
     setUpdating(task.id);
     try {
-      await updateScheduledTask(task.id, { interval_seconds: n });
+      const { message } = await updateScheduledTask(task.task_code, { interval_seconds: n });
       setTasks(prev => prev.map(t => t.id === task.id ? { ...t, interval_seconds: n } : t));
       setEditingId(null);
+      Alert.alert('成功', message);
     } catch (e) { Alert.alert('保存失败', (e as Error).message); }
     finally { setUpdating(null); }
   }
@@ -58,8 +60,9 @@ export default function ScheduledTasksScreen() {
   async function handleTrigger(task: ScheduledTask) {
     setUpdating(task.id);
     try {
-      await triggerScheduledTask(task.id);
-      Alert.alert('已触发', `${task.task_name} 已手动触发`);
+      // 后端 trigger 响应只有 { success, message }，message 即可展示的触发结果
+      const message = await triggerScheduledTask(task.task_code);
+      Alert.alert('已触发', message);
     } catch (e) { Alert.alert('触发失败', (e as Error).message); }
     finally { setUpdating(null); }
   }
@@ -112,8 +115,8 @@ export default function ScheduledTasksScreen() {
             </View>
             <View style={styles.row}>
               <Text style={[styles.label, { color: c.textMuted }]}>状态</Text>
-              <Badge label={item.task_running ? '运行中' : '空闲'} variant={item.task_running ? 'success' : 'gray'} />
-              {!item.enabled && <Badge label="已禁用" variant="danger" />}
+              {/* 后端无 task_running/scheduler_running 字段，仅展示启用状态 */}
+              <Badge label={item.enabled ? '已启用' : '已禁用'} variant={item.enabled ? 'success' : 'danger'} />
             </View>
             <Pressable
               onPress={() => handleTrigger(item)}

--- a/xianyu-mobile/app/(tabs)/mine/shared-scan.tsx
+++ b/xianyu-mobile/app/(tabs)/mine/shared-scan.tsx
@@ -1,82 +1,297 @@
-import { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, Alert, RefreshControl } from 'react-native';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Pressable,
+  Alert,
+  RefreshControl,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useColorScheme } from 'react-native';
-import { Card, Button, Loading } from '@/components/ui';
+import * as Clipboard from 'expo-clipboard';
+import { ScanLine } from 'lucide-react-native';
+import { Card, Button, Loading, EmptyState } from '@/components/ui';
 import { colors, spacing, typography, radius } from '@/lib/theme';
-import { getApiClient } from '@/api/wrappers/client';
+import {
+  createSharedSession,
+  listSharedSessions,
+  getSharedSessionStatus,
+  deleteSharedSession,
+  type SharedScanSession,
+  type SharedScanWorkerInfo,
+} from '@/api/wrappers/shared-scan';
 
-interface ScanSession { session_id: string; status: string; created_at: string; }
+/** 兼职扫码状态 → 中文标签 + 语义色（对齐 web SharedScanManager 的徽章） */
+function workerStatusMeta(
+  status: string,
+  c: { info: string; warning: string; success: string; error: string; textMuted: string },
+): { label: string; color: string } {
+  switch (status) {
+    case 'qrcode_ready':
+      return { label: '等待扫码', color: c.info };
+    case 'scanning':
+      return { label: '扫码中', color: c.warning };
+    case 'verification_required':
+      return { label: '需人脸验证', color: c.warning };
+    case 'success':
+      return { label: '登录成功', color: c.success };
+    case 'failed':
+      return { label: '登录失败', color: c.error };
+    default:
+      return { label: status || '未知', color: c.textMuted };
+  }
+}
+
+/** ISO/字符串时间 → 简洁可读形式，失败则原样返回 */
+function formatTime(raw: string): string {
+  if (!raw) return '';
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getMonth() + 1}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** Unix 秒时间戳 → HH:mm */
+function formatUnix(ts: number): string {
+  if (!ts) return '';
+  const d = new Date(ts * 1000);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** 轮询间隔（毫秒），与 web 端一致 */
+const POLL_INTERVAL = 3000;
 
 export default function SharedScanScreen() {
   const scheme = useColorScheme();
   const c = colors[scheme === 'dark' ? 'dark' : 'light'];
-  const [sessions, setSessions] = useState<ScanSession[]>([]);
+
+  const [sessions, setSessions] = useState<SharedScanSession[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  // 展开查看兼职状态的会话
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [workers, setWorkers] = useState<SharedScanWorkerInfo[]>([]);
+  const [workersLoading, setWorkersLoading] = useState(false);
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimer.current) {
+      clearInterval(pollTimer.current);
+      pollTimer.current = null;
+    }
+  }, []);
+
+  const fetchWorkers = useCallback(async (sessionId: string, showLoading = false) => {
+    if (showLoading) setWorkersLoading(true);
+    try {
+      const status = await getSharedSessionStatus(sessionId);
+      setWorkers(status.part_time_workers);
+    } catch {
+      // 轮询失败静默，不打断刷新
+    } finally {
+      if (showLoading) setWorkersLoading(false);
+    }
+  }, []);
 
   const load = useCallback(async () => {
     try {
       setRefreshing(true);
-      const client = await getApiClient();
-      const { data } = (await (client.GET as any)('/api/v1/shared-scan/list')) as {
-        data?: ScanSession[]; error?: unknown;
-      };
-      setSessions(data ?? []);
-    } catch (e) { console.error(e); }
-    finally { setLoading(false); setRefreshing(false); }
+      setSessions(await listSharedSessions());
+    } catch (e) {
+      Alert.alert('加载失败', (e as Error).message);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
   }, []);
 
   useEffect(() => { load(); }, [load]);
 
+  /** 展开某会话的兼职状态面板，并开始轮询 */
+  const openWorkers = useCallback(
+    (sessionId: string) => {
+      stopPolling();
+      setActiveId(sessionId);
+      setWorkers([]);
+      fetchWorkers(sessionId, true);
+      pollTimer.current = setInterval(() => fetchWorkers(sessionId), POLL_INTERVAL);
+    },
+    [stopPolling, fetchWorkers],
+  );
+
+  const closeWorkers = useCallback(() => {
+    stopPolling();
+    setActiveId(null);
+    setWorkers([]);
+  }, [stopPolling]);
+
+  // 卸载时清理轮询
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const toggleWorkers = useCallback(
+    (sessionId: string) => {
+      if (activeId === sessionId) closeWorkers();
+      else openWorkers(sessionId);
+    },
+    [activeId, closeWorkers, openWorkers],
+  );
+
   async function handleCreate() {
+    setCreating(true);
     try {
-      const client = await getApiClient();
-      const { data, error } = (await (client.POST as any)('/api/v1/shared-scan/create')) as {
-        data?: { session_id: string }; error?: unknown;
-      };
-      if (error) throw error;
-      Alert.alert('成功', `已创建共享扫码会话: ${data?.session_id}`);
+      const created = await createSharedSession();
       await load();
-    } catch (e) { Alert.alert('创建失败', (e as Error).message); }
+      if (created.session_id) openWorkers(created.session_id);
+      Alert.alert('创建成功', '会话已创建，复制链接发给兼职即可扫码登录', [
+        { text: '复制链接', onPress: () => copyLink(created.share_url) },
+        { text: '完成', style: 'cancel' },
+      ]);
+    } catch (e) {
+      Alert.alert('创建失败', (e as Error).message);
+    } finally {
+      setCreating(false);
+    }
   }
 
-  async function handleDelete(sessionId: string) {
-    Alert.alert('确认删除', `删除会话 ${sessionId}？`, [
-      { text: '取消' },
-      { text: '删除', onPress: async () => {
-        try {
-          const client = await getApiClient();
-          await (client.DELETE as any)(`/api/v1/shared-scan/${sessionId}`);
-          await load();
-        } catch (e) { Alert.alert('删除失败', (e as Error).message); }
-      } },
+  async function copyLink(url: string) {
+    if (!url) {
+      Alert.alert('复制失败', '分享链接为空，请刷新列表后重试');
+      return;
+    }
+    try {
+      await Clipboard.setStringAsync(url);
+      Alert.alert('已复制', '分享链接已复制到剪贴板，发给兼职即可');
+    } catch {
+      Alert.alert('复制失败', '请手动复制：' + url);
+    }
+  }
+
+  function handleDelete(session: SharedScanSession) {
+    Alert.alert('确认删除', `删除会话 ${session.session_id.slice(0, 8)}…？该会话下 ${session.worker_count} 条兼职记录将一并删除。`, [
+      { text: '取消', style: 'cancel' },
+      {
+        text: '删除', style: 'destructive', onPress: async () => {
+          try {
+            await deleteSharedSession(session.session_id);
+            if (activeId === session.session_id) closeWorkers();
+            await load();
+          } catch (e) { Alert.alert('删除失败', (e as Error).message); }
+        },
+      },
     ]);
   }
 
   if (loading) {
-    return (<SafeAreaView style={[styles.container, { backgroundColor: c.background }]}><Loading label="加载..." /></SafeAreaView>);
+    return (<SafeAreaView style={[styles.container, { backgroundColor: c.background }]}><Loading label="加载共享会话..." /></SafeAreaView>);
   }
+
+  const stats = {
+    total: workers.length,
+    waiting: workers.filter((w) => w.status === 'qrcode_ready').length,
+    scanning: workers.filter((w) => w.status === 'scanning').length,
+    success: workers.filter((w) => w.status === 'success').length,
+  };
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.background }]} edges={['left', 'right', 'bottom']}>
       <View style={styles.header}>
-        <Button label="创建会话" onPress={handleCreate} variant="secondary" />
+        <Text style={[styles.headerHint, { color: c.textMuted }]}>创建会话并把链接发给兼职，各自独立扫码</Text>
+        <Button label="创建会话" onPress={handleCreate} loading={creating} style={styles.createBtn} />
       </View>
+
       <FlatList
-        data={sessions} keyExtractor={(item) => item.session_id}
+        data={sessions}
+        keyExtractor={(item) => item.session_id}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={load} />}
-        renderItem={({ item }) => (
-          <Card style={styles.card}>
-            <Text style={[styles.sessionId, { color: c.text }]} numberOfLines={1}>{item.session_id}</Text>
-            <View style={styles.cardRow}>
-              <Text style={[styles.status, { color: item.status === 'active' ? c.success : c.textMuted }]}>{item.status}</Text>
-              <Text style={[styles.time, { color: c.textMuted }]}>{item.created_at}</Text>
-            </View>
-            <Button label="删除" variant="danger" onPress={() => handleDelete(item.session_id)} style={styles.btn} />
-          </Card>
-        )}
-        ListEmptyComponent={<View style={styles.empty}><Text style={[styles.emptyText, { color: c.textMuted }]}>暂无共享扫码会话</Text></View>}
+        renderItem={({ item }) => {
+          const expanded = activeId === item.session_id;
+          return (
+            <Card style={styles.card}>
+              <Pressable onPress={() => toggleWorkers(item.session_id)} style={styles.cardTop}>
+                <View style={styles.sessionInfo}>
+                  <Text style={[styles.sessionId, { color: c.text }]} numberOfLines={1}>
+                    {item.session_id.slice(0, 8)}…
+                  </Text>
+                  <View style={[styles.sessionBadge, { backgroundColor: item.status === 'active' ? c.info : c.textMuted }]}>
+                    <Text style={styles.badgeText}>{item.status === 'active' ? '进行中' : item.status}</Text>
+                  </View>
+                </View>
+                <Text style={[styles.sessionStats, { color: c.textMuted }]}>
+                  {item.worker_count} 名兼职 · {item.success_count} 人成功
+                </Text>
+                <Text style={[styles.sessionTime, { color: c.textMuted }]}>
+                  创建 {formatTime(item.created_at)}{item.expires_at ? ` · ${formatTime(item.expires_at)} 过期` : ''}
+                </Text>
+              </Pressable>
+
+              <View style={styles.cardActions}>
+                <Button label="复制链接" variant="secondary" onPress={() => copyLink(item.share_url)} style={styles.actionBtn} />
+                <Button
+                  label={expanded ? '收起状态' : '查看兼职'}
+                  variant="ghost"
+                  onPress={() => toggleWorkers(item.session_id)}
+                  style={styles.actionBtn}
+                />
+                <Button label="删除" variant="danger" onPress={() => handleDelete(item)} style={styles.actionBtn} />
+              </View>
+
+              {expanded && (
+                <View style={[styles.workersWrap, { borderTopColor: c.border, borderTopWidth: 1 }]}>
+                  <View style={styles.workersHeader}>
+                    <Text style={[styles.workersStats, { color: c.textSecondary }]}>
+                      共 {stats.total} 人 · 等待 {stats.waiting} · 扫码中 {stats.scanning} · 成功 {stats.success}
+                    </Text>
+                    <Pressable onPress={() => fetchWorkers(item.session_id, true)} hitSlop={8}>
+                      <Text style={[styles.refreshText, { color: c.primary }]}>刷新</Text>
+                    </Pressable>
+                  </View>
+                  {workersLoading && workers.length === 0 ? (
+                    <Text style={[styles.hint, { color: c.textMuted }]}>加载兼职状态...</Text>
+                  ) : workers.length === 0 ? (
+                    <Text style={[styles.hint, { color: c.textMuted }]}>
+                      暂无兼职加入，将分享链接发给兼职后，每 3 秒自动刷新状态
+                    </Text>
+                  ) : (
+                    workers.map((w) => {
+                      const meta = workerStatusMeta(w.status, c);
+                      return (
+                        <View key={w.sub_session_id} style={[styles.workerRow, { borderBottomColor: c.border }]}>
+                          <View style={styles.workerTexts}>
+                            <Text style={[styles.workerId, { color: c.text }]} numberOfLines={1}>
+                              {w.sub_session_id.slice(0, 8)}…
+                            </Text>
+                            <Text style={[styles.workerSub, { color: c.textMuted }]} numberOfLines={1}>
+                              {w.joined_at ? `加入 ${formatUnix(w.joined_at)}` : ''}
+                              {w.account_id ? ` · 账号 ${w.account_id}` : ''}
+                            </Text>
+                          </View>
+                          <View style={[styles.workerBadge, { backgroundColor: meta.color }]}>
+                            <Text style={styles.badgeText}>{meta.label}</Text>
+                          </View>
+                        </View>
+                      );
+                    })
+                  )}
+                </View>
+              )}
+            </Card>
+          );
+        }}
+        ListEmptyComponent={
+          <EmptyState
+            icon={ScanLine}
+            title="暂无共享会话"
+            message="创建会话后将链接发给多个兼职，各自独立扫码登录闲鱼账号"
+            actionLabel="创建会话"
+            onAction={handleCreate}
+          />
+        }
         contentContainerStyle={styles.list}
       />
     </SafeAreaView>
@@ -85,14 +300,34 @@ export default function SharedScanScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: spacing.lg, paddingVertical: spacing.md },
-  list: { padding: spacing.lg, gap: spacing.md },
+  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: spacing.lg, paddingVertical: spacing.md, gap: spacing.md },
+  headerHint: { ...typography.small, flex: 1 },
+  createBtn: { minHeight: 40, paddingHorizontal: spacing.md },
+  list: { padding: spacing.lg, paddingTop: 0, gap: spacing.md, paddingBottom: 80 },
   card: { gap: spacing.sm },
+  cardTop: { gap: spacing.xs },
+  sessionInfo: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   sessionId: { ...typography.body, fontWeight: '600' },
-  cardRow: { flexDirection: 'row', justifyContent: 'space-between' },
-  status: { ...typography.caption, fontWeight: '600' },
-  time: { ...typography.small },
-  btn: { minHeight: 36, marginTop: spacing.xs },
-  empty: { alignItems: 'center', paddingVertical: 28 },
-  emptyText: { ...typography.body },
+  sessionBadge: { paddingHorizontal: spacing.sm, paddingVertical: 2, borderRadius: 4 },
+  sessionStats: { ...typography.caption },
+  sessionTime: { ...typography.small },
+  cardActions: { flexDirection: 'row', gap: spacing.sm },
+  actionBtn: { flex: 1, minHeight: 38 },
+  workersWrap: { paddingTop: spacing.sm, marginTop: spacing.xs, gap: spacing.sm },
+  workersHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  workersStats: { ...typography.small, flex: 1, marginRight: spacing.sm },
+  refreshText: { ...typography.small, fontWeight: '600' },
+  workerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  workerTexts: { flex: 1, marginRight: spacing.sm, gap: 2 },
+  workerId: { ...typography.caption, fontWeight: '600' },
+  workerSub: { ...typography.small },
+  workerBadge: { paddingHorizontal: spacing.sm, paddingVertical: 2, borderRadius: radius.sm },
+  badgeText: { ...typography.small, fontWeight: '600', color: '#FFF' },
+  hint: { ...typography.small },
 });

--- a/xianyu-mobile/app/(tabs)/orders/index.tsx
+++ b/xianyu-mobile/app/(tabs)/orders/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -26,6 +26,7 @@ import {
   getOrderDetail,
   deleteOrder,
   fetchXianyuOrders,
+  batchDeleteOrders,
   getAutoRateConfig,
   updateAutoRateConfig,
   batchRate,
@@ -33,6 +34,7 @@ import {
   updateConfirmReceiptConfig,
   type Order,
   type OrderDetail,
+  type FetchXianyuStats,
   type AutoRateConfig,
   type ConfirmReceiptConfig,
 } from '@/api/wrappers/orders-tab';
@@ -43,6 +45,12 @@ import { useAccountsStore } from '@/stores/accounts';
 import { usePagedList } from '@/hooks/usePagedList';
 
 const PAGE_SIZE = 20;
+/** 搜索/筛选草稿 → 生效的防抖间隔 */
+const FILTER_DEBOUNCE_MS = 450;
+/** 单账号同步超时 */
+const SYNC_ONE_TIMEOUT_MS = 120000;
+/** 全账号同步超时（账号多时明显更久，对齐 web 的 10 分钟） */
+const SYNC_ALL_TIMEOUT_MS = 600000;
 
 /** 把细粒度订单状态归并为筛选 tab 分组 */
 function groupStatus(status: string): string {
@@ -64,6 +72,79 @@ const STATUS_TABS = [
   { key: 'other', label: '其他' },
 ];
 
+/** 发货方式服务端筛选 chips（key 对应后端 delivery_method 取值） */
+const DELIVERY_FILTERS = [
+  { key: '', label: '全部' },
+  { key: 'none', label: '未发货' },
+  { key: 'manual', label: '手动发货' },
+  { key: 'auto', label: '自动发货' },
+  { key: 'scheduled', label: '定时发货' },
+];
+
+/** 服务端筛选的生效值（防抖后提交给 getOrders 的那一份） */
+interface AppliedFilters {
+  accountId: string;
+  search: string;
+  delivery: string;
+  startDate: string;
+  endDate: string;
+}
+
+const INITIAL_FILTERS: AppliedFilters = {
+  accountId: '',
+  search: '',
+  delivery: '',
+  startDate: '',
+  endDate: '',
+};
+
+/** 拼同步统计摘要：获取/新增/更新（+失败） */
+function syncStatsSummary(stats: FetchXianyuStats): string {
+  let s = `获取 ${stats.total_fetched} 条，新增 ${stats.new_inserted} 条，更新 ${stats.updated} 条`;
+  if (stats.failed > 0) s += `，失败 ${stats.failed} 条`;
+  return s;
+}
+
+/** 拼失败账号提示（最多展示 2 条，避免 Alert 过长） */
+function syncErrorsText(stats: FetchXianyuStats): string {
+  if (stats.errors.length === 0) return '';
+  const head = stats.errors.slice(0, 2).join('；');
+  return `\n失败账号：${head}${stats.errors.length > 2 ? ' 等' : ''}`;
+}
+
+/** 通用筛选 chip（账号/发货方式共用样式，与自动化设置弹窗一致） */
+function FilterChip({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  const scheme = useColorScheme();
+  const c = colors[scheme === 'dark' ? 'dark' : 'light'];
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.chip,
+        {
+          borderColor: active ? c.primary : c.border,
+          backgroundColor: active ? c.primaryLight : 'transparent',
+        },
+      ]}
+    >
+      <Text
+        style={[styles.chipText, { color: active ? c.primary : c.textSecondary }]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
 /** 发货方式 → 中文文案（与 web statusMap 口径一致） */
 function deliveryMethodText(m?: string): string {
   if (!m) return '未发货';
@@ -82,12 +163,86 @@ function sendStatusText(s?: string | null): string {
   return '待确认';
 }
 
+/**
+ * 订单卡片主体（普通模式与多选模式共用）。
+ * selected 传 undefined 表示非多选态（不渲染勾选框），传 boolean 表示多选态。
+ */
+function OrderCardBody({ item, selected }: { item: Order; selected?: boolean }) {
+  const scheme = useColorScheme();
+  const dark = scheme === 'dark';
+  const c: ThemeColors = colors[dark ? 'dark' : 'light'];
+  const meta = getStatusMeta(item.status);
+  const tc = toneColors(meta.tone, dark);
+  return (
+    <Card style={[styles.orderCard, selected === true && { borderColor: c.primary }]}>
+      <View style={styles.titleRow}>
+        {selected !== undefined ? (
+          <View
+            style={[
+              styles.checkbox,
+              {
+                borderColor: selected ? c.primary : c.border,
+                backgroundColor: selected ? c.primary : 'transparent',
+              },
+            ]}
+          >
+            {selected ? <Text style={styles.checkboxCheck}>✓</Text> : null}
+          </View>
+        ) : null}
+        <Text
+          style={[styles.title, { color: c.text, flex: 1 }]}
+          numberOfLines={2}
+        >
+          {item.item_title || '未命名商品'}
+        </Text>
+        <View style={[styles.tag, { backgroundColor: tc.bg }]}>
+          <Text style={[styles.tagText, { color: tc.fg }]}>{meta.label}</Text>
+        </View>
+      </View>
+      <View style={styles.metaRow}>
+        <Text style={[styles.amount, { color: c.warning }]}>
+          ¥{item.amount || '--'}
+        </Text>
+        <Text style={[styles.qty, { color: c.textSecondary }]}>
+          ×{item.quantity}
+        </Text>
+        {item.placed_at ? (
+          <Text style={[styles.subText, { color: c.textMuted }]}>
+            {formatDateTime(item.placed_at)}
+          </Text>
+        ) : null}
+      </View>
+      <View style={styles.subRow}>
+        <Text
+          style={[styles.subText, { color: c.textMuted }]}
+          numberOfLines={1}
+        >
+          买家：{item.buyer_nick || item.buyer_id || '--'}
+        </Text>
+        <Text style={[styles.orderNo, { color: c.textMuted }]} numberOfLines={1}>
+          {item.order_no}
+        </Text>
+      </View>
+    </Card>
+  );
+}
+
 // ---------------------------------------------------------------------------
 
 export default function OrdersPage() {
   const scheme = useColorScheme();
   const dark = scheme === 'dark';
   const c: ThemeColors = colors[dark ? 'dark' : 'light'];
+
+  // 服务端筛选：草稿输入值（即时响应用户输入）
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterAccountId, setFilterAccountId] = useState('');
+  const [filterDelivery, setFilterDelivery] = useState('');
+  const [filterStartDate, setFilterStartDate] = useState('');
+  const [filterEndDate, setFilterEndDate] = useState('');
+  const [filtersExpanded, setFiltersExpanded] = useState(false);
+  // 防抖后的生效值：真正传给 getOrders 的那一份
+  const [appliedFilters, setAppliedFilters] = useState<AppliedFilters>(INITIAL_FILTERS);
 
   // 订单列表（page 分页）：翻页/竞态序号/跨页去重/hasMore 收口均在 usePagedList 内部处理
   const {
@@ -102,7 +257,13 @@ export default function OrdersPage() {
     pageSize: PAGE_SIZE,
     dedupeBy: (o) => o.order_no,
     fetchPage: async ({ page = 1, limit = PAGE_SIZE }) => {
-      const resp = await getOrders(page, limit);
+      const resp = await getOrders(page, limit, {
+        cookieId: appliedFilters.accountId || undefined,
+        search: appliedFilters.search || undefined,
+        deliveryMethod: appliedFilters.delivery || undefined,
+        startDate: appliedFilters.startDate || undefined,
+        endDate: appliedFilters.endDate || undefined,
+      });
       return { items: resp.data, total: resp.total };
     },
     onError: (e, phase) => {
@@ -111,28 +272,140 @@ export default function OrdersPage() {
     },
   });
 
-  // 状态筛选 + 搜索（客户端过滤当前已加载订单）
+  // 草稿 → 防抖 → 生效（450ms 内连续输入只发一次请求）
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setAppliedFilters((prev) => {
+        const next: AppliedFilters = {
+          accountId: filterAccountId,
+          search: searchQuery.trim(),
+          delivery: filterDelivery,
+          startDate: filterStartDate.trim(),
+          endDate: filterEndDate.trim(),
+        };
+        const same =
+          prev.accountId === next.accountId &&
+          prev.search === next.search &&
+          prev.delivery === next.delivery &&
+          prev.startDate === next.startDate &&
+          prev.endDate === next.endDate;
+        return same ? prev : next;
+      });
+    }, FILTER_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [filterAccountId, searchQuery, filterDelivery, filterStartDate, filterEndDate]);
+
+  // 筛选生效后回第 1 页重新拉取。首跑（初始空筛选）跳过，交给 usePagedList 挂载首载
+  const filterRunSeqRef = useRef(0);
+  const appliedKey = `${appliedFilters.accountId}|${appliedFilters.search}|${appliedFilters.delivery}|${appliedFilters.startDate}|${appliedFilters.endDate}`;
+  useEffect(() => {
+    filterRunSeqRef.current += 1;
+    if (filterRunSeqRef.current === 1) return;
+    refreshOrders();
+  }, [appliedKey, refreshOrders]);
+
+  // 状态筛选（客户端按 tab 分组过滤当前已加载订单，保留原能力；搜索已上移到服务端）
   const [statusFilter, setStatusFilter] = useState('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const filteredOrders = orders.filter((o) => {
-    const byStatus = statusFilter === 'all' || groupStatus(o.status) === statusFilter;
-    const q = searchQuery.trim();
-    const bySearch = !q || o.order_no.includes(q) || (o.item_title || '').includes(q) || (o.buyer_nick || o.buyer_id || '').includes(q);
-    return byStatus && bySearch;
-  });
+  const filteredOrders = orders.filter(
+    (o) => statusFilter === 'all' || groupStatus(o.status) === statusFilter,
+  );
+
+  // 多选批量删除
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [batchDeleting, setBatchDeleting] = useState(false);
+
+  const enterSelectMode = useCallback((firstId: string) => {
+    if (!firstId) return;
+    setSelectMode(true);
+    setSelectedIds(new Set([firstId]));
+  }, []);
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }, []);
+
+  const toggleSelect = useCallback((id: string) => {
+    if (!id) return;
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const allSelected =
+    filteredOrders.length > 0 &&
+    filteredOrders.every((o) => !o.id || selectedIds.has(o.id));
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(
+        new Set(filteredOrders.map((o) => o.id).filter(Boolean)),
+      );
+    }
+  };
+
+  const doBatchDelete = useCallback(() => {
+    const ids = Array.from(selectedIds).filter(Boolean);
+    if (ids.length === 0) return;
+    Alert.alert(
+      '批量删除确认',
+      `确定删除选中的 ${ids.length} 个订单吗？删除后无法恢复。`,
+      [
+        { text: '取消', style: 'cancel' },
+        {
+          text: '删除',
+          style: 'destructive',
+          onPress: async () => {
+            setBatchDeleting(true);
+            try {
+              const res = await batchDeleteOrders(ids);
+              Alert.alert(
+                '删除完成',
+                res.message || `成功 ${res.deleted} 条，失败 ${res.failed} 条`,
+              );
+              exitSelectMode();
+              await refreshOrders();
+            } catch (e) {
+              Alert.alert('批量删除失败', (e as Error).message);
+            } finally {
+              setBatchDeleting(false);
+            }
+          },
+        },
+      ],
+      { cancelable: true },
+    );
+  }, [selectedIds, exitSelectMode, refreshOrders]);
 
   // 订单详情弹窗
   const [detailVisible, setDetailVisible] = useState(false);
   const [detail, setDetail] = useState<OrderDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
 
-  // 账号列表（用于同步与设置）
+  // 账号列表（用于筛选栏、同步与设置）
   const accounts = useAccountsStore((s) => s.options);
   const loadAccountOptions = useAccountsStore((s) => s.load);
+
+  // 挂载时预取账号（筛选栏 chips 需要；TTL 内复用缓存，不重复请求）
+  useEffect(() => {
+    loadAccountOptions().catch(() => {
+      // 静默失败：筛选栏退化为只有「全部账号」，同步入口会再次尝试加载
+    });
+  }, [loadAccountOptions]);
 
   // 同步闲鱼订单
   const [syncPickerVisible, setSyncPickerVisible] = useState(false);
   const [syncing, setSyncing] = useState(false);
+  const [syncScopeAll, setSyncScopeAll] = useState(false);
   // 同步代际 token：取消时自增使在途作废（per-invocation generation，替代共享布尔）
   const syncGenRef = useRef(0);
 
@@ -174,7 +447,45 @@ export default function OrdersPage() {
     }
   }, []);
 
-  // ---- 同步闲鱼订单 ----
+  // ---- 同步闲鱼订单（单账号 / 全部账号共用，完成后展示统计）----
+  const runSync = useCallback(
+    async (scopeAll: boolean, account: AccountOption | null) => {
+      setSyncPickerVisible(false);
+      setSyncing(true);
+      setSyncScopeAll(scopeAll);
+      // 代际 token：取消时自增使在途作废，避免"取消→立即重 Sync"时旧请求弹 Alert 或提前关遮罩
+      const myGen = ++syncGenRef.current;
+      try {
+        const task = scopeAll
+          ? fetchXianyuOrders(undefined)
+          : fetchXianyuOrders(account!.id);
+        // 账号离线时后端会阻塞：单账号 120s、全部账号 600s 超时兜底
+        const stats = await withTimeout(
+          task,
+          scopeAll ? SYNC_ALL_TIMEOUT_MS : SYNC_ONE_TIMEOUT_MS,
+          '同步超时，请确认账号在线后重试',
+        );
+        if (syncGenRef.current !== myGen) return; // 已被取消或被新同步取代
+        const summary = syncStatsSummary(stats);
+        const errText = syncErrorsText(stats);
+        Alert.alert(
+          scopeAll ? '同步全部完成' : '同步完成',
+          scopeAll
+            ? `共处理 ${stats.accounts_processed} 个账号：${summary}${errText}`
+            : `账号「${account!.remark || account!.id}」：${summary}${errText}`,
+        );
+        await refreshOrders();
+      } catch (e) {
+        if (syncGenRef.current !== myGen) return;
+        Alert.alert('同步失败', (e as Error).message);
+      } finally {
+        // 仅当前代才动 syncing 状态，避免把新同步的遮罩提前关闭
+        if (syncGenRef.current === myGen) setSyncing(false);
+      }
+    },
+    [refreshOrders],
+  );
+
   const openSync = useCallback(async () => {
     try {
       await loadAccountOptions();
@@ -190,34 +501,31 @@ export default function OrdersPage() {
   }, [loadAccountOptions]);
 
   const doSync = useCallback(
-    async (account: AccountOption) => {
-      setSyncPickerVisible(false);
-      setSyncing(true);
-      // 代际 token：取消时自增使在途作废，避免"取消→立即重 Sync"时旧请求弹 Alert 或提前关遮罩
-      const myGen = ++syncGenRef.current;
-      try {
-        // 120s 超时：账号离线时后端会阻塞，避免无限转圈且模态无法关闭
-        await withTimeout(
-          fetchXianyuOrders(account.id),
-          120000,
-          '同步超时，请确认账号在线后重试',
-        );
-        if (syncGenRef.current !== myGen) return; // 已被取消或被新同步取代
-        Alert.alert(
-          '同步成功',
-          `已同步账号「${account.remark || account.id}」的闲鱼订单`,
-        );
-        await refreshOrders();
-      } catch (e) {
-        if (syncGenRef.current !== myGen) return;
-        Alert.alert('同步失败', (e as Error).message);
-      } finally {
-        // 仅当前代才动 syncing 状态，避免把新同步的遮罩提前关闭
-        if (syncGenRef.current === myGen) setSyncing(false);
-      }
+    (account: AccountOption) => {
+      runSync(false, account);
     },
-    [refreshOrders],
+    [runSync],
   );
+
+  const doSyncAll = useCallback(() => {
+    runSync(true, null);
+  }, [runSync]);
+
+  // ---- 筛选重置 ----
+  const resetFilters = useCallback(() => {
+    setSearchQuery('');
+    setFilterAccountId('');
+    setFilterDelivery('');
+    setFilterStartDate('');
+    setFilterEndDate('');
+  }, []);
+
+  const activeFilterCount = [
+    filterAccountId,
+    filterDelivery,
+    filterStartDate.trim(),
+    filterEndDate.trim(),
+  ].filter(Boolean).length;
 
   // ---- 自动化设置 ----
   const loadSettingsConfig = useCallback(
@@ -338,8 +646,16 @@ export default function OrdersPage() {
   // ---- 渲染订单项（useCallback 避免每次渲染重建导致 FlatList 全量重渲染）----
   const renderItem = useCallback(
     ({ item }: { item: Order }) => {
-      const meta = getStatusMeta(item.status);
-      const tc = toneColors(meta.tone, dark);
+      // 多选模式：整卡可点切换勾选，不再提供滑动操作
+      if (selectMode) {
+        const selected = !!item.id && selectedIds.has(item.id);
+        return (
+          <Pressable onPress={() => toggleSelect(item.id)}>
+            <OrderCardBody item={item} selected={selected} />
+          </Pressable>
+        );
+      }
+
       // 发货守卫：已发货/已完成/卡券已发送时禁用（灰色 + 不可点）
       const deliveryDisabled =
         item.status === 'shipped' ||
@@ -361,15 +677,29 @@ export default function OrdersPage() {
               label: '手动发货',
               bg: deliveryDisabled ? c.surfaceAlt : c.info,
               fg: deliveryDisabled ? c.textMuted : '#FFFFFF',
-              onPress: async () => {
+              onPress: () => {
                 if (deliveryDisabled) return; // 当前状态不可发货
-                try {
-                  await manualDelivery(item.order_no);
-                  Alert.alert('发货成功', `订单 ${item.order_no} 已手动发货`);
-                  refreshOrders();
-                } catch (e) {
-                  Alert.alert('发货失败', (e as Error).message);
-                }
+                // 二次确认：手动发货会真实发送卡券给买家，误触代价高
+                Alert.alert(
+                  '手动发货确认',
+                  `确定对订单 ${item.order_no} 手动发货吗？发货后会向买家发送卡券内容。`,
+                  [
+                    { text: '取消', style: 'cancel' },
+                    {
+                      text: '确认发货',
+                      onPress: async () => {
+                        try {
+                          await manualDelivery(item.order_no);
+                          Alert.alert('发货成功', `订单 ${item.order_no} 已手动发货`);
+                          refreshOrders();
+                        } catch (e) {
+                          Alert.alert('发货失败', (e as Error).message);
+                        }
+                      },
+                    },
+                  ],
+                  { cancelable: true },
+                );
               },
             },
             {
@@ -440,47 +770,17 @@ export default function OrdersPage() {
             { label: '详情', bg: c.primary, onPress: () => openDetail(item.order_no) },
           ]}
         >
-          <Card style={styles.orderCard}>
-            <View style={styles.titleRow}>
-              <Text
-                style={[styles.title, { color: c.text, flex: 1 }]}
-                numberOfLines={2}
-              >
-                {item.item_title || '未命名商品'}
-              </Text>
-              <View style={[styles.tag, { backgroundColor: tc.bg }]}>
-                <Text style={[styles.tagText, { color: tc.fg }]}>{meta.label}</Text>
-              </View>
-            </View>
-            <View style={styles.metaRow}>
-              <Text style={[styles.amount, { color: c.warning }]}>
-                ¥{item.amount || '--'}
-              </Text>
-              <Text style={[styles.qty, { color: c.textSecondary }]}>
-                ×{item.quantity}
-              </Text>
-              {item.placed_at ? (
-                <Text style={[styles.subText, { color: c.textMuted }]}>
-                  {formatDateTime(item.placed_at)}
-                </Text>
-              ) : null}
-            </View>
-            <View style={styles.subRow}>
-              <Text
-                style={[styles.subText, { color: c.textMuted }]}
-                numberOfLines={1}
-              >
-                买家：{item.buyer_nick || item.buyer_id || '--'}
-              </Text>
-              <Text style={[styles.orderNo, { color: c.textMuted }]} numberOfLines={1}>
-                {item.order_no}
-              </Text>
-            </View>
-          </Card>
+          {/* 内层 Pressable 只处理长按（进入多选）；普通点击仍穿透交给外层打开详情 */}
+          <Pressable
+            onLongPress={() => enterSelectMode(item.id)}
+            delayLongPress={400}
+          >
+            <OrderCardBody item={item} />
+          </Pressable>
         </SwipeableRow>
       );
     },
-    [openDetail, refreshOrders, c.text, c.error, c.info, c.surfaceAlt, c.textSecondary, c.textMuted, c.warning, c.primary, dark],
+    [selectMode, selectedIds, toggleSelect, enterSelectMode, openDetail, refreshOrders, c.text, c.error, c.info, c.surfaceAlt, c.textSecondary, c.textMuted, c.warning, c.primary, dark],
   );
 
   if (loading) {
@@ -501,7 +801,7 @@ export default function OrdersPage() {
         </View>
       </View>
 
-      {/* 搜索栏 */}
+      {/* 搜索栏（服务端搜索，防抖后生效） */}
       <View style={[styles.searchBar, { backgroundColor: c.surface, borderBottomColor: c.border }]}>
         <Search size={16} stroke={c.textMuted} />
         <TextInput
@@ -516,10 +816,142 @@ export default function OrdersPage() {
             <Text style={{ color: c.textMuted, fontSize: 18 }}>×</Text>
           </Pressable>
         ) : null}
+        <Pressable
+          onPress={() => setFiltersExpanded((v) => !v)}
+          hitSlop={8}
+          style={styles.filterToggle}
+        >
+          <Text
+            style={[
+              styles.filterToggleText,
+              { color: activeFilterCount > 0 ? c.primary : c.textSecondary },
+            ]}
+          >
+            筛选{activeFilterCount > 0 ? `(${activeFilterCount})` : ''}
+          </Text>
+        </Pressable>
       </View>
+
+      {/* 高级筛选面板：账号 / 发货方式 / 日期范围（均为服务端筛选） */}
+      {filtersExpanded ? (
+        <View
+          style={[
+            styles.filterPanel,
+            { backgroundColor: c.surface, borderBottomColor: c.border },
+          ]}
+        >
+          <Text style={[styles.filterLabel, { color: c.textSecondary }]}>账号</Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.chipsScroll}
+          >
+            <FilterChip
+              label="全部账号"
+              active={filterAccountId === ''}
+              onPress={() => setFilterAccountId('')}
+            />
+            {accounts.map((a) => (
+              <FilterChip
+                key={a.id}
+                label={a.remark || a.id}
+                active={filterAccountId === a.id}
+                onPress={() =>
+                  setFilterAccountId((prev) => (prev === a.id ? '' : a.id))
+                }
+              />
+            ))}
+          </ScrollView>
+
+          <Text style={[styles.filterLabel, { color: c.textSecondary }]}>
+            发货方式
+          </Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.chipsScroll}
+          >
+            {DELIVERY_FILTERS.map((t) => (
+              <FilterChip
+                key={t.key}
+                label={t.label}
+                active={filterDelivery === t.key}
+                onPress={() => setFilterDelivery(t.key)}
+              />
+            ))}
+          </ScrollView>
+
+          <Text style={[styles.filterLabel, { color: c.textSecondary }]}>
+            日期范围（YYYY-MM-DD）
+          </Text>
+          <View style={styles.dateRow}>
+            <Input
+              value={filterStartDate}
+              onChangeText={setFilterStartDate}
+              placeholder="开始 2026-01-01"
+              maxLength={10}
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={styles.dateInput}
+            />
+            <Text style={[styles.dateDivider, { color: c.textMuted }]}>至</Text>
+            <Input
+              value={filterEndDate}
+              onChangeText={setFilterEndDate}
+              placeholder="结束 2026-12-31"
+              maxLength={10}
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={styles.dateInput}
+            />
+          </View>
+
+          {activeFilterCount > 0 || searchQuery ? (
+            <Pressable onPress={resetFilters} hitSlop={8} style={styles.resetBtn}>
+              <Text style={[styles.resetBtnText, { color: c.error }]}>
+                重置全部筛选
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
 
       {/* 状态筛选 */}
       <FilterTabs tabs={STATUS_TABS} active={statusFilter} onChange={setStatusFilter} />
+
+      {/* 多选模式操作条 */}
+      {selectMode ? (
+        <View
+          style={[
+            styles.batchBar,
+            { backgroundColor: c.surface, borderBottomColor: c.border },
+          ]}
+        >
+          <Pressable onPress={exitSelectMode} hitSlop={8}>
+            <Text style={[styles.batchBarBtn, { color: c.textSecondary }]}>
+              取消
+            </Text>
+          </Pressable>
+          <Text style={[styles.batchBarText, { color: c.text }]}>
+            已选 {selectedIds.size} 项
+          </Text>
+          <View style={styles.batchBarActions}>
+            <Pressable onPress={toggleSelectAll} hitSlop={8}>
+              <Text style={[styles.batchBarBtn, { color: c.primary }]}>
+                {allSelected ? '取消全选' : '全选'}
+              </Text>
+            </Pressable>
+            <Button
+              label={`删除(${selectedIds.size})`}
+              variant="danger"
+              onPress={doBatchDelete}
+              loading={batchDeleting}
+              disabled={batchDeleting || selectedIds.size === 0}
+              style={styles.batchDeleteBtn}
+            />
+          </View>
+        </View>
+      ) : null}
 
       <FlatList
         data={filteredOrders}
@@ -777,6 +1209,26 @@ export default function OrdersPage() {
                   </Text>
                 </Pressable>
               )}
+              // 一键同步全部账号：cookie_id 留空由后端遍历所有启用账号
+              ListHeaderComponent={
+                <Pressable
+                  style={[styles.accountItem, { borderColor: c.border }]}
+                  onPress={doSyncAll}
+                >
+                  <Text
+                    style={[
+                      styles.accountItemText,
+                      { color: c.text, fontWeight: '600' },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    全部账号（一键同步）
+                  </Text>
+                  <Text style={[styles.accountAction, { color: c.primary }]}>
+                    同步
+                  </Text>
+                </Pressable>
+              }
               style={styles.accountList}
             />
           </Pressable>
@@ -789,7 +1241,7 @@ export default function OrdersPage() {
           <View style={[styles.syncCard, { backgroundColor: c.surface }]}>
             <ActivityIndicator size="large" color={c.primary} />
             <Text style={[styles.syncText, { color: c.text }]}>
-              正在同步闲鱼订单...
+              {syncScopeAll ? '正在同步全部账号的订单...' : '正在同步闲鱼订单...'}
             </Text>
             <Text style={[styles.syncHint, { color: c.textMuted }]}>
               该过程可能需要数分钟
@@ -1026,6 +1478,46 @@ const styles = StyleSheet.create({
   // 顶部搜索栏
   searchBar: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingHorizontal: 16, paddingVertical: 8, borderBottomWidth: 1 },
   searchInput: { flex: 1, fontSize: 14, paddingVertical: 4 },
+  filterToggle: { paddingHorizontal: spacing.xs },
+  filterToggleText: { ...typography.small, fontWeight: '600' },
+  // 高级筛选面板
+  filterPanel: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    gap: spacing.xs,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  filterLabel: { ...typography.caption, marginTop: spacing.xs },
+  chipsScroll: { gap: spacing.sm, paddingVertical: spacing.xs, alignItems: 'center' },
+  dateRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  dateInput: { flex: 1, minHeight: 40, paddingVertical: spacing.xs },
+  dateDivider: { ...typography.caption },
+  resetBtn: { alignSelf: 'flex-end', paddingVertical: spacing.xs, paddingHorizontal: spacing.sm },
+  resetBtnText: { ...typography.small, fontWeight: '600' },
+  // 多选操作条
+  batchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+  },
+  batchBarBtn: { ...typography.body, fontWeight: '600' },
+  batchBarText: { ...typography.body, fontWeight: '600', flex: 1 },
+  batchBarActions: { flexDirection: 'row', alignItems: 'center', gap: spacing.md },
+  batchDeleteBtn: { minHeight: 36, paddingHorizontal: spacing.md },
+  // 多选勾选框
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.sm,
+  },
+  checkboxCheck: { color: '#FFFFFF', fontSize: 13, fontWeight: '700', lineHeight: 16 },
   // 卡片首行：商品名 + 状态徽章
   titleRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm, marginBottom: 4 },
   // 底部留白避让 tab 栏，避免最后一张订单卡片被遮挡

--- a/xianyu-mobile/app/(tabs)/products/index.tsx
+++ b/xianyu-mobile/app/(tabs)/products/index.tsx
@@ -7,7 +7,6 @@ import {
   Switch,
   Pressable,
   Alert,
-  Modal,
   RefreshControl,
   ScrollView,
 } from 'react-native';
@@ -20,15 +19,10 @@ import { colors, spacing, typography, radius } from '@/lib/theme';
 import {
   getListingOverview,
   getMonitoredItems,
-  getCards,
-  createCard,
-  updateCard,
-  deleteCard,
   getDeliveryBlockRules,
   updateDeliveryBlockRules,
   type ListingOverview,
   type MonitoredItem,
-  type Card as CardType,
   type DeliveryBlockRule,
 } from '@/api/wrappers/products';
 import { useAccountsStore } from '@/stores/accounts';
@@ -327,229 +321,31 @@ function MonitorTab() {
 }
 
 // ---------------------------------------------------------------------------
-// 2. 卡券管理：列表 + 新增/编辑/删除
+// 2. 卡券管理：旧版 text-only 编辑器已下线，引导前往完整卡券管理页
 // ---------------------------------------------------------------------------
 
 function CardsTab() {
   const scheme = useColorScheme();
   const c = colors[scheme === 'dark' ? 'dark' : 'light'];
-  const [cards, setCards] = useState<CardType[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [modalVisible, setModalVisible] = useState(false);
-  // editing === null 表示新增模式
-  const [editing, setEditing] = useState<CardType | null>(null);
-  const [content, setContent] = useState('');
-  const [remark, setRemark] = useState('');
-  const [saving, setSaving] = useState(false);
-
-  const load = useCallback(async () => {
-    setRefreshing(true);
-    try {
-      const list = await getCards();
-      setCards(list);
-    } catch (e) {
-      Alert.alert('加载失败', (e as Error).message);
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  function openCreate() {
-    setEditing(null);
-    setContent('');
-    setRemark('');
-    setModalVisible(true);
-  }
-
-  function openEdit(card: CardType) {
-    setEditing(card);
-    setContent(card.content);
-    setRemark(card.remark ?? '');
-    setModalVisible(true);
-  }
-
-  function closeModal() {
-    setModalVisible(false);
-  }
-
-  async function save() {
-    const contentTrim = content.trim();
-    if (!contentTrim) {
-      Alert.alert('提示', '请输入卡券内容');
-      return;
-    }
-    setSaving(true);
-    try {
-      if (editing) {
-        await updateCard(editing.id, contentTrim, remark.trim() || undefined);
-      } else {
-        await createCard(contentTrim, remark.trim() || undefined);
-      }
-      closeModal();
-      await load();
-    } catch (e) {
-      Alert.alert('保存失败', (e as Error).message);
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  function confirmDelete(card: CardType) {
-    Alert.alert(
-      '删除卡券',
-      `确定删除「${card.remark || '此卡券'}」吗？此操作不可恢复。`,
-      [
-        { text: '取消', style: 'cancel' },
-        {
-          text: '删除',
-          style: 'destructive',
-          onPress: () => doDelete(card),
-        },
-      ],
-      { cancelable: true },
-    );
-  }
-
-  async function doDelete(card: CardType) {
-    try {
-      await deleteCard(card.id);
-      setCards((prev) => prev.filter((x) => x.id !== card.id));
-    } catch (e) {
-      Alert.alert('删除失败', (e as Error).message);
-    }
-  }
-
-  function handleLongPress(card: CardType) {
-    Alert.alert(card.remark || '卡券', undefined, [
-      { text: '编辑', onPress: () => openEdit(card) },
-      {
-        text: '删除',
-        style: 'destructive',
-        onPress: () => confirmDelete(card),
-      },
-      { text: '取消', style: 'cancel' },
-    ]);
-  }
-
-  if (loading) return <Loading label="加载卡券..." />;
-
+  const router = useRouter();
   return (
-    <>
-      <View style={styles.subHeader}>
-        <Text style={[styles.subTitle, { color: c.text }]}>
-          共 {cards.length} 张
+    <View style={styles.guideWrap}>
+      <Card style={styles.guideCard}>
+        <View style={[styles.guideIcon, { backgroundColor: c.primaryLight }]}>
+          <Ticket color={c.primary} size={26} />
+        </View>
+        <Text style={[styles.guideTitle, { color: c.text }]}>卡券管理已升级</Text>
+        <Text style={[styles.guideDesc, { color: c.textMuted }]}>
+          此处为旧版入口（仅支持固定文字卡券），已停止维护。请前往完整的卡券管理页，支持固定文字
+          / 批量数据 / API接口 / 图片四种类型，以及关联商品、复制、批量删除、服务端搜索等功能。
         </Text>
-        <Button label="+ 新增卡券" onPress={openCreate} variant="secondary" />
-      </View>
-
-      <FlatList
-        data={cards}
-        keyExtractor={(item) => String(item.id)}
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={load} />
-        }
-        renderItem={({ item }) => (
-          <Pressable onLongPress={() => handleLongPress(item)}>
-            <Card style={styles.cardItem}>
-              <Text
-                style={[styles.cardContent, { color: c.text }]}
-                numberOfLines={3}
-              >
-                {item.content || '（空内容）'}
-              </Text>
-              {item.remark ? (
-                <Text
-                  style={[styles.cardRemark, { color: c.textMuted }]}
-                  numberOfLines={1}
-                >
-                  备注：{item.remark}
-                </Text>
-              ) : null}
-            </Card>
-          </Pressable>
-        )}
-        ListEmptyComponent={
-          <EmptyState
-            icon={Ticket}
-            title="暂无卡券"
-            message="点击右上角「+ 新增卡券」添加"
-          />
-        }
-        contentContainerStyle={styles.listContent}
-      />
-
-      {/* 新增/编辑 Modal */}
-      <Modal
-        visible={modalVisible}
-        transparent
-        animationType="fade"
-        onRequestClose={closeModal}
-      >
-        <Pressable style={styles.modalOverlay} onPress={closeModal}>
-          <Pressable
-            style={[styles.modalCard, { backgroundColor: c.surface }]}
-            onPress={() => {}}
-          >
-            <View style={styles.modalHeader}>
-              <Text style={[styles.modalTitle, { color: c.text }]}>
-                {editing ? '编辑卡券' : '新增卡券'}
-              </Text>
-              <Pressable onPress={closeModal} hitSlop={8}>
-                <Text style={[styles.closeBtn, { color: c.textMuted }]}>✕</Text>
-              </Pressable>
-            </View>
-
-            <View style={styles.fieldGroup}>
-              <Text style={[styles.fieldLabel, { color: c.textSecondary }]}>
-                内容
-              </Text>
-              <Input
-                value={content}
-                onChangeText={setContent}
-                placeholder="请输入卡券内容"
-                multiline
-                numberOfLines={4}
-                autoFocus
-              />
-            </View>
-
-            <View style={styles.fieldGroup}>
-              <Text style={[styles.fieldLabel, { color: c.textSecondary }]}>
-                备注
-              </Text>
-              <Input
-                value={remark}
-                onChangeText={setRemark}
-                placeholder="可选，备注名称"
-                maxLength={50}
-              />
-            </View>
-
-            <View style={styles.modalActions}>
-              <Button
-                label="取消"
-                variant="ghost"
-                onPress={closeModal}
-                style={styles.modalBtn}
-              />
-              <Button
-                label="保存"
-                onPress={save}
-                loading={saving}
-                disabled={saving}
-                style={styles.modalBtn}
-              />
-            </View>
-          </Pressable>
-        </Pressable>
-      </Modal>
-    </>
+        <Button
+          label="前往卡券管理"
+          onPress={() => router.push('/(tabs)/mine/cards')}
+          style={styles.guideBtn}
+        />
+      </Card>
+    </View>
   );
 }
 
@@ -772,22 +568,26 @@ const styles = StyleSheet.create({
   },
   tabLabel: { ...typography.body, fontWeight: '600' },
   // 通用列表
-  listContent: { padding: spacing.lg, gap: spacing.md },
+  listContent: { padding: spacing.lg, gap: spacing.md, paddingBottom: 80 },
   empty: { alignItems: 'center', justifyContent: 'center', paddingVertical: 28 },
   emptyText: { ...typography.body },
-  // 子页头
-  subHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
-  },
-  subTitle: { ...typography.heading },
   // 监控统计
   statsRow: { flexDirection: 'row', gap: spacing.md, marginBottom: spacing.md },
   // 监控商品项
   itemCard: { gap: spacing.sm },
+  // 卡券引导卡片（旧版入口已下线）
+  guideWrap: { flex: 1, padding: spacing.lg },
+  guideCard: { alignItems: 'center', gap: spacing.md, paddingVertical: spacing.xl },
+  guideIcon: {
+    width: 56,
+    height: 56,
+    borderRadius: radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  guideTitle: { ...typography.heading },
+  guideDesc: { ...typography.small, textAlign: 'center', lineHeight: 20 },
+  guideBtn: { minWidth: 180, marginTop: spacing.xs },
   itemHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -811,10 +611,6 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   actionBtn: { minHeight: 36, paddingHorizontal: spacing.lg },
-  // 卡券
-  cardItem: { gap: spacing.xs },
-  cardContent: { ...typography.body },
-  cardRemark: { ...typography.small },
   // 账号选择
   // 横向列表必须给显式高度：默认 flexGrow:1 会撑满整屏；仅 flexGrow:0 时安卓初始测量会把文字压扁
   acctScroll: {
@@ -850,28 +646,6 @@ const styles = StyleSheet.create({
   },
   ruleValue: { ...typography.body, fontWeight: '500' },
   ruleType: { ...typography.small, marginTop: spacing.xs },
-  // Modal
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: spacing.lg,
-  },
-  modalCard: {
-    width: '100%',
-    maxWidth: 340,
-    borderRadius: radius.lg,
-    padding: spacing.lg,
-    gap: spacing.md,
-  },
-  modalHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  modalTitle: { ...typography.heading },
-  closeBtn: { fontSize: 22, paddingHorizontal: spacing.xs },
   priceItemTitle: { ...typography.small },
   fieldGroup: { gap: spacing.xs },
   fieldLabel: { ...typography.caption },


### PR DESCRIPTION
本 PR 在已合并的 #317（移动端 App）基础上，修复扫描发现的"假功能/接口不匹配"，并补齐与 web 端的功能差异。

## P0 假功能修复（点了没反应或必失败）

| 页面 | 问题 | 修复 |
|---|---|---|
| 定时任务 | 开关/改间隔/手动触发全部 404（用数字 id 拼路径，后端要 task_code；且参数放 body 而后端只收 query） | 改用项目里已有的 task_code 封装，参数走 query |
| 商品管理 | "刷新"只重读本地库，真实同步接口从未调用 | 新增"同步本账号/同步全部"，调 POST /items/get-all-from-account |
| 用户管理 | 列表恒空（解析 data 键，后端返回 users 键） | 解析 users 键，加用户名搜索 |
| 商品搜索 | 翻页失效（page 应为 start_page） | 改用 start_page |
| 消息通知开关 | 调不存在的 PUT 405，拨了不生效 | 改用 POST upsert |
| 数据管理 | 订单 Tab 恒空（表名应为 xy_orders）；清空表按钮打 501 占位 | 改表名，移除假按钮 |
| 日志页 | 管理员日志恒空（应为 tail 解析）；自动回复日志显示"(无内容)"（字段应为 reply_text）；"清空"按钮实际清空全部系统日志 | 按 tail 解析、映射字段、移除错位按钮 |
| 商品 Tab 旧卡券编辑器 | 只支持 text 创建（用户反馈"只能建 txt"的根源） | 替换为引导跳转完整卡券页 |

## 补齐 web 端缺失功能

- **卡券**：关联商品入口（原为死页面）、复制、批量删除、服务端搜索分页、详情查看
- **商品**：多选批量下架/删记录/清关联、改价（含多规格 SKU）、列表筛选、multi-spec/多数量发货开关
- **订单**：服务端筛选（账号/日期/发货方式）、批量删除、全账号一键同步、发货二次确认
- **账号**：手动 Cookie 添加、导出落盘、AI 模型在线拉取
- **仪表盘**：真实统计（原为假数据）、近 7 日订单趋势
- **个人设置**：对接码/API 秘钥查看复制重置
- **商品发布**：从占位页变为完整三段式（单品表单/批量发布+进度轮询/发布记录）
- **通知渠道**：8 种类型 + 编辑能力
- **爬虫**：任务创建/删除/立即执行
- **共享扫码**：分享链接 + 兼职实时状态
- **上新监控**：任务编辑 + 批量操作 + 完整字段
- **新增整页**：采集商品、弹窗公告

## 额外修复

- tab 切换 bug：切走再切回"我的"仍显示子页（原 StackActions.popToTop 对 expo-router 内联 router 无效，改 navigate(name, {screen:'index'})）

## 测试

- 全项目 tsc 0 错误
- 安卓 12 模拟器实测：定时任务触发返回调度器真实 message、商品同步返回"获取 2 件 新增/更新 2 件 账号 1/1"、卡券关联商品保存成功、tab 切换 bug 修复、商品发布三段式、新页面入口
- 脱敏扫描：无服务器地址/密码/账号 ID/API key 等敏感信息